### PR TITLE
implement US-028, 029, 030, 031, 032, 034

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,55 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # required to push to GHCR
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/backend:latest
+            ghcr.io/${{ github.repository }}/backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/frontend:latest
+            ghcr.io/${{ github.repository }}/frontend:${{ github.sha }}
+          build-args: |
+            VITE_SUPABASE_URL=${{ secrets.VITE_SUPABASE_URL }}
+            VITE_SUPABASE_ANON_KEY=${{ secrets.VITE_SUPABASE_ANON_KEY }}
+            VITE_API_URL=${{ secrets.VITE_API_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main, s1-dev]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      # ── Frontend ────────────────────────────────────────────────────────────
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Lint frontend
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Test frontend
+        run: npm test --if-present
+        working-directory: frontend
+
+      # ── Backend ─────────────────────────────────────────────────────────────
+      # tree-sitter native modules require build tools
+      - name: Install backend build tools
+        run: sudo apt-get update && sudo apt-get install -y python3 make g++
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Lint backend
+        run: npm run lint
+        working-directory: backend
+
+      - name: Test backend
+        run: npm test --if-present
+        working-directory: backend

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,171 @@
+# CodeLens — Production Deployment Guide
+
+This guide covers everything needed to deploy CodeLens publicly with HTTPS.
+
+---
+
+## Architecture overview
+
+| Layer     | Recommended service           | Alternative           |
+|-----------|-------------------------------|-----------------------|
+| Frontend  | **Vercel** (static + CDN)     | Netlify               |
+| Backend   | **Render** (web service)      | Railway, Fly.io       |
+| Database  | **Supabase** (new prod project) | —                   |
+| Registry  | **GitHub Container Registry** (GHCR) | Docker Hub    |
+
+---
+
+## Prerequisites
+
+- Docker installed locally (for testing production builds)
+- GitHub repository with CI/CD workflows from US-030
+- A domain name (optional but recommended)
+
+---
+
+## Step 1 — Production Supabase project
+
+1. Go to [supabase.com](https://supabase.com) → New project
+2. Once created, open the SQL Editor and run **both** migrations in order:
+   - `scripts/001_initial_schema.sql`
+   - `scripts/002_webhooks.sql`
+   - `scripts/003_teams.sql`
+3. Navigate to **Authentication → Providers → GitHub** and enable GitHub OAuth
+4. Copy the following values (Settings → API):
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+
+---
+
+## Step 2 — GitHub OAuth App
+
+Create a **new** OAuth App (or update the existing dev one) at
+<https://github.com/settings/developers>:
+
+| Field              | Value                                      |
+|--------------------|--------------------------------------------|
+| Homepage URL       | `https://your-frontend-domain.com`         |
+| Callback URL       | `https://your-frontend-domain.com/auth/callback` |
+
+Copy `Client ID` and `Client Secret`.
+
+Also update the Supabase Auth settings:
+- **Site URL**: `https://your-frontend-domain.com`
+- **Redirect URLs**: add `https://your-frontend-domain.com/auth/callback`
+
+---
+
+## Step 3 — Deploy the backend (Render)
+
+1. New **Web Service** → connect the GitHub repo
+2. **Runtime**: Docker  
+   **Dockerfile path**: `backend/Dockerfile`  
+   **Root directory**: (leave blank — the context is the repo root)
+3. Set the following **Environment Variables** as secrets:
+
+```
+NODE_ENV=production
+PORT=3001
+SUPABASE_URL=<from step 1>
+SUPABASE_ANON_KEY=<from step 1>
+SUPABASE_SERVICE_ROLE_KEY=<from step 1>
+GITHUB_CLIENT_ID=<from step 2>
+GITHUB_CLIENT_SECRET=<from step 2>
+GITHUB_CALLBACK_URL=https://your-frontend-domain.com/auth/callback
+OPENAI_API_KEY=<your key>
+GROQ_API_KEY=<your key>
+FRONTEND_URL=https://your-frontend-domain.com
+BACKEND_URL=https://your-backend-domain.onrender.com
+```
+
+4. Deploy and copy the public HTTPS URL (e.g. `https://codelens-api.onrender.com`)
+
+---
+
+## Step 4 — Deploy the frontend (Vercel)
+
+1. Import the GitHub repo into Vercel
+2. **Framework preset**: Vite
+3. **Root directory**: `frontend`
+4. **Build command**: `npm run build`
+5. **Output directory**: `dist`
+6. Set the following **Environment Variables**:
+
+```
+VITE_SUPABASE_URL=<from step 1>
+VITE_SUPABASE_ANON_KEY=<from step 1>
+VITE_API_URL=https://codelens-api.onrender.com
+VITE_API_PROXY_TARGET=https://codelens-api.onrender.com
+```
+
+7. Deploy and copy the production URL (e.g. `https://codelens.vercel.app`)
+8. Go back and update `FRONTEND_URL` on the backend to match this URL
+
+---
+
+## Step 5 — Custom domain (optional)
+
+- In Vercel: Settings → Domains → Add your domain → follow DNS instructions
+- In Render: Settings → Custom Domains → follow DNS instructions
+
+---
+
+## Step 6 — GitHub Actions secrets (for CD pipeline)
+
+In your GitHub repo → Settings → Secrets and variables → Actions, add:
+
+```
+VITE_SUPABASE_URL
+VITE_SUPABASE_ANON_KEY
+VITE_API_URL
+```
+
+The `GITHUB_TOKEN` secret is automatically provided by Actions.
+
+---
+
+## Step 7 — Branch protection
+
+In GitHub → repo → Settings → Branches → Add rule for `main`:
+
+- [x] Require a pull request before merging
+- [x] Require status checks to pass before merging → select `Lint & Test`
+- [x] Require branches to be up to date before merging
+
+---
+
+## Step 8 — CORS verification
+
+The backend restricts `Access-Control-Allow-Origin` to the exact `FRONTEND_URL`
+environment variable. After deployment, verify:
+
+```bash
+curl -si -X OPTIONS https://your-backend.onrender.com/api/repos \
+  -H "Origin: https://malicious.com" \
+  -H "Access-Control-Request-Method: GET"
+# Expect: no Access-Control-Allow-Origin header for foreign origins
+```
+
+---
+
+## Docker-only deployment (self-hosted)
+
+If you prefer to self-host using the production compose file:
+
+```bash
+cp .env.example .env.prod
+# Fill in all production values in .env.prod
+docker-compose -f docker-compose.prod.yml --env-file .env.prod up -d
+```
+
+The frontend container proxies `/api/*` to the backend via the Nginx config.
+Set `VITE_API_URL` to an empty string or `/api` when using this setup.
+
+---
+
+## Health check
+
+```
+GET /health → { "status": "ok" }
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,46 @@
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+# Needs build tools to compile tree-sitter native modules.
+FROM node:20-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+
+# Install ALL deps (including dev) for native compilation
+RUN npm ci
+
+COPY . .
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+# tree-sitter .node bindings still need build tools at runtime.
+FROM node:20-slim AS runtime
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+
+# Install production deps only — native modules get recompiled here
+RUN npm ci --omit=dev
+
+# Copy application source from builder stage
+COPY --from=builder /app/src ./src
+
+# Run as a non-root unprivileged user
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+USER appuser
+
+EXPOSE 3001
+
+CMD ["node", "src/index.js"]

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -29,6 +29,22 @@ const upsertProfile = async (req, res) => {
     return res.status(500).json({ error: 'Failed to save profile' });
   }
 
+  // Auto-join teams: if any team_members rows reference this GitHub username
+  // but have no user_id yet, backfill them now so the new user instantly sees
+  // shared repos on their dashboard.
+  if (github_username) {
+    const { error: teamJoinErr } = await supabaseAdmin
+      .from('team_members')
+      .update({ user_id: userId })
+      .eq('github_username', github_username)
+      .is('user_id', null);
+
+    if (teamJoinErr) {
+      // Non-fatal — log and continue
+      console.error('[upsertProfile] team auto-join failed:', teamJoinErr);
+    }
+  }
+
   res.json({ ok: true });
 };
 

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -1,6 +1,7 @@
 /**
- * Repository controller 
+ * Repository controller
  */
+const crypto = require('crypto');
 const { supabaseAdmin } = require('../db/supabase');
 const indexer = require('../services/indexer');
 
@@ -74,20 +75,64 @@ const uploadRepo = async (req, res) => {
   res.json({ ok: true, repo });
 };
 
-/** GET /api/repos — list repos belonging to the authenticated user */
+/** GET /api/repos — list repos owned by the user + repos shared via teams */
 const listRepos = async (req, res) => {
-  const { data, error } = await supabaseAdmin
+  // Own repos
+  const { data: ownedRepos, error: ownedErr } = await supabaseAdmin
     .from('repositories')
     .select('*')
     .eq('user_id', req.user.id)
     .order('created_at', { ascending: false });
 
-  if (error) {
-    console.error('[listRepos] Error:', error);
+  if (ownedErr) {
+    console.error('[listRepos] Error fetching own repos:', ownedErr);
     return res.status(500).json({ error: 'Failed to fetch repositories' });
   }
 
-  res.json({ repos: data });
+  // Team-shared repos: first get team IDs the user belongs to, then fetch repos
+  const { data: memberships } = await supabaseAdmin
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', req.user.id);
+
+  const teamIds = (memberships || []).map((m) => m.team_id);
+
+  let teamRepoRows = [];
+  let teamErr = null;
+  if (teamIds.length > 0) {
+    const { data, error } = await supabaseAdmin
+      .from('team_repositories')
+      .select('repo_id, repositories(*), teams(name)')
+      .in('team_id', teamIds);
+    teamRepoRows = data || [];
+    teamErr = error;
+  }
+
+  if (teamErr) {
+    console.error('[listRepos] Error fetching team repos:', teamErr);
+    // Non-fatal: return own repos only
+    return res.json({ repos: ownedRepos || [] });
+  }
+
+  const ownedIds = new Set((ownedRepos || []).map((r) => r.id));
+  const sharedRepos = (teamRepoRows || [])
+    .filter((row) => row.repositories && !ownedIds.has(row.repositories.id))
+    .map((row) => ({
+      ...row.repositories,
+      shared: true,
+      team_name: row.teams?.name || null,
+    }));
+
+  // Deduplicate shared repos (a repo can be in multiple teams)
+  const sharedById = new Map();
+  sharedRepos.forEach((r) => sharedById.set(r.id, r));
+
+  const repos = [
+    ...(ownedRepos || []),
+    ...Array.from(sharedById.values()),
+  ];
+
+  res.json({ repos });
 };
 
 /** GET /api/repos/:repoId/status — polling endpoint for indexing progress */
@@ -185,17 +230,45 @@ const reindexRepo = async (req, res) => {
   res.json({ ok: true, message: 'Re-indexing started' });
 };
 
+/**
+ * Checks if the current user can access a given repo — either as owner or team member.
+ */
+async function canAccessRepo(repoId, userId) {
+  // Owner check
+  const { data: owned } = await supabaseAdmin
+    .from('repositories')
+    .select('id')
+    .eq('id', repoId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (owned) return true;
+
+  // Team membership check
+  const { data: memberships } = await supabaseAdmin
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', userId);
+  const teamIds = (memberships || []).map((m) => m.team_id);
+  if (teamIds.length === 0) return false;
+
+  const { data: teamRepo } = await supabaseAdmin
+    .from('team_repositories')
+    .select('repo_id')
+    .eq('repo_id', repoId)
+    .in('team_id', teamIds)
+    .maybeSingle();
+
+  return !!teamRepo;
+}
+
 /** GET /api/repos/:repoId/analysis — fetch nodes, edges, and issues in a single request */
 const getAnalysisData = async (req, res) => {
   const { repoId } = req.params;
   console.log(`[getAnalysisData] Fetching analysis data for repoId: ${repoId} for user: ${req.user.id}`);
-  
-  const { data: repo, error: fetchError } = await supabaseAdmin
-    .from('repositories')
-    .select('id')
-    .eq('id', repoId)
-    .eq('user_id', req.user.id)
-    .single();
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  const repo = allowed ? { id: repoId } : null;
+  const fetchError = allowed ? null : new Error('not found');
 
   if (fetchError || !repo) {
     return res.status(404).json({ error: 'Repository not found or unauthorized' });
@@ -229,4 +302,72 @@ const getAnalysisData = async (req, res) => {
   }
 };
 
-module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData };
+/**
+ * PATCH /api/repos/:repoId — update mutable repo fields (auto_sync_enabled)
+ */
+const updateRepo = async (req, res) => {
+  const { repoId } = req.params;
+  const { auto_sync_enabled } = req.body;
+
+  if (typeof auto_sync_enabled !== 'boolean') {
+    return res.status(400).json({ error: 'auto_sync_enabled must be a boolean' });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('repositories')
+    .update({ auto_sync_enabled })
+    .eq('id', repoId)
+    .eq('user_id', req.user.id)
+    .select()
+    .single();
+
+  if (error || !data) {
+    console.error('[updateRepo]', error);
+    return res.status(404).json({ error: 'Repository not found or unauthorized' });
+  }
+
+  res.json({ ok: true, repo: data });
+};
+
+/**
+ * GET /api/repos/:repoId/webhook — generate (or regenerate) a webhook secret.
+ * Returns the secret exactly once — store it immediately as it cannot be retrieved again.
+ */
+const generateWebhook = async (req, res) => {
+  const { repoId } = req.params;
+
+  // Verify ownership
+  const { data: repo, error: fetchError } = await supabaseAdmin
+    .from('repositories')
+    .select('id, source')
+    .eq('id', repoId)
+    .eq('user_id', req.user.id)
+    .single();
+
+  if (fetchError || !repo) {
+    return res.status(404).json({ error: 'Repository not found or unauthorized' });
+  }
+
+  if (repo.source !== 'github') {
+    return res.status(400).json({ error: 'Webhooks are only supported for GitHub repositories' });
+  }
+
+  const secret = crypto.randomBytes(32).toString('hex');
+
+  const { error: updateError } = await supabaseAdmin
+    .from('repositories')
+    .update({ webhook_secret: secret })
+    .eq('id', repoId);
+
+  if (updateError) {
+    console.error('[generateWebhook]', updateError);
+    return res.status(500).json({ error: 'Failed to save webhook secret' });
+  }
+
+  const backendUrl = process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 3001}`;
+  const webhookUrl = `${backendUrl}/api/webhooks/github`;
+
+  res.json({ ok: true, webhookUrl, secret });
+};
+
+module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData, updateRepo, generateWebhook };

