### PR TITLE
feat(us-027): context-aware sidebar nav, URL tab state, and UX fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,177 @@
+# CLAUDE.md — CodeLens Hub
+
+## What This Project Is
+
+CodeLens is a full-stack web app that helps developers understand large, unfamiliar codebases. Core capabilities:
+- Interactive force-directed dependency graph (D3.js)
+- Architectural issue detection (circular deps, god files, dead code, high coupling)
+- RAG-powered natural language code search
+- File complexity/impact ("blast radius") analysis
+- AI code review panel
+
+---
+
+## Tech Stack
+
+| Layer | Tech |
+|---|---|
+| Frontend | React 18, Vite, Tailwind CSS, D3.js v7, React Router 6 |
+| Backend | Node.js 20, Express 4 |
+| Database | PostgreSQL 15 (Supabase) + pgvector extension |
+| Auth | Supabase Auth, GitHub OAuth |
+| AST Parsing | Tree-sitter (JS, TS, TSX, Python, C#) |
+| Embeddings | OpenAI `text-embedding-3-small` (1536-dim) |
+| LLM/RAG | Groq API |
+| GitHub integration | Octokit |
+| AI SDK | `@anthropic-ai/sdk` |
+
+---
+
+## Running the App
+
+```bash
+# Bootstrap (first time)
+bash scripts/setup.sh
+# Fill in .env (copy from .env.example), apply SQL schema via Supabase dashboard
+
+# Development (two terminals)
+cd backend && npm run dev   # http://localhost:3001
+cd frontend && npm run dev  # http://localhost:3000
+
+# Or via Docker
+docker-compose up -d
+```
+
+Frontend dev server proxies `/api/*` to `localhost:3001`.
+
+---
+
+## Key Scripts
+
+```bash
+# Frontend
+npm run dev      # Vite dev server
+npm run build    # Production build → dist/
+npm run lint     # ESLint
+
+# Backend
+npm run dev      # Nodemon watch
+npm start        # Production
+npm run lint     # ESLint
+```
+
+---
+
+## Project Structure
+
+```
+CodeLens-hub/
+├── frontend/src/
+│   ├── components/     # UI: DependencyGraph, SearchPanel, ReviewPanel, etc.
+│   ├── pages/          # Login, Dashboard, RepoView, Search
+│   ├── context/        # AuthContext
+│   ├── hooks/          # useGraphSimulation (D3 physics)
+│   └── lib/            # supabase.js client
+│
+├── backend/src/
+│   ├── index.js        # Express setup + all route mounting
+│   ├── routes/         # Route definitions
+│   ├── controllers/    # Request handlers (repo, search, analysis, review)
+│   ├── services/       # Business logic (indexer, indexerService)
+│   ├── parsers/        # Tree-sitter AST parsing per language
+│   ├── ai/             # ragService.js (RAG pipeline)
+│   ├── db/             # Supabase admin client
+│   └── middleware/     # Auth, error handling
+│
+├── scripts/
+│   ├── setup.sh                 # Idempotent bootstrap
+│   └── 001_initial_schema.sql   # DB schema migration
+│
+└── docker-compose.yml           # postgres + backend + frontend
+```
+
+---
+
+## API Routes
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Health check |
+| `*` | `/api/auth/*` | GitHub OAuth |
+| `*` | `/api/repos/*` | Connect repos, upload ZIPs |
+| `*` | `/api/search/*` | RAG code search |
+| `*` | `/api/analysis/*` | Dependency graph, metrics, issues, impact |
+| `*` | `/api/review/*` | AI code review |
+
+---
+
+## Database Schema
+
+Tables (all with RLS):
+- `profiles` — user metadata + GitHub token
+- `repositories` — connected repos, status: `pending | indexing | ready | failed`
+- `graph_nodes` — files with metrics (line_count, complexity_score, incoming/outgoing counts)
+- `graph_edges` — dependency edges (from_path → to_path)
+- `code_chunks` — chunked source code with 1536-dim pgvector embeddings
+- `analysis_issues` — detected issues: `circular_dependency | god_file | dead_code | high_coupling`
+
+---
+
+## Environment Variables
+
+Required in `.env` (see `.env.example`):
+
+```
+SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
+VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_API_URL, VITE_API_PROXY_TARGET
+GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_CALLBACK_URL
+OPENAI_API_KEY       # for text-embedding-3-small
+GROQ_API_KEY         # for RAG LLM responses
+NODE_ENV, PORT
+```
+
+---
+
+## Indexing Pipeline (Core Flow)
+
+1. User connects GitHub repo → Octokit fetches repo tree
+2. Files filtered by supported language (`.js`, `.ts`, `.tsx`, `.py`, `.cs`)
+3. Tree-sitter parses each file → extracts imports, exports, functions, classes
+4. Dependency graph built → stored in `graph_nodes` + `graph_edges`
+5. Source split into semantic chunks → embeddings via OpenAI → stored in `code_chunks`
+6. Analysis runs → issues stored in `analysis_issues`
+
+---
+
+## Testing
+
+No automated test suite currently exists. Manual test utilities are in:
+- `backend/src/parsers/test-parser.js`
+- `backend/src/parsers/debug-ast.js`
+
+When adding tests, prefer Vitest for frontend, Jest or Vitest for backend.
+
+---
+
+## Linting
+
+ESLint is configured in both `frontend/` and `backend/`. No Prettier, no commit hooks. Run `npm run lint` inside each subdirectory.
+
+---
+
+## Architectural Conventions
+
+- **Backend:** MVC-ish pattern — routes → controllers → services → parsers/AI/db
+- **Frontend:** Feature-based component structure, single AuthContext for session
+- **Auth:** All backend routes requiring auth validate the Supabase JWT via middleware
+- **Error handling:** `express-async-errors` patches async routes; centralized error middleware in `backend/src/middleware/`
+- **Concurrency:** `p-limit` controls concurrent repo file fetches to avoid GitHub rate limits
+
+---
+
+## Notes for Development
+
+- Tree-sitter native modules require build tools (python3, make, g++) — the `backend/Dockerfile.dev` handles this; local installs need them too
+- The Supabase schema must be applied manually via the Supabase SQL Editor before the app works
+- Frontend Vite proxy (`/api/*` → port 3001) is configured in `frontend/vite.config.js`
+- No CI/CD pipeline is currently configured

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
+import { RepoProvider } from './context/RepoContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
 import Login        from './pages/Login';
 import AuthCallback from './pages/AuthCallback';
 import Dashboard    from './pages/Dashboard';
 import RepoView     from './pages/RepoView';
-import Search       from './pages/Search';
 
 export default function App() {
   return (
@@ -17,11 +17,10 @@ export default function App() {
         <Route path="/auth/callback" element={<AuthCallback />} />
 
         {/* Protected — unauthenticated users are sent to /login */}
-        <Route element={<ProtectedRoute />}>
+        <Route element={<RepoProvider><ProtectedRoute /></RepoProvider>}>
           <Route path="/"                        element={<Dashboard />} />
           <Route path="/dashboard"               element={<Dashboard />} />
           <Route path="/repo/:repoId"            element={<RepoView />} />
-          <Route path="/repo/:repoId/search"     element={<Search />} />
         </Route>
       </Routes>
     </AuthProvider>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,12 +1,18 @@
 import { useState, useEffect } from 'react';
-import { Link, Outlet, useLocation } from 'react-router-dom';
+import { Link, Outlet, useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useRepo } from '../context/RepoContext';
 import OnboardingModal from './OnboardingModal';
 
 export default function Layout() {
   const { user, signOut } = useAuth();
+  const { repo, issueCount } = useRepo();
   const location = useLocation();
+  const { repoId } = useParams();
+  const [searchParams] = useSearchParams();
   const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
+
+  const activeTab = searchParams.get('tab') || 'graph';
 
   // Show onboarding modal on first dashboard visit
   useEffect(() => {
@@ -22,42 +28,108 @@ export default function Layout() {
     await signOut();
   };
 
-  const navLinks = [
-    { name: 'Dashboard', href: '/dashboard', icon: HomeIcon },
+  const repoNavItems = [
+    { label: 'Graph',       tab: 'graph',   icon: GraphIcon   },
+    { label: 'Metrics',     tab: 'metrics', icon: MetricsIcon },
+    { label: 'Issues',      tab: 'issues',  icon: IssuesIcon  },
+    { label: 'Search',      tab: 'search',  icon: SearchIcon  },
+    { label: 'Code Review', tab: 'review',  icon: ReviewIcon  },
   ];
 
   return (
     <div className="flex min-h-screen bg-gray-950">
-      {/* Sidebar */}
-      <div className="flex w-64 flex-col border-r border-gray-800 bg-gray-900">
-        <div className="flex h-16 items-center px-6 border-b border-gray-800">
-          <span className="text-xl font-bold tracking-tight text-white">CodeLens</span>
+      {/* ── Sidebar ───────────────────────────────────────────────────── */}
+      {/*
+        Responsive behaviour:
+        - < lg  (< 1024px): icon-only, w-14
+        - >= lg (≥ 1024px): full width, w-64
+      */}
+      <div className="flex w-14 lg:w-64 shrink-0 flex-col border-r border-gray-800 bg-gray-900">
+
+        {/* Brand */}
+        <div className="flex h-16 items-center justify-center lg:justify-start px-0 lg:px-6 border-b border-gray-800">
+          <Link
+            to="/dashboard"
+            className="font-bold tracking-tight text-white hover:text-gray-200 transition-colors"
+          >
+            <span className="hidden lg:inline text-xl">CodeLens</span>
+            <span className="lg:hidden text-sm">CL</span>
+          </Link>
         </div>
 
-        <nav className="flex-1 space-y-1 px-3 py-4">
-          {navLinks.map((item) => {
-            const isActive = location.pathname.startsWith(item.href);
-            return (
+        <nav className="flex-1 space-y-1 px-1.5 lg:px-3 py-4 overflow-y-auto">
+          {repoId ? (
+            /* ── Repo context nav ── */
+            <>
+              {/* Back link */}
               <Link
-                key={item.name}
-                to={item.href}
-                className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-gray-800 text-white'
-                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
-                }`}
+                to="/dashboard"
+                title="Repositories"
+                className="flex items-center justify-center lg:justify-start gap-2 rounded-md px-2 lg:px-3 py-2 text-sm font-medium text-gray-400 hover:bg-gray-800 hover:text-white transition-colors mb-2"
               >
-                <item.icon className="h-5 w-5 shrink-0" />
-                {item.name}
+                <ArrowLeftIcon className="h-4 w-4 shrink-0" />
+                <span className="hidden lg:inline">Repositories</span>
               </Link>
-            );
-          })}
+
+              {/* Repo identity */}
+              <div className="hidden lg:block px-3 py-2 mb-1">
+                <p
+                  className="text-sm font-semibold text-white truncate"
+                  title={repo?.full_name || repo?.name || ''}
+                >
+                  {repo?.name || '…'}
+                </p>
+                {repo?.status && <StatusBadge status={repo.status} />}
+              </div>
+
+              <div className="hidden lg:block border-t border-gray-800 my-2" />
+
+              {/* Tab nav items */}
+              {repoNavItems.map(({ label, tab, icon: Icon }) => {
+                const isActive = activeTab === tab;
+                return (
+                  <Link
+                    key={tab}
+                    to={`/repo/${repoId}?tab=${tab}`}
+                    title={label}
+                    className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'bg-gray-800 text-white'
+                        : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                    }`}
+                  >
+                    <Icon className="h-5 w-5 shrink-0" />
+                    <span className="hidden lg:inline">{label}</span>
+                    {tab === 'issues' && issueCount > 0 && (
+                      <span className="hidden lg:inline ml-auto rounded-full bg-red-500/80 px-1.5 py-0.5 text-xs font-semibold text-white">
+                        {issueCount}
+                      </span>
+                    )}
+                  </Link>
+                );
+              })}
+            </>
+          ) : (
+            /* ── Dashboard nav ── */
+            <Link
+              to="/dashboard"
+              title="Dashboard"
+              className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors ${
+                location.pathname.startsWith('/dashboard') || location.pathname === '/'
+                  ? 'bg-gray-800 text-white'
+                  : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+              }`}
+            >
+              <HomeIcon className="h-5 w-5 shrink-0" />
+              <span className="hidden lg:inline">Dashboard</span>
+            </Link>
+          )}
         </nav>
 
-        {/* User / Sign Out Footer */}
-        <div className="border-t border-gray-800 p-4">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="h-8 w-8 overflow-hidden rounded-full bg-gray-800">
+        {/* ── User / Sign-out footer ── */}
+        <div className="border-t border-gray-800 p-2 lg:p-4">
+          <div className="flex items-center justify-center lg:justify-start gap-3 mb-3">
+            <div className="h-8 w-8 overflow-hidden rounded-full bg-gray-800 shrink-0">
               {user?.user_metadata?.avatar_url ? (
                 <img src={user.user_metadata.avatar_url} alt="Avatar" className="h-full w-full object-cover" />
               ) : (
@@ -66,34 +138,36 @@ export default function Layout() {
                 </div>
               )}
             </div>
-            <div className="flex flex-col text-sm">
+            <div className="hidden lg:flex flex-col text-sm">
               <span className="font-medium text-white truncate max-w-[140px]">
                 {user?.user_metadata?.user_name || user?.email || 'User'}
               </span>
             </div>
           </div>
 
-          {/* Show introduction again — positioned above sign out */}
+          {/* Show introduction again */}
           <button
             onClick={() => setIsOnboardingOpen(true)}
-            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-500 hover:bg-gray-800 hover:text-gray-300 transition-colors mb-1"
+            title="Show introduction again"
+            className="flex w-full items-center justify-center lg:justify-start gap-2 rounded-md px-2 lg:px-3 py-2 text-sm font-medium text-gray-500 hover:bg-gray-800 hover:text-gray-300 transition-colors mb-1"
           >
             <InfoIcon className="h-4 w-4 shrink-0" />
-            Show introduction again
+            <span className="hidden lg:inline">Show introduction again</span>
           </button>
 
           <button
             onClick={handleSignOut}
-            className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-400 hover:bg-gray-800 hover:text-white transition-colors"
+            title="Sign out"
+            className="flex w-full items-center justify-center lg:justify-start gap-2 rounded-md px-2 lg:px-3 py-2 text-sm font-medium text-gray-400 hover:bg-gray-800 hover:text-white transition-colors"
           >
-            <SignOutIcon className="h-4 w-4" />
-            Sign out
+            <SignOutIcon className="h-4 w-4 shrink-0" />
+            <span className="hidden lg:inline">Sign out</span>
           </button>
         </div>
       </div>
 
-      {/* Main Content Area */}
-      <main className="flex-1 overflow-y-auto">
+      {/* ── Main Content Area ── */}
+      <main className="flex-1 overflow-y-auto min-w-0">
         <Outlet />
       </main>
 
@@ -106,11 +180,80 @@ export default function Layout() {
   );
 }
 
-// Simple SVG Icons
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }) {
+  const styles = {
+    ready:    'bg-green-500/10 text-green-400 ring-1 ring-inset ring-green-500/20',
+    failed:   'bg-red-500/10 text-red-400 ring-1 ring-inset ring-red-500/20',
+    indexing: 'bg-blue-500/10 text-blue-400 ring-1 ring-inset ring-blue-500/20 animate-pulse',
+    pending:  'bg-gray-500/10 text-gray-400 ring-1 ring-inset ring-gray-500/20 animate-pulse',
+  };
+  const label =
+    status === 'pending'
+      ? 'Indexing'
+      : status.charAt(0).toUpperCase() + status.slice(1);
+  return (
+    <span className={`mt-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${styles[status] || styles.pending}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
 function HomeIcon(props) {
   return (
     <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    </svg>
+  );
+}
+
+function ArrowLeftIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+    </svg>
+  );
+}
+
+function GraphIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
+    </svg>
+  );
+}
+
+function MetricsIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+    </svg>
+  );
+}
+
+function IssuesIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+    </svg>
+  );
+}
+
+function SearchIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803a7.5 7.5 0 0010.607 10.607z" />
+    </svg>
+  );
+}
+
+function ReviewIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" />
     </svg>
   );
 }