--- a/backend/src/controllers/teamController.js
+++ b/backend/src/controllers/teamController.js
@@ -1,0 +1,212 @@
+/**
+ * Team controller — manages teams, membership, and shared repositories.
+ */
+const { Octokit } = require('octokit');
+const { supabaseAdmin } = require('../db/supabase');
+
+/**
+ * POST /api/teams
+ * Create a team, sync GitHub collaborators for the given repo, and link the repo.
+ *
+ * Body: { name: string, repoFullName: string }
+ */
+const createTeam = async (req, res) => {
+  const { name, repoFullName } = req.body;
+  if (!name || !repoFullName) {
+    return res.status(400).json({ error: 'name and repoFullName are required' });
+  }
+
+  // Fetch the repo owned by this user
+  const { data: repo, error: repoErr } = await supabaseAdmin
+    .from('repositories')
+    .select('id, name, source')
+    .eq('name', repoFullName)
+    .eq('user_id', req.user.id)
+    .single();
+
+  if (repoErr || !repo) {
+    return res.status(404).json({ error: 'Repository not found or you do not own it' });
+  }
+
+  if (repo.source !== 'github') {
+    return res.status(400).json({ error: 'Teams can only be created for GitHub repositories' });
+  }
+
+  // Get the owner's GitHub token
+  const { data: profile } = await supabaseAdmin
+    .from('profiles')
+    .select('github_access_token, github_username')
+    .eq('id', req.user.id)
+    .single();
+
+  if (!profile?.github_access_token) {
+    return res.status(400).json({ error: 'GitHub token not found' });
+  }
+
+  // 1. Create the team
+  const { data: team, error: teamErr } = await supabaseAdmin
+    .from('teams')
+    .insert({ name, created_by: req.user.id })
+    .select()
+    .single();
+
+  if (teamErr) {
+    console.error('[createTeam] insert team:', teamErr);
+    return res.status(500).json({ error: 'Failed to create team' });
+  }
+
+  // 2. Insert creator as owner
+  const ownerUsername = profile.github_username || req.user.user_metadata?.user_name || '';
+  await supabaseAdmin.from('team_members').insert({
+    team_id:         team.id,
+    user_id:         req.user.id,
+    github_username: ownerUsername,
+    role:            'owner',
+  });
+
+  // 3. Fetch GitHub collaborators and bulk-insert them as team members
+  let collaboratorCount = 0;
+  try {
+    const [owner, repoName] = repoFullName.split('/');
+    const octokit = new Octokit({ auth: profile.github_access_token });
+
+    const collaborators = await octokit.paginate(
+      octokit.rest.repos.listCollaborators,
+      { owner, repo: repoName, affiliation: 'direct', per_page: 100 }
+    );
+
+    const memberRows = collaborators
+      .filter((c) => c.login !== ownerUsername)
+      .map((c) => ({
+        team_id:         team.id,
+        github_username: c.login,
+        role:            'member',
+        // user_id is null until the collaborator signs into CodeLens
+      }));
+
+    if (memberRows.length > 0) {
+      const { error: membersErr } = await supabaseAdmin
+        .from('team_members')
+        .insert(memberRows, { onConflict: 'team_id,github_username', ignoreDuplicates: true });
+
+      if (membersErr) {
+        console.error('[createTeam] insert members:', membersErr);
+      } else {
+        collaboratorCount = memberRows.length;
+      }
+    }
+  } catch (ghErr) {
+    console.error('[createTeam] GitHub collaborators fetch failed:', ghErr.message);
+    // Non-fatal — team and owner are already created
+  }
+
+  // 4. Link the repo to the team
+  await supabaseAdmin
+    .from('team_repositories')
+    .insert({ team_id: team.id, repo_id: repo.id });
+
+  res.json({ ok: true, team, collaboratorCount });
+};
+
+/**
+ * GET /api/teams — list teams the current user belongs to
+ */
+const listTeams = async (req, res) => {
+  const { data, error } = await supabaseAdmin
+    .from('team_members')
+    .select('role, teams(id, name, created_at, created_by)')
+    .eq('user_id', req.user.id)
+    .order('joined_at', { ascending: false });
+
+  if (error) {
+    console.error('[listTeams]', error);
+    return res.status(500).json({ error: 'Failed to fetch teams' });
+  }
+
+  const teams = (data || []).map((row) => ({
+    ...row.teams,
+    role: row.role,
+  }));
+
+  res.json({ teams });
+};
+
+/**
+ * POST /api/teams/:teamId/repos — add a repo to a team (owner only)
+ * Body: { repoId: string }
+ */
+const addRepoToTeam = async (req, res) => {
+  const { teamId } = req.params;
+  const { repoId } = req.body;
+
+  if (!repoId) return res.status(400).json({ error: 'repoId is required' });
+
+  // Check caller is owner of the team
+  const { data: membership } = await supabaseAdmin
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', req.user.id)
+    .single();
+
+  if (!membership || membership.role !== 'owner') {
+    return res.status(403).json({ error: 'Only team owners can add repositories' });
+  }
+
+  // Check caller owns the repo
+  const { data: repo } = await supabaseAdmin
+    .from('repositories')
+    .select('id')
+    .eq('id', repoId)
+    .eq('user_id', req.user.id)
+    .single();
+
+  if (!repo) {
+    return res.status(404).json({ error: 'Repository not found or you do not own it' });
+  }
+
+  const { error } = await supabaseAdmin
+    .from('team_repositories')
+    .insert({ team_id: teamId, repo_id: repoId });
+
+  if (error && error.code !== '23505') { // ignore unique violation
+    console.error('[addRepoToTeam]', error);
+    return res.status(500).json({ error: 'Failed to add repository to team' });
+  }
+
+  res.json({ ok: true });
+};
+
+/**
+ * GET /api/teams/:teamId/repos — list repos in a team
+ */
+const listTeamRepos = async (req, res) => {
+  const { teamId } = req.params;
+
+  // Verify membership
+  const { data: membership } = await supabaseAdmin
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', req.user.id)
+    .single();
+
+  if (!membership) {
+    return res.status(403).json({ error: 'You are not a member of this team' });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('team_repositories')
+    .select('repositories(*)')
+    .eq('team_id', teamId);
+
+  if (error) {
+    console.error('[listTeamRepos]', error);
+    return res.status(500).json({ error: 'Failed to fetch team repositories' });
+  }
+
+  const repos = (data || []).map((row) => ({ ...row.repositories, shared: true }));
+  res.json({ repos });
+};
+
+module.exports = { createTeam, listTeams, addRepoToTeam, listTeamRepos };

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -1,0 +1,100 @@
+/**
+ * Webhook controller — handles incoming GitHub push events.
+ * This endpoint is called by GitHub, not by the authenticated user,
+ * so it does NOT use the requireAuth middleware.
+ */
+const crypto = require('crypto');
+const { supabaseAdmin } = require('../db/supabase');
+const indexer = require('../services/indexer');
+
+/**
+ * POST /api/webhooks/github
+ *
+ * Receives a GitHub push event, validates the HMAC-SHA256 signature,
+ * and triggers re-indexing if the push is to the repo's default branch.
+ *
+ * Must be mounted BEFORE express.json() so that req.body is the raw Buffer.
+ */
+const handleGitHubPush = async (req, res) => {
+  const signature = req.headers['x-hub-signature-256'];
+  const event     = req.headers['x-github-event'];
+  const rawBody   = req.body; // Buffer (set by express.raw middleware on this route)
+
+  // Only process push events
+  if (event !== 'push') {
+    return res.status(200).json({ ok: true, skipped: 'not a push event' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(rawBody.toString('utf8'));
+  } catch {
+    return res.status(400).json({ error: 'Invalid JSON payload' });
+  }
+
+  const fullName = payload?.repository?.full_name;
+  const ref      = payload?.ref;
+
+  if (!fullName || !ref) {
+    return res.status(400).json({ error: 'Missing repository.full_name or ref in payload' });
+  }
+
+  // Look up the repo by name (stored as "owner/repo") with auto_sync_enabled = true
+  const { data: repo, error: fetchError } = await supabaseAdmin
+    .from('repositories')
+    .select('id, user_id, webhook_secret, default_branch, name, source')
+    .eq('name', fullName)
+    .eq('auto_sync_enabled', true)
+    .eq('source', 'github')
+    .maybeSingle();
+
+  if (fetchError || !repo) {
+    // Return 200 to avoid GitHub marking the webhook as failed
+    return res.status(200).json({ ok: true, skipped: 'repo not found or auto-sync disabled' });
+  }
+
+  // Validate the HMAC-SHA256 signature
+  if (!repo.webhook_secret || !signature) {
+    return res.status(403).json({ error: 'Webhook secret not configured or missing signature' });
+  }
+
+  const expected = 'sha256=' + crypto
+    .createHmac('sha256', repo.webhook_secret)
+    .update(rawBody)
+    .digest('hex');
+
+  const isValid = crypto.timingSafeEqual(
+    Buffer.from(signature, 'utf8'),
+    Buffer.from(expected,  'utf8')
+  );
+
+  if (!isValid) {
+    return res.status(403).json({ error: 'Invalid webhook signature' });
+  }
+
+  // Only re-index pushes to the default branch
+  const defaultRef = `refs/heads/${repo.default_branch || 'main'}`;
+  if (ref !== defaultRef) {
+    return res.status(200).json({ ok: true, skipped: 'push not to default branch' });
+  }
+
+  // Fetch the repo owner's GitHub token
+  const { data: profile } = await supabaseAdmin
+    .from('profiles')
+    .select('github_access_token')
+    .eq('id', repo.user_id)
+    .single();
+
+  if (!profile?.github_access_token) {
+    console.error(`[webhook] No GitHub token for user ${repo.user_id}`);
+    return res.status(200).json({ ok: true, skipped: 'no GitHub token found for repo owner' });
+  }
+
+  // Fire-and-forget re-index — reuses the same pipeline as the manual Re-index button
+  console.log(`[webhook] Triggering re-index for repo ${repo.id} (${fullName}) on push to ${ref}`);
+  indexer.startGitHubIndexing(repo.id, profile.github_access_token, repo.name);
+
+  res.status(200).json({ ok: true, reindexing: true });
+};
+
+module.exports = { handleGitHubPush };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,12 +6,14 @@ const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
 
-const repoRoutes   = require('./routes/repo');
-const searchRoutes = require('./routes/search');
+const repoRoutes     = require('./routes/repo');
+const searchRoutes   = require('./routes/search');
 const analysisRoutes = require('./routes/analysis');
-const authRoutes   = require('./routes/auth');
-const reviewRoutes = require('./routes/review');
-const errorHandler = require('./middleware/errorHandler');
+const authRoutes     = require('./routes/auth');
+const reviewRoutes   = require('./routes/review');
+const webhookRoutes  = require('./routes/webhooks');
+const teamRoutes     = require('./routes/teams');
+const errorHandler   = require('./middleware/errorHandler');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -29,6 +31,9 @@ app.use('/api/repos',    repoRoutes);
 app.use('/api/search',   searchRoutes);
 app.use('/api/analysis', analysisRoutes);
 app.use('/api/review',   reviewRoutes);
+// Webhook routes use express.raw per-route (mounted before global express.json parses them)
+app.use('/api/webhooks', webhookRoutes);
+app.use('/api/teams',    teamRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/backend/src/routes/repo.js
+++ b/backend/src/routes/repo.js
@@ -32,4 +32,10 @@ router.post('/:repoId/reindex', requireAuth, repoController.reindexRepo);
 // Delete a repo and its index
 router.delete('/:repoId', requireAuth, repoController.deleteRepo);
 
+// Update mutable repo fields (e.g. auto_sync_enabled)
+router.patch('/:repoId', requireAuth, repoController.updateRepo);
+
+// Generate (or regenerate) a webhook secret for a GitHub repo — secret shown once
+router.get('/:repoId/webhook', requireAuth, repoController.generateWebhook);
+
 module.exports = router;

--- a/backend/src/routes/teams.js
+++ b/backend/src/routes/teams.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { requireAuth } = require('../middleware/auth');
+const teamController = require('../controllers/teamController');
+
+router.post('/',                    requireAuth, teamController.createTeam);
+router.get('/',                     requireAuth, teamController.listTeams);
+router.post('/:teamId/repos',       requireAuth, teamController.addRepoToTeam);
+router.get('/:teamId/repos',        requireAuth, teamController.listTeamRepos);
+
+module.exports = router;

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { handleGitHubPush } = require('../controllers/webhookController');
+
+// Use express.raw so that the raw Buffer body is available for HMAC validation.
+// This must be set per-route, not globally, to avoid breaking the rest of the API.
+router.post('/github', express.raw({ type: 'application/json' }), handleGitHubPush);
+
+module.exports = router;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+# Production compose file — no volume mounts, no hot-reload.
+# All credentials MUST be supplied as environment variables or via a .env file.
+# Usage:
+#   docker-compose -f docker-compose.prod.yml up -d
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile      # uses the multi-stage production Dockerfile
+    ports:
+      - '3001:3001'
+    environment:
+      - NODE_ENV=production
+      - PORT=3001
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+      - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+      - GITHUB_CALLBACK_URL=${GITHUB_CALLBACK_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - GROQ_API_KEY=${GROQ_API_KEY}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - BACKEND_URL=${BACKEND_URL}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3001/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile      # uses the multi-stage Nginx production Dockerfile
+      args:
+        - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
+        - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
+        - VITE_API_URL=${VITE_API_URL}
+    ports:
+      - '80:80'
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,48 @@
+# ── Stage 1: Vite build ───────────────────────────────────────────────────────
+FROM node:20-slim AS builder
+
+# Vite bakes env vars into the static bundle at build time.
+# Pass them via --build-arg in docker-compose or docker build.
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+ARG VITE_API_URL
+ARG VITE_API_PROXY_TARGET
+
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_API_PROXY_TARGET=$VITE_API_PROXY_TARGET
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Build the Vite app — outputs to /app/dist
+RUN npm run build
+
+# ── Stage 2: Nginx serve ──────────────────────────────────────────────────────
+FROM nginx:alpine AS runtime
+
+# Copy the built static files
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Run as a non-root unprivileged user
+# Note: nginx master must run as root to bind port 80, but worker processes
+# run as the nginx user by default. We set the worker user explicitly.
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown nginx:nginx /var/run/nginx.pid
+
+USER nginx
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static assets with long-term caching
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # Proxy API requests to the backend service
+    location /api/ {
+        proxy_pass http://backend:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        # Allow longer timeout for SSE streaming endpoints (search)
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # SPA fallback — all other routes served by index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/components/CreateTeamModal.jsx
+++ b/frontend/src/components/CreateTeamModal.jsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+export default function CreateTeamModal({ isOpen, onClose, onCreated }) {
+  const { session } = useAuth();
+  const [teamName, setTeamName]   = useState('');
+  const [repoFullName, setRepoFullName] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!teamName.trim() || !repoFullName.trim()) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/teams', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          name:        teamName.trim(),
+          repoFullName: repoFullName.trim(),
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to create team');
+      }
+
+      const data = await res.json();
+      setTeamName('');
+      setRepoFullName('');
+      onClose();
+      onCreated(data.team, data.collaboratorCount);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setError(null);
+    setTeamName('');
+    setRepoFullName('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+      <div
+        className="w-full max-w-md rounded-2xl border border-gray-800 bg-gray-950 p-8 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-white">Create a Team</h2>
+          <p className="mt-1 text-sm text-gray-400">
+            Sync your GitHub repository collaborators into a team. They will automatically see the shared repository when they sign in to CodeLens.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-300">
+              Team name
+            </label>
+            <input
+              type="text"
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+              placeholder="e.g. Backend squad"
+              required
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder:text-gray-600 focus:border-indigo-500 focus:outline-none transition"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-300">
+              GitHub repository
+            </label>
+            <input
+              type="text"
+              value={repoFullName}
+              onChange={(e) => setRepoFullName(e.target.value)}
+              placeholder="owner/repository"
+              required
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm text-white placeholder:text-gray-600 focus:border-indigo-500 focus:outline-none transition"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              Must be a repository you have already connected to CodeLens. Collaborators will be fetched from GitHub.
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-lg border border-red-800 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={isSubmitting}
+              className="flex-1 rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-sm font-medium text-gray-300 hover:bg-gray-800 transition disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !teamName.trim() || !repoFullName.trim()}
+              className="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Creating...' : 'Create team'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DependencyGraph.jsx
+++ b/frontend/src/components/DependencyGraph.jsx
@@ -340,6 +340,7 @@ export default function DependencyGraph({
   onNodeSelect,
   onAnalyseImpact,
   onClearImpactAnalysis,
+  repoName,
 }) {
   const containerRef = useRef(null);
   const svgRef = useRef(null);
@@ -348,6 +349,50 @@ export default function DependencyGraph({
   const [contextMenu, setContextMenu] = useState(null);
   const [clusteringEnabled, setClusteringEnabled] = useState(true);
   const [expandedClusters, setExpandedClusters] = useState(new Set());
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+
+  const exportFilename = repoName ? repoName.replace(/[^\w.-]/g, '_') : 'graph';
+
+  const exportSVG = () => {
+    const svgEl = svgRef.current;
+    if (!svgEl) return;
+    const serializer = new XMLSerializer();
+    const svgStr = serializer.serializeToString(svgEl);
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${exportFilename}-graph.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setExportMenuOpen(false);
+  };
+
+  const exportPNG = async () => {
+    setExportMenuOpen(false);
+    let canvas;
+    if (renderMode === 'canvas') {
+      canvas = canvasRef.current;
+      if (!canvas) return;
+    } else {
+      const svgEl = svgRef.current;
+      if (!svgEl) return;
+      const svgStr = new XMLSerializer().serializeToString(svgEl);
+      const blob = new Blob([svgStr], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      const img = new Image();
+      await new Promise((resolve) => { img.onload = resolve; img.src = url; });
+      canvas = document.createElement('canvas');
+      canvas.width = svgEl.clientWidth * 2;
+      canvas.height = svgEl.clientHeight * 2;
+      canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+      URL.revokeObjectURL(url);
+    }
+    const a = document.createElement('a');
+    a.href = canvas.toDataURL('image/png');
+    a.download = `${exportFilename}-graph.png`;
+    a.click();
+  };
 
   const issueNodePaths = useMemo(() => {
     const pathSet = new Set();
@@ -482,13 +527,16 @@ export default function DependencyGraph({
   }, [toastVisible]);
 
   useEffect(() => {
-    if (!contextMenu) return undefined;
+    if (!contextMenu && !exportMenuOpen) return undefined;
 
-    const handleOutsideClick = () => setContextMenu(null);
+    const handleOutsideClick = () => {
+      setContextMenu(null);
+      setExportMenuOpen(false);
+    };
     window.addEventListener('pointerdown', handleOutsideClick);
 
     return () => window.removeEventListener('pointerdown', handleOutsideClick);
-  }, [contextMenu]);
+  }, [contextMenu, exportMenuOpen]);
 
   const { resetView } = useGraphSimulation({
     containerRef,
@@ -575,6 +623,34 @@ export default function DependencyGraph({
                 Collapse all
               </button>
             )}
+            <div className="relative">
+              <button
+                onClick={() => setExportMenuOpen((v) => !v)}
+                className="rounded-full border border-gray-700 bg-gray-950/80 px-3 py-1 text-xs font-medium text-gray-400 transition hover:border-gray-500 hover:text-gray-200"
+              >
+                Export image
+              </button>
+              {exportMenuOpen && (
+                <div
+                  className="absolute right-0 top-full z-30 mt-1 min-w-36 rounded-xl border border-gray-700 bg-gray-950/95 p-1.5 shadow-2xl shadow-black/50 backdrop-blur"
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  <button
+                    onClick={exportSVG}
+                    disabled={renderMode === 'canvas'}
+                    className="block w-full rounded-lg px-3 py-2 text-left text-sm text-gray-100 transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Export as SVG
+                  </button>
+                  <button
+                    onClick={exportPNG}
+                    className="block w-full rounded-lg px-3 py-2 text-left text-sm text-gray-100 transition hover:bg-gray-800"
+                  >
+                    Export as PNG
+                  </button>
+                </div>
+              )}
+            </div>
             <button
               onClick={resetView}
               className="rounded-full border border-gray-700 bg-gray-950/80 px-4 py-2 text-sm font-medium text-gray-100 transition hover:border-gray-500 hover:bg-gray-900"

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -29,11 +29,12 @@ export default function Layout() {
   };
 
   const repoNavItems = [
-    { label: 'Graph',       tab: 'graph',   icon: GraphIcon   },
-    { label: 'Metrics',     tab: 'metrics', icon: MetricsIcon },
-    { label: 'Issues',      tab: 'issues',  icon: IssuesIcon  },
-    { label: 'Search',      tab: 'search',  icon: SearchIcon  },
-    { label: 'Code Review', tab: 'review',  icon: ReviewIcon  },
+    { label: 'Graph',       tab: 'graph',    icon: GraphIcon    },
+    { label: 'Metrics',     tab: 'metrics',  icon: MetricsIcon  },
+    { label: 'Issues',      tab: 'issues',   icon: IssuesIcon   },
+    { label: 'Search',      tab: 'search',   icon: SearchIcon   },
+    { label: 'Code Review', tab: 'review',   icon: ReviewIcon   },
+    { label: 'Settings',    tab: 'settings', icon: SettingsIcon },
   ];
 
   return (
@@ -270,6 +271,15 @@ function InfoIcon(props) {
   return (
     <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+    </svg>
+  );
+}
+
+function SettingsIcon(props) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
     </svg>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -3,6 +3,71 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import ConnectGitHubModal from '../components/ConnectGitHubModal';
 import UploadRepoModal from '../components/UploadRepoModal';
+import CreateTeamModal from '../components/CreateTeamModal';
+
+function StatusBadge({ status }) {
+  switch (status) {
+    case 'ready':
+      return <span className="inline-flex items-center rounded-full bg-green-500/10 px-2 py-1 text-xs font-medium text-green-400 ring-1 ring-inset ring-green-500/20">Ready</span>;
+    case 'failed':
+      return <span className="inline-flex items-center rounded-full bg-red-500/10 px-2 py-1 text-xs font-medium text-red-400 ring-1 ring-inset ring-red-500/20">Failed</span>;
+    case 'indexing':
+      return <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-1 text-xs font-medium text-blue-400 ring-1 ring-inset ring-blue-500/20 animate-pulse">Indexing</span>;
+    default:
+      return <span className="inline-flex items-center rounded-full bg-gray-500/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-500/20">Pending</span>;
+  }
+}
+
+function RepoCard({ repo, onRetry }) {
+  return (
+    <Link
+      key={repo.id}
+      to={`/repo/${repo.id}`}
+      className="group relative flex flex-col justify-between rounded-xl border border-gray-800 bg-gray-900 p-6 transition hover:border-gray-700 hover:bg-gray-800/80 hover:shadow-lg"
+    >
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-100 group-hover:text-indigo-400 transition-colors">
+            {repo.name}
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            {repo.source === 'github' ? 'GitHub' : 'Upload'} • {repo.file_count || 0} files
+            {repo.shared && repo.team_name && (
+              <span className="ml-2 inline-flex items-center rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-400 ring-1 ring-inset ring-violet-500/20">
+                {repo.team_name}
+              </span>
+            )}
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-1.5">
+          <StatusBadge status={repo.status} />
+          {repo.auto_sync_enabled && (
+            <span className="inline-flex items-center rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs font-medium text-indigo-400 ring-1 ring-inset ring-indigo-500/20">
+              Auto-sync
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-gray-800/50 pt-4 mt-2">
+        <span className="text-xs text-gray-500">
+          {repo.indexed_at
+            ? `Indexed on ${new Date(repo.indexed_at).toLocaleDateString()}`
+            : `Added on ${new Date(repo.created_at).toLocaleDateString()}`}
+        </span>
+
+        {repo.status === 'failed' && !repo.shared && (
+          <button
+            onClick={(e) => onRetry(e, repo.id)}
+            className="rounded bg-red-900/40 px-3 py-1 text-xs font-semibold text-red-300 hover:bg-red-800/60 transition"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    </Link>
+  );
+}
 
 export default function Dashboard() {
   const { session } = useAuth();
@@ -12,6 +77,8 @@ export default function Dashboard() {
   const [error, setError] = useState(null);
   const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [isCreateTeamOpen, setIsCreateTeamOpen] = useState(false);
+  const [teamCreatedMsg, setTeamCreatedMsg] = useState(null);
 
   const fetchRepos = useCallback(async () => {
     if (!session?.access_token) return;
@@ -79,19 +146,6 @@ export default function Dashboard() {
     }
   };
 
-  const StatusBadge = ({ status }) => {
-    switch (status) {
-      case 'ready':
-        return <span className="inline-flex items-center rounded-full bg-green-500/10 px-2 py-1 text-xs font-medium text-green-400 ring-1 ring-inset ring-green-500/20">Ready</span>;
-      case 'failed':
-        return <span className="inline-flex items-center rounded-full bg-red-500/10 px-2 py-1 text-xs font-medium text-red-400 ring-1 ring-inset ring-red-500/20">Failed</span>;
-      case 'indexing':
-        return <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-1 text-xs font-medium text-blue-400 ring-1 ring-inset ring-blue-500/20 animate-pulse">Indexing</span>;
-      default: // pending
-        return <span className="inline-flex items-center rounded-full bg-gray-500/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-500/20">Pending</span>;
-    }
-  };
-
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center p-8">
@@ -104,21 +158,33 @@ export default function Dashboard() {
     <div className="min-h-screen bg-gray-950 p-8 text-white">
       <div className="mb-8 flex items-center justify-between">
         <h1 className="text-3xl font-bold tracking-tight">Your Repositories</h1>
-        <div className="flex gap-4">
+        <div className="flex gap-3">
           <button
-             onClick={() => setIsUploadModalOpen(true)}
-             className="rounded-md bg-gray-800 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700 transition"
+            onClick={() => setIsCreateTeamOpen(true)}
+            className="rounded-md border border-gray-700 bg-gray-900 px-4 py-2 text-sm font-semibold text-gray-300 hover:bg-gray-800 transition"
+          >
+            Create Team
+          </button>
+          <button
+            onClick={() => setIsUploadModalOpen(true)}
+            className="rounded-md bg-gray-800 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700 transition"
           >
             Upload Repository
           </button>
           <button
-             onClick={() => setIsConnectModalOpen(true)}
-             className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 transition shadow-sm"
+            onClick={() => setIsConnectModalOpen(true)}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 transition shadow-sm"
           >
             Connect GitHub
           </button>
         </div>
       </div>
+
+      {teamCreatedMsg && (
+        <div className="mb-6 rounded-lg border border-green-800 bg-green-900/30 px-5 py-3 text-sm text-green-300">
+          {teamCreatedMsg}
+        </div>
+      )}
 
       {error && (
         <div className="mb-6 rounded-md bg-red-900/50 p-4 border border-red-800 text-red-200">
@@ -139,44 +205,33 @@ export default function Dashboard() {
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {repos.map(repo => (
-            <Link
-              key={repo.id}
-              to={`/repo/${repo.id}`}
-              className="group relative flex flex-col justify-between rounded-xl border border-gray-800 bg-gray-900 p-6 transition hover:border-gray-700 hover:bg-gray-800/80 hover:shadow-lg"
-            >
-              <div className="mb-4 flex items-start justify-between">
-                <div>
-                  <h2 className="text-xl font-semibold text-gray-100 group-hover:text-indigo-400 transition-colors">
-                    {repo.name}
-                  </h2>
-                  <p className="text-sm text-gray-500 mt-1">
-                    {repo.source === 'github' ? 'GitHub' : 'Upload'} • {repo.file_count || 0} files
-                  </p>
+        <>
+          {/* Own repos */}
+          {(() => {
+            const ownedRepos = repos.filter(r => !r.shared);
+            const sharedRepos = repos.filter(r => r.shared);
+            return (
+              <>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {ownedRepos.map(repo => (
+                    <RepoCard key={repo.id} repo={repo} onRetry={handleRetry} />
+                  ))}
                 </div>
-                <StatusBadge status={repo.status} />
-              </div>
 
-              <div className="flex items-center justify-between border-t border-gray-800/50 pt-4 mt-2">
-                <span className="text-xs text-gray-500">
-                  {repo.indexed_at 
-                    ? `Indexed on ${new Date(repo.indexed_at).toLocaleDateString()}`
-                    : `Added on ${new Date(repo.created_at).toLocaleDateString()}`}
-                </span>
-                
-                {repo.status === 'failed' && (
-                  <button
-                    onClick={(e) => handleRetry(e, repo.id)}
-                    className="rounded bg-red-900/40 px-3 py-1 text-xs font-semibold text-red-300 hover:bg-red-800/60 transition"
-                  >
-                    Retry
-                  </button>
+                {sharedRepos.length > 0 && (
+                  <div className="mt-10">
+                    <h2 className="mb-4 text-lg font-semibold text-gray-300">Team Repositories</h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {sharedRepos.map(repo => (
+                        <RepoCard key={repo.id} repo={repo} onRetry={handleRetry} />
+                      ))}
+                    </div>
+                  </div>
                 )}
-              </div>
-            </Link>
-          ))}
-        </div>
+              </>
+            );
+          })()}
+        </>
       )}
 
       <ConnectGitHubModal
@@ -190,6 +245,18 @@ export default function Dashboard() {
         isOpen={isUploadModalOpen}
         onClose={() => setIsUploadModalOpen(false)}
         onConnected={fetchRepos}
+      />
+
+      <CreateTeamModal
+        isOpen={isCreateTeamOpen}
+        onClose={() => setIsCreateTeamOpen(false)}
+        onCreated={(team, count) => {
+          fetchRepos();
+          setTeamCreatedMsg(
+            `Team "${team.name}" created with ${count} collaborator${count !== 1 ? 's' : ''} added. They will see the shared repository when they sign in.`
+          );
+          setTimeout(() => setTeamCreatedMsg(null), 8000);
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -370,6 +370,154 @@ function IssuesPanel({ nodes, issues, onNodeSelect }) {
 }
 
 
+function SettingsPanel({ repo, session, onRepoUpdated }) {
+  const [autoSync, setAutoSync] = useState(repo?.auto_sync_enabled ?? false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [webhookInfo, setWebhookInfo] = useState(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [copied, setCopied] = useState('');
+
+  const isGitHub = repo?.source === 'github';
+
+  const handleAutoSyncToggle = async () => {
+    const next = !autoSync;
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/repos/${repo.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ auto_sync_enabled: next }),
+      });
+      if (!res.ok) throw new Error('Failed to update setting');
+      setAutoSync(next);
+      onRepoUpdated();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleGenerateWebhook = async () => {
+    setIsGenerating(true);
+    setWebhookInfo(null);
+    try {
+      const res = await fetch(`/api/repos/${repo.id}/webhook`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to generate webhook');
+      const data = await res.json();
+      setWebhookInfo(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleCopy = async (text, key) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied(''), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (!isGitHub) {
+    return (
+      <div className="flex h-[40rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
+        <p className="text-sm text-gray-500">Webhook auto-sync is only available for GitHub repositories.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-8">
+      {/* Auto-sync toggle */}
+      <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-white">Auto-sync on push</h3>
+            <p className="mt-1 text-sm text-gray-400">
+              Automatically re-index this repository whenever a push is made to the default branch via GitHub webhook.
+            </p>
+          </div>
+          <button
+            onClick={handleAutoSyncToggle}
+            disabled={isSaving}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none disabled:opacity-50 ${
+              autoSync ? 'bg-indigo-600' : 'bg-gray-700'
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                autoSync ? 'translate-x-5' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </div>
+        {autoSync && (
+          <p className="mt-3 text-xs text-indigo-400">
+            Auto-sync is enabled. Make sure a webhook is configured in your GitHub repository settings below.
+          </p>
+        )}
+      </div>
+
+      {/* Webhook URL generation */}
+      <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+        <h3 className="text-base font-semibold text-white">Webhook configuration</h3>
+        <p className="mt-1 text-sm text-gray-400">
+          Generate a webhook URL and secret to configure in your GitHub repository settings
+          (Settings → Webhooks → Add webhook). Set the content type to{' '}
+          <code className="rounded bg-gray-800 px-1 py-0.5 text-xs text-gray-200">application/json</code>{' '}
+          and select the <strong className="text-gray-300">Push</strong> event only.
+        </p>
+
+        <button
+          onClick={handleGenerateWebhook}
+          disabled={isGenerating}
+          className="mt-4 rounded-md bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition disabled:opacity-50"
+        >
+          {isGenerating ? 'Generating...' : 'Generate webhook URL'}
+        </button>
+
+        {webhookInfo && (
+          <div className="mt-4 space-y-3">
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-300">
+              Save the secret now — it will not be shown again. Generating a new one will invalidate the previous secret.
+            </div>
+
+            {[
+              { label: 'Webhook URL', value: webhookInfo.webhookUrl, key: 'url' },
+              { label: 'Secret',      value: webhookInfo.secret,     key: 'secret' },
+            ].map(({ label, value, key }) => (
+              <div key={key}>
+                <p className="mb-1 text-xs uppercase tracking-widest text-gray-500">{label}</p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 overflow-auto rounded-md border border-gray-700 bg-gray-950 px-3 py-2 font-mono text-xs text-gray-200 break-all">
+                    {value}
+                  </code>
+                  <button
+                    onClick={() => handleCopy(value, key)}
+                    className="shrink-0 rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-xs font-medium text-gray-300 hover:bg-gray-800 transition"
+                  >
+                    {copied === key ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function RepoView() {
   const { repoId } = useParams();
   const { session } = useAuth();
@@ -659,6 +807,7 @@ export default function RepoView() {
                 onNodeSelect={handleNodeSelect}
                 onAnalyseImpact={handleStartImpactAnalysis}
                 onClearImpactAnalysis={handleClearImpactAnalysis}
+                repoName={repo?.name}
               />
             </div>
 
@@ -686,6 +835,15 @@ export default function RepoView() {
             {/* Review tab — CodeReviewPanel */}
             <div className={activeTab === 'review' ? 'block h-full' : 'hidden'}>
               <CodeReviewPanel repoId={repoId} />
+            </div>
+
+            {/* Settings tab — webhook / auto-sync */}
+            <div className={activeTab === 'settings' ? 'block h-full' : 'hidden'}>
+              <SettingsPanel
+                repo={repo}
+                session={session}
+                onRepoUpdated={fetchRepo}
+              />
             </div>
           </div>
         )}

--- a/scripts/002_webhooks.sql
+++ b/scripts/002_webhooks.sql
@@ -1,0 +1,6 @@
+-- Migration: add webhook support columns to repositories
+-- Apply via Supabase SQL Editor
+
+ALTER TABLE repositories
+  ADD COLUMN IF NOT EXISTS webhook_secret    TEXT,
+  ADD COLUMN IF NOT EXISTS auto_sync_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/scripts/003_teams.sql
+++ b/scripts/003_teams.sql
@@ -1,0 +1,92 @@
+-- Migration: Teams / Organizations
+-- Apply via Supabase SQL Editor after 002_webhooks.sql
+
+-- ── Tables ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS teams (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       TEXT        NOT NULL,
+  created_by UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS team_members (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id         UUID        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  user_id         UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  github_username TEXT        NOT NULL,
+  role            TEXT        NOT NULL DEFAULT 'member'
+                              CHECK (role IN ('owner', 'member')),
+  joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (team_id, github_username)
+);
+
+CREATE INDEX IF NOT EXISTS team_members_user_id_idx ON team_members (user_id);
+CREATE INDEX IF NOT EXISTS team_members_team_id_idx ON team_members (team_id);
+
+CREATE TABLE IF NOT EXISTS team_repositories (
+  id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  repo_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  UNIQUE (team_id, repo_id)
+);
+
+CREATE INDEX IF NOT EXISTS team_repositories_team_id_idx ON team_repositories (team_id);
+CREATE INDEX IF NOT EXISTS team_repositories_repo_id_idx ON team_repositories (repo_id);
+
+-- ── Row Level Security ────────────────────────────────────────────────────────
+
+ALTER TABLE teams            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE team_members     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE team_repositories ENABLE ROW LEVEL SECURITY;
+
+-- Teams: visible to members of the team
+CREATE POLICY "Team members can view their teams"
+  ON teams FOR SELECT
+  USING (
+    id IN (
+      SELECT team_id FROM team_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- Owners can insert/delete teams they created
+CREATE POLICY "Team owners can manage their teams"
+  ON teams FOR ALL
+  USING (created_by = auth.uid());
+
+-- team_members: visible to other members of the same team
+CREATE POLICY "Team members can view members of their teams"
+  ON team_members FOR SELECT
+  USING (
+    team_id IN (
+      SELECT team_id FROM team_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- team_repositories: visible to team members
+CREATE POLICY "Team members can view team repositories"
+  ON team_repositories FOR SELECT
+  USING (
+    team_id IN (
+      SELECT team_id FROM team_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- ── Update repositories RLS for team access ───────────────────────────────────
+-- Drop the original single-owner policy and replace with one that also
+-- grants read access to team members.
+
+DROP POLICY IF EXISTS "Users can only access their own repos" ON repositories;
+
+CREATE POLICY "Users can access own repos or team-shared repos"
+  ON repositories FOR ALL
+  USING (
+    auth.uid() = user_id
+    OR id IN (
+      SELECT repo_id
+      FROM   team_repositories
+      WHERE  team_id IN (
+        SELECT team_id FROM team_members WHERE user_id = auth.uid()
+      )
+    )
+  );


### PR DESCRIPTION
- US-028: GitHub webhook auto-sync — POST /api/webhooks/github with
  HMAC-SHA256 validation, PATCH /api/repos/:id toggle, GET /api/repos/:id/webhook
  secret generation; Settings tab in RepoView with auto-sync toggle and
  one-time webhook URL reveal; auto-sync badge on Dashboard repo cards

- US-029: Production Dockerisation — multi-stage backend/Dockerfile (non-root
  appuser), multi-stage frontend/Dockerfile (Vite build → Nginx alpine, non-root
  nginx user), nginx.conf with SPA fallback and /api/ proxy, docker-compose.prod.yml

- US-030: CI/CD pipeline — .github/workflows/ci.yml (lint + test on push/PR),
  .github/workflows/cd.yml (build and push Docker images to GHCR on merge to main)

- US-031: Cloud hosting — DEPLOYMENT.md covering Supabase, GitHub OAuth,
  Render/Vercel setup, CORS verification, branch protection, and self-hosted Docker

- US-032: Graph export — Export image dropdown in DependencyGraph toolbar with
  SVG serialisation and PNG via canvas (2x resolution); repoName prop threaded
  through from RepoView

- US-034: Team organisations — teams/team_members/team_repositories DB migration
  with RLS, POST /api/teams syncs GitHub collaborators via Octokit, listRepos
  returns owned + team-shared repos, auth profile sync auto-joins team members
  on sign-in; Create Team modal and Team Repositories section on Dashboard

Fix: query repositories by name column (not full_name which is never populated)
     in teamController and webhookController
     
     Closes #39 
     Closes #40 
     Closes #41 
     Closes #42 
     Closes #43 
     Closes #45 