--- a/frontend/src/context/RepoContext.jsx
+++ b/frontend/src/context/RepoContext.jsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState } from 'react';
+
+const RepoContext = createContext(null);
+
+export function RepoProvider({ children }) {
+  const [repo, setRepo] = useState(null);
+  const [issueCount, setIssueCount] = useState(0);
+
+  return (
+    <RepoContext.Provider value={{ repo, setRepo, issueCount, setIssueCount }}>
+      {children}
+    </RepoContext.Provider>
+  );
+}
+
+export function useRepo() {
+  const ctx = useContext(RepoContext);
+  if (!ctx) throw new Error('useRepo must be used within a RepoProvider');
+  return ctx;
+}

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useRepo } from '../context/RepoContext';
 import DependencyGraph from '../components/DependencyGraph';
 import SearchPanel from '../components/SearchPanel';
 import CodeReviewPanel from '../components/CodeReviewPanel';
@@ -20,6 +21,18 @@ function getFileBasename(filePath) {
   const normalizedPath = filePath.replace(/\\/g, '/');
   const parts = normalizedPath.split('/');
   return parts[parts.length - 1] || filePath;
+}
+
+function formatDate(ts) {
+  if (!ts) return null;
+  const d = new Date(ts);
+  const diff = Date.now() - d.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return d.toLocaleDateString();
 }
 
 function buildImpactAnalysis(sourcePath, nodes, edges) {
@@ -71,29 +84,6 @@ function buildImpactAnalysis(sourcePath, nodes, edges) {
     transitiveIds: transitive.map(getGraphId),
   };
 }
-
-// Helper component for tabs
-const TabButton = ({ active, label, onClick, badge }) => (
-  <button
-    onClick={onClick}
-    className={`
-      flex items-center gap-2 whitespace-nowrap border-b-2 py-4 px-1 text-sm font-medium transition-colors
-      ${active
-        ? 'border-indigo-500 text-indigo-400'
-        : 'border-transparent text-gray-400 hover:border-gray-700 hover:text-gray-200'
-      }
-    `}
-  >
-    {label}
-    {badge !== undefined && badge > 0 && (
-      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-        active ? 'bg-indigo-500/20 text-indigo-300' : 'bg-gray-800 text-gray-300'
-      }`}>
-        {badge}
-      </span>
-    )}
-  </button>
-);
 
 // --- Child Panels ---
 function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnalyseImpact }) {
@@ -218,7 +208,7 @@ function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnalyseImpact }) {
               }
 
               return (
-                <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path)} className={rowClass} style={{ height: 44 }}>
+                <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path, { openGraph: true })} className={rowClass} style={{ height: 44 }}>
                   <td className={`px-6 py-3 font-mono text-xs ${textFade}`}>{node.file_path}</td>
                   <td className={`px-6 py-3 ${metaFade}`}>{formatLanguage(node.language)}</td>
                   <td className={`px-6 py-3 ${metaFade}`}>{node.line_count}</td>
@@ -383,9 +373,11 @@ function IssuesPanel({ nodes, issues, onNodeSelect }) {
 export default function RepoView() {
   const { repoId } = useParams();
   const { session } = useAuth();
+  const { setRepo: setRepoCtx, setIssueCount } = useRepo();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') || 'graph';
 
   const [repo, setRepo]         = useState(null);
-  const [activeTab, setActiveTab] = useState('graph');
 
   const [selectedNodeId, setSelectedNodeId] = useState(null);
   const [impactSourcePath, setImpactSourcePath] = useState(null);
@@ -401,9 +393,9 @@ export default function RepoView() {
   const handleNodeSelect = useCallback((nodeIdOrIds, options = {}) => {
     setSelectedNodeId(nodeIdOrIds);
     if (options.openGraph) {
-      setActiveTab('graph');
+      setSearchParams({ tab: 'graph' }, { replace: true });
     }
-  }, []);
+  }, [setSearchParams]);
 
   const selectedNode = useMemo(() => {
     if (Array.isArray(selectedNodeId) || !selectedNodeId) return null;
@@ -424,8 +416,8 @@ export default function RepoView() {
 
     setImpactSourcePath(sourcePath);
     setSelectedNodeId(sourceNode.id || sourceNode.file_path);
-    setActiveTab('graph');
-  }, [analysisData.nodes]);
+    setSearchParams({ tab: 'graph' }, { replace: true });
+  }, [analysisData.nodes, setSearchParams]);
 
   const handleClearImpactAnalysis = useCallback(() => {
     setImpactSourcePath(null);
@@ -450,6 +442,7 @@ export default function RepoView() {
       setAnalysisError(null);
     } catch (err) {
       console.error('Failed to fetch analysis datasets:', err);
+      setAnalysisError(err.message || 'Failed to load analysis data');
     }
   }, [repoId, hasFetchedData, session?.access_token]);
 
@@ -497,8 +490,37 @@ export default function RepoView() {
   useEffect(() => {
     return () => {
       setAnalysisData({ nodes: [], edges: [], issues: [] });
+      setRepoCtx(null);
+      setIssueCount(0);
     };
-  }, []);
+  }, [setRepoCtx, setIssueCount]);
+
+  // Sync repo and issue count into context so Layout's sidebar stays current
+  useEffect(() => {
+    setRepoCtx(repo);
+  }, [repo, setRepoCtx]);
+
+  useEffect(() => {
+    setIssueCount(analysisData.issues.length);
+  }, [analysisData.issues, setIssueCount]);
+
+  // When a repo transitions from indexing → ready, land on Metrics for a better
+  // "here's what we found" first impression rather than an empty graph.
+  const prevStatusRef = useRef(null);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = repo?.status ?? null;
+    if ((prev === 'pending' || prev === 'indexing') && repo?.status === 'ready') {
+      setSearchParams((current) => {
+        if (!current.get('tab')) {
+          const next = new URLSearchParams(current);
+          next.set('tab', 'metrics');
+          return next;
+        }
+        return current;
+      }, { replace: true });
+    }
+  }, [repo?.status, setSearchParams]);
 
   const handleReindex = async () => {
     if (!session?.access_token) return;
@@ -548,12 +570,8 @@ export default function RepoView() {
     <div className="flex flex-col min-h-screen bg-gray-950 text-white">
 
       {/* Header Container */}
-      <div className="border-b border-gray-800 bg-gray-900/50 px-8 pt-6">
-        <Link to="/dashboard" className="mb-4 inline-flex items-center text-sm font-medium text-gray-400 hover:text-white transition-colors">
-          &larr; Dashboard
-        </Link>
-
-        <div className="flex items-center justify-between pb-4">
+      <div className="border-b border-gray-800 bg-gray-900/50 px-8 py-6">
+        <div className="flex items-center justify-between">
           <div>
             <div className="flex items-center gap-3">
               <h1 className="text-2xl font-bold tracking-tight">{repo.name}</h1>
@@ -567,7 +585,8 @@ export default function RepoView() {
               </span>
             </div>
             <p className="text-sm text-gray-400 mt-1">
-              {repo.source === 'github' ? 'GitHub' : 'Uploaded ZIP'} • {repo.file_count || 0} files indexed
+              {repo.source === 'github' ? 'GitHub' : 'Uploaded ZIP'} · {repo.file_count || 0} files
+              {repo.indexed_at && ` · last indexed ${formatDate(repo.indexed_at)}`}
             </p>
           </div>
 
@@ -579,22 +598,6 @@ export default function RepoView() {
             {isReindexing ? 'Starting...' : 'Re-index'}
           </button>
         </div>
-
-        {/* Tab Bar — includes Review tab after Search */}
-        {!isWorking && repo.status !== 'failed' && (
-          <div className="mt-2 -mb-px flex gap-6">
-            <TabButton active={activeTab === 'graph'}   label="Graph"   onClick={() => setActiveTab('graph')}   />
-            <TabButton active={activeTab === 'metrics'} label="Metrics" onClick={() => setActiveTab('metrics')} />
-            <TabButton
-              active={activeTab === 'issues'}
-              label="Issues"
-              onClick={() => setActiveTab('issues')}
-              badge={analysisData.issues.length}
-            />
-            <TabButton active={activeTab === 'search'} label="Search" onClick={() => setActiveTab('search')} />
-            <TabButton active={activeTab === 'review'} label="Review" onClick={() => setActiveTab('review')} />
-          </div>
-        )}
       </div>
 
       {/* Main Content Area */}

--- a/user-stories-CodeLens.md
+++ b/user-stories-CodeLens.md
@@ -895,6 +895,24 @@ Assign labels: `epic/infra`, `epic/auth`, `epic/dashboard`, `epic/graph`, `epic/
 
 ---
 
+US-026: AI Code Review Panel
+
+**As a** developer
+**I want to** paste a code snippet and get an AI review that considers my actual codebase
+**So that** I know whether the code is well-written and whether it integrates cleanly with what already exists
+
+**Acceptance Criteria**
+- [ ] Code Review panel accessible from the repo sidebar nav
+- [ ] Textarea for pasting a code snippet (up to ~200 lines)
+- [ ] Optional context field: "What is this code supposed to do?"
+- [ ] On submit, sends the snippet + top 5 semantically similar chunks from the indexed codebase to Claude
+- [ ] Claude responds with: a quality assessment, specific improvement suggestions, and a compatibility note ("This pattern matches how auth is handled in src/middleware/auth.js" or "This introduces a new pattern that conflicts with...")
+- [ ] Response streams in like the Search panel
+- [ ] A "Clean up this code" quick action that asks Claude to rewrite the snippet following patterns it found in the repo
+
+**Note**
+> Reuse the SSE streaming infrastructure from `searchController.js`. The system prompt should be: "You are reviewing a code snippet for a developer. You have context from their existing codebase below. Assess code quality, suggest improvements, and specifically note whether this code is consistent with the patterns and conventions you see in their codebase."
+
 ### US-027: Context-aware sidebar navigation
 
 **Labels:** `epic/dashboard`


### PR DESCRIPTION
US-027 — Context-aware sidebar navigation:
- Add RepoContext (repo + issueCount) shared between RepoView and Layout
- Sidebar now shows repo-specific nav (Graph/Metrics/Issues/Search/Code Review)
  when inside /repo/:repoId, with back link and status badge
- Remove horizontal tab bar from RepoView header; sidebar owns navigation
- Tab state lifted to URL param (?tab=graph) — survives refresh and browser back/forward

Bug fixes:
- analysisError never displayed: catch block in fetchAnalysisData now sets the error state
- Dead route /repo/:repoId/search removed from App.jsx routing
- MetricsPanel row click now correctly switches to Graph tab per US-015 spec

UX improvements:
- Sidebar collapses to icon-only (w-14) on <lg screens; labels and user info visible on lg+
- Each repo nav item now has a matching icon for the icon-only mobile layout
- Repo page header shows "last indexed X ago" using indexed_at timestamp
- After indexing completes (pending/indexing → ready), app lands on Metrics tab
  instead of the empty Graph, giving a better "here's what we found" first impression
- Active sidebar item uses bg-gray-800/text-white to match dashboard link style (consistent)

Closes #38 