### PR TITLE
feat: implement rate limiting and full file content storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ GITHUB_CALLBACK_URL=http://localhost:3001/auth/github/callback
 # Used for generating code_chunks embeddings and RAG chat responses
 OPENAI_API_KEY=your-openai-api-key
 
+# ─── AI Rate Limiting & Cost Controls (US-042) ───────────────────────────────────
+# Per-user daily token budget across all AI providers (default: 500 000)
+MAX_DAILY_TOKENS_PER_USER=500000
+# Per-user request rate limits on AI endpoints
+MAX_RPM=30
+MAX_RPH=500
+# Comma-separated Supabase user UUIDs with access to GET /api/admin/usage
+ADMIN_USER_IDS=
+
 # ─── Frontend (Vite public vars) ────────────────────────────────────────────────
 # Vite only exposes vars prefixed with VITE_ to the browser bundle
 VITE_SUPABASE_URL=https://your-project.supabase.co

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -236,8 +236,12 @@ const reindexRepo = async (req, res) => {
     }
 
     if (githubToken) {
-      indexer.startGitHubIndexing(repo.id, githubToken, repo.name);
+      // Use full_name (owner/repo) so the GitHub API call resolves correctly.
+      // Fall back to name for repos connected before full_name was populated.
+      const repoFullName = repo.full_name || repo.name;
+      indexer.startGitHubIndexing(repo.id, githubToken, repoFullName);
     } else {
+      console.error(`[reindexRepo] GitHub token not found in vault for user ${req.user.id} — profile.github_token_secret_id: ${profile?.github_token_secret_id ?? 'null'}. User must sign out and sign back in to re-sync their token.`);
       await supabaseAdmin.from('repositories').update({ status: 'failed' }).eq('id', repoId);
     }
   } else if (repo.source === 'upload') {

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -196,7 +196,7 @@ const reindexRepo = async (req, res) => {
     return res.status(404).json({ error: 'Repository not found or unauthorized' });
   }
 
-  const tables = ['code_chunks', 'analysis_issues', 'graph_edges', 'graph_nodes'];
+  const tables = ['code_chunks', 'file_contents', 'analysis_issues', 'graph_edges', 'graph_nodes'];
 
   for (const table of tables) {
     const { error: deleteError } = await supabaseAdmin
@@ -395,7 +395,8 @@ const generateWebhook = async (req, res) => {
 
 /**
  * GET /api/repos/:repoId/file?path=src/index.js
- * Returns concatenated source content from code_chunks for a given file.
+ * Returns full file content from file_contents (US-043), falling back to
+ * concatenated code_chunks for repos indexed before US-043 was deployed.
  */
 const getFileContent = async (req, res) => {
   const { repoId } = req.params;
@@ -418,7 +419,19 @@ const getFileContent = async (req, res) => {
     .eq('file_path', filePath)
     .maybeSingle();
 
-  // Concatenate chunks in line order
+  // Primary: full content from file_contents (US-043)
+  const { data: fc, error: fcErr } = await supabaseAdmin
+    .from('file_contents')
+    .select('content')
+    .eq('repo_id', repoId)
+    .eq('file_path', filePath)
+    .maybeSingle();
+
+  if (!fcErr && fc) {
+    return res.json({ content: fc.content, filePath, language: node?.language || null });
+  }
+
+  // Fallback: concatenate code_chunks (pre-US-043 repos)
   const { data: chunks, error } = await supabaseAdmin
     .from('code_chunks')
     .select('content, start_line')

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -19,6 +19,7 @@
 const { OpenAI }        = require('openai');
 const Anthropic         = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
+const { recordUsage }   = require('../services/usageTracker');
 
 const _openai    = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const _anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
@@ -31,18 +32,6 @@ const anthropic = _proxy(_anthropic, '__CODELENS_ANTHROPIC__');
 // ---------------------------------------------------------------------------
 // Helpers — mirrors searchController.js exactly
 // ---------------------------------------------------------------------------
-
-/**
- * Embed a code snippet using OpenAI text-embedding-3-small.
- * Same as embedQuery in searchController.js.
- */
-async function embedSnippet(snippet) {
-  const res = await openai.embeddings.create({
-    model: 'text-embedding-3-small',
-    input: snippet,
-  });
-  return res.data[0].embedding;
-}
 
 /**
  * Retrieve the top-k most similar code chunks from Supabase using pgvector.
@@ -195,12 +184,16 @@ const review = async (req, res) => {
 
     // 2. Embed the snippet
     let embedding;
+    let embedTokens = 0;
     try {
-      embedding = await embedSnippet(snippet.trim());
+      const embedRes = await openai.embeddings.create({ model: 'text-embedding-3-small', input: snippet.trim() });
+      embedding   = embedRes.data[0].embedding;
+      embedTokens = embedRes.usage?.total_tokens || 0;
     } catch (err) {
       send({ type: 'error', message: 'Failed to process your snippet. Please try again.' });
       return res.end();
     }
+    recordUsage({ userId: req.user.id, endpoint: 'review', provider: 'openai', embeddingTokens: embedTokens });
 
     // 3. Retrieve top 5 similar chunks
     let chunks;
@@ -227,12 +220,18 @@ const review = async (req, res) => {
       stream:     true,
     });
 
+    let inputTokens = 0, outputTokens = 0;
     for await (const event of stream) {
-      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+      if (event.type === 'message_start') {
+        inputTokens = event.message?.usage?.input_tokens || 0;
+      } else if (event.type === 'message_delta') {
+        outputTokens = event.usage?.output_tokens || 0;
+      } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
         send({ type: 'chunk', text: event.delta.text });
       }
     }
 
+    recordUsage({ userId: req.user.id, endpoint: 'review', provider: 'anthropic', promptTokens: inputTokens, completionTokens: outputTokens });
     send({ type: 'done' });
     res.end();
 

--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -17,6 +17,7 @@
 const { OpenAI }     = require('openai');
 const Anthropic      = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
+const { recordUsage } = require('../services/usageTracker');
 
 const _openai    = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const _anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
@@ -29,18 +30,6 @@ const anthropic = _proxy(_anthropic, '__CODELENS_ANTHROPIC__');
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Embed a single query string with OpenAI text-embedding-3-small.
- * Returns a Float32Array-compatible JS array (1536 dims).
- */
-async function embedQuery(query) {
-  const res = await openai.embeddings.create({
-    model: 'text-embedding-3-small',
-    input: query,
-  });
-  return res.data[0].embedding;
-}
 
 /**
  * Retrieve the top-k most similar code chunks from Supabase using pgvector.
@@ -187,13 +176,17 @@ const search = async (req, res) => {
     // 2. Embed the query
     const embedStart = Date.now();
     let embedding;
+    let embedTokens = 0;
     try {
-      embedding = await embedQuery(query.trim());
+      const embedRes = await openai.embeddings.create({ model: 'text-embedding-3-small', input: query.trim() });
+      embedding    = embedRes.data[0].embedding;
+      embedTokens  = embedRes.usage?.total_tokens || 0;
     } catch (err) {
       clearTimeout(timeoutId);
       send({ type: 'error', message: 'Failed to process your query. Please try again.' });
       return res.end();
     }
+    recordUsage({ userId: req.user.id, endpoint: 'search', provider: 'openai', embeddingTokens: embedTokens });
     console.log(`[search] Embedding took ${Date.now() - embedStart}ms`);
     if (pipelineTimedOut) return;
 
@@ -259,12 +252,19 @@ const search = async (req, res) => {
       stream:     true,
     });
 
+    let inputTokens = 0, outputTokens = 0;
     for await (const event of stream) {
       if (pipelineTimedOut) break;
-      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+      if (event.type === 'message_start') {
+        inputTokens = event.message?.usage?.input_tokens || 0;
+      } else if (event.type === 'message_delta') {
+        outputTokens = event.usage?.output_tokens || 0;
+      } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
         send({ type: 'chunk', text: event.delta.text });
       }
     }
+
+    recordUsage({ userId: req.user.id, endpoint: 'search', provider: 'anthropic', promptTokens: inputTokens, completionTokens: outputTokens });
 
     clearTimeout(timeoutId);
     if (!pipelineTimedOut) {

--- a/backend/src/controllers/usageController.js
+++ b/backend/src/controllers/usageController.js
@@ -1,0 +1,66 @@
+/**
+ * Usage controller (US-042)
+ *
+ * GET /api/usage/today  — current user's daily token consumption
+ * GET /api/admin/usage  — aggregate across all users (admin only)
+ */
+
+const { supabaseAdmin } = require('../db/supabase');
+
+const MAX_TOKENS  = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
+const ADMIN_IDS   = new Set((process.env.ADMIN_USER_IDS || '').split(',').map(s => s.trim()).filter(Boolean));
+
+/** GET /api/usage/today */
+const getTodayUsage = async (req, res) => {
+  const userId = req.user.id;
+  const since  = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from('api_usage')
+    .select('prompt_tokens, completion_tokens, embedding_tokens')
+    .eq('user_id', userId)
+    .gte('created_at', since);
+
+  if (error) return res.status(500).json({ error: 'Failed to fetch usage data' });
+
+  const used = (data || []).reduce(
+    (sum, r) => sum + (r.prompt_tokens || 0) + (r.completion_tokens || 0) + (r.embedding_tokens || 0),
+    0
+  );
+
+  res.json({ used, limit: MAX_TOKENS });
+};
+
+/** GET /api/admin/usage */
+const getAdminUsage = async (req, res) => {
+  if (!ADMIN_IDS.has(req.user.id)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from('api_usage')
+    .select('user_id, endpoint, provider, prompt_tokens, completion_tokens, embedding_tokens, created_at')
+    .gte('created_at', since)
+    .order('created_at', { ascending: false });
+
+  if (error) return res.status(500).json({ error: 'Failed to fetch admin usage data' });
+
+  // Aggregate per user
+  const byUser = {};
+  for (const row of data || []) {
+    if (!byUser[row.user_id]) byUser[row.user_id] = { user_id: row.user_id, total_tokens: 0, requests: 0 };
+    byUser[row.user_id].total_tokens +=
+      (row.prompt_tokens || 0) + (row.completion_tokens || 0) + (row.embedding_tokens || 0);
+    byUser[row.user_id].requests++;
+  }
+
+  res.json({
+    period: '24h',
+    rows: data || [],
+    by_user: Object.values(byUser).sort((a, b) => b.total_tokens - a.total_tokens),
+  });
+};
+
+module.exports = { getTodayUsage, getAdminUsage };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,6 +14,8 @@ const reviewRoutes   = require('./routes/review');
 const webhookRoutes  = require('./routes/webhooks');
 const teamRoutes     = require('./routes/teams');
 const fileChatRoutes = require('./routes/fileChat');
+const usageRoutes    = require('./routes/usage');
+const adminRoutes    = require('./routes/admin');
 const errorHandler   = require('./middleware/errorHandler');
 
 const app = express();
@@ -62,6 +64,8 @@ app.use('/api/review',   reviewRoutes);
 app.use('/api/webhooks', webhookRoutes);
 app.use('/api/teams',     teamRoutes);
 app.use('/api/file-chat', fileChatRoutes);
+app.use('/api/usage',     usageRoutes);
+app.use('/api/admin',     adminRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/backend/src/middleware/aiRateLimit.js
+++ b/backend/src/middleware/aiRateLimit.js
@@ -1,0 +1,92 @@
+/**
+ * AI endpoint rate limiting (US-042)
+ *
+ * Enforces:
+ *   - MAX_RPM  requests per minute per user  (default 30)
+ *   - MAX_RPH  requests per hour  per user   (default 500)
+ *   - MAX_DAILY_TOKENS_PER_USER tokens/day   (default 500 000)
+ *
+ * Request-count windows are tracked in-memory (single-instance).
+ * Token budget is persisted in Supabase api_usage and survives restarts.
+ */
+
+const { supabaseAdmin } = require('../db/supabase');
+
+const MAX_RPM    = parseInt(process.env.MAX_RPM                 || '30',     10);
+const MAX_RPH    = parseInt(process.env.MAX_RPH                 || '500',    10);
+const MAX_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
+
+// In-memory sliding-window counters keyed by `userId:windowId`
+const minuteCounters = new Map();
+const hourCounters   = new Map();
+
+// Prune expired entries every 5 minutes to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [k, v] of minuteCounters) if (now > v.expiry) minuteCounters.delete(k);
+  for (const [k, v] of hourCounters)   if (now > v.expiry) hourCounters.delete(k);
+}, 5 * 60 * 1000);
+
+async function dailyTokensUsed(userId) {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await supabaseAdmin
+    .from('api_usage')
+    .select('prompt_tokens, completion_tokens, embedding_tokens')
+    .eq('user_id', userId)
+    .gte('created_at', since);
+
+  if (error) return 0; // fail open
+  return (data || []).reduce(
+    (sum, r) => sum + (r.prompt_tokens || 0) + (r.completion_tokens || 0) + (r.embedding_tokens || 0),
+    0
+  );
+}
+
+const aiRateLimit = async (req, res, next) => {
+  const userId = req.user?.id;
+  if (!userId) return next();
+
+  const now         = Date.now();
+  const currentMin  = Math.floor(now / 60_000);
+  const currentHour = Math.floor(now / 3_600_000);
+
+  // ── Per-minute check ────────────────────────────────────────────────────────
+  const minKey    = `${userId}:${currentMin}`;
+  const minEntry  = minuteCounters.get(minKey) || { count: 0, expiry: (currentMin + 1) * 60_000 };
+  if (minEntry.count >= MAX_RPM) {
+    return res.status(429).json({
+      error: `Rate limit exceeded: max ${MAX_RPM} requests per minute.`,
+      retryAfterSeconds: Math.ceil((minEntry.expiry - now) / 1000),
+    });
+  }
+  minEntry.count++;
+  minuteCounters.set(minKey, minEntry);
+
+  // ── Per-hour check ──────────────────────────────────────────────────────────
+  const hourKey   = `${userId}:${currentHour}`;
+  const hourEntry = hourCounters.get(hourKey) || { count: 0, expiry: (currentHour + 1) * 3_600_000 };
+  if (hourEntry.count >= MAX_RPH) {
+    return res.status(429).json({
+      error: `Rate limit exceeded: max ${MAX_RPH} requests per hour.`,
+      retryAfterSeconds: Math.ceil((hourEntry.expiry - now) / 1000),
+    });
+  }
+  hourEntry.count++;
+  hourCounters.set(hourKey, hourEntry);
+
+  // ── Daily token budget ──────────────────────────────────────────────────────
+  const used = await dailyTokensUsed(userId);
+  if (used >= MAX_TOKENS) {
+    // Seconds until midnight UTC
+    const midnight = new Date();
+    midnight.setUTCHours(24, 0, 0, 0);
+    return res.status(429).json({
+      error: `Daily token budget exceeded (${used.toLocaleString()} / ${MAX_TOKENS.toLocaleString()} tokens used today).`,
+      retryAfterSeconds: Math.ceil((midnight.getTime() - now) / 1000),
+    });
+  }
+
+  next();
+};
+
+module.exports = { aiRateLimit };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,9 @@
+const express          = require('express');
+const router           = express.Router();
+const usageController  = require('../controllers/usageController');
+const { requireAuth }  = require('../middleware/auth');
+
+// Aggregate usage across all users — gated by ADMIN_USER_IDS env var
+router.get('/usage', requireAuth, usageController.getAdminUsage);
+
+module.exports = router;

--- a/backend/src/routes/review.js
+++ b/backend/src/routes/review.js
@@ -1,9 +1,10 @@
-const express        = require('express');
-const router         = express.Router();
+const express          = require('express');
+const router           = express.Router();
 const reviewController = require('../controllers/reviewController');
 const { requireAuth }  = require('../middleware/auth');
+const { aiRateLimit }  = require('../middleware/aiRateLimit');
 
 // POST /api/review/:repoId   body: { snippet, context?, mode? }
-router.post('/:repoId', requireAuth, reviewController.review);
+router.post('/:repoId', requireAuth, aiRateLimit, reviewController.review);
 
 module.exports = router;

--- a/backend/src/routes/search.js
+++ b/backend/src/routes/search.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const searchController = require('../controllers/searchController');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth }  = require('../middleware/auth');
+const { aiRateLimit }  = require('../middleware/aiRateLimit');
 
 // Natural language search over an indexed repo (RAG)
 // POST /api/search/:repoId   body: { query: string }
 // Streams back SSE events: { type: 'sources'|'chunk'|'done'|'error', ... }
-router.post('/:repoId', requireAuth, searchController.search);
+router.post('/:repoId', requireAuth, aiRateLimit, searchController.search);
 
 module.exports = router;

--- a/backend/src/routes/usage.js
+++ b/backend/src/routes/usage.js
@@ -1,0 +1,9 @@
+const express          = require('express');
+const router           = express.Router();
+const usageController  = require('../controllers/usageController');
+const { requireAuth }  = require('../middleware/auth');
+
+// Current user's daily token consumption
+router.get('/today', requireAuth, usageController.getTodayUsage);
+
+module.exports = router;

--- a/backend/src/sast/rules/cross_language.json
+++ b/backend/src/sast/rules/cross_language.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "cross_http_url",
+    "name": "Hardcoded HTTP URL",
+    "severity": "low",
+    "cwe": "CWE-319",
+    "description": "Plain HTTP transmits data in cleartext — use HTTPS instead.",
+    "fixHint": "Replace http:// with https:// to ensure encrypted transport.",
+    "pattern": "http://(?!localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0)"
+  },
+  {
+    "id": "cross_hardcoded_ipv4",
+    "name": "Hardcoded IPv4 Address",
+    "severity": "low",
+    "cwe": "CWE-547",
+    "description": "Hardcoded IP addresses make environments difficult to reconfigure and may expose internal network topology.",
+    "fixHint": "Move IP addresses to environment variables or configuration files.",
+    "pattern": "(?<![\\d.])(?!127\\.0\\.0\\.1|0\\.0\\.0\\.0|localhost)(\\b(?:10|172\\.(?:1[6-9]|2\\d|3[01])|192\\.168)\\.\\d{1,3}\\.\\d{1,3}\\b)"
+  }
+]

--- a/backend/src/sast/secret-rules.json
+++ b/backend/src/sast/secret-rules.json
@@ -1,6 +1,6 @@
 [
   { "id": "aws_access_key", "name": "AWS Access Key", "pattern": "(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}", "severity": "high" },
-  { "id": "aws_secret_key", "name": "AWS Secret Key", "pattern": "(?i)aws_secret_access_key.{0,20}['\"][0-9a-zA-Z/+]{40}['\"]", "severity": "high" },
+  { "id": "aws_secret_key", "name": "AWS Secret Key", "pattern": "aws_secret_access_key.{0,20}['\"][0-9a-zA-Z/+]{40}['\"]", "flags": "gi", "severity": "high" },
   { "id": "github_pat", "name": "GitHub PAT", "pattern": "gh[pous]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}", "severity": "high" },
   { "id": "github_oauth", "name": "GitHub OAuth", "pattern": "gho_[a-zA-Z0-9]{36}", "severity": "high" },
   { "id": "openai_api_key", "name": "OpenAI API Key", "pattern": "sk-[a-zA-Z0-9]{48}", "severity": "high" },

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -450,43 +450,43 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       }
     }
 
-    // 10. Extract Semantic Chunks and Embed Vectors (US-017)
+    // 10. Store full file contents (US-043) — independent of OpenAI key
+    await supabaseAdmin.from('file_contents').delete().eq('repo_id', repoId);
+    const FILE_SIZE_CAP = 1024 * 1024; // 1 MB
+    const fileContentRows = [];
+    for (const file of pendingFiles) {
+      if (!file.content) continue;
+      const raw = file.content;
+      const truncated = raw.length > FILE_SIZE_CAP;
+      fileContentRows.push({
+        repo_id:   repoId,
+        file_path: file.path,
+        content:   truncated ? raw.slice(0, FILE_SIZE_CAP) + '\n\n/* [CodeLens] File truncated at 1 MB */' : raw,
+        byte_size: Buffer.byteLength(raw, 'utf8'),
+      });
+    }
+    if (fileContentRows.length > 0) {
+      const fcBatches = chunkArray(fileContentRows, 200);
+      for (const batch of fcBatches) {
+        const { error: fcErr } = await supabaseAdmin
+          .from('file_contents')
+          .upsert(batch, { onConflict: 'repo_id,file_path', ignoreDuplicates: false });
+        if (fcErr) console.error(`[indexer] file_contents insert error: ${fcErr.message}`);
+      }
+    }
+    console.log(`[indexer] Stored ${fileContentRows.length} file contents.`);
+
+    // 11. Extract Semantic Chunks and Embed Vectors (US-017)
     if (!process.env.OPENAI_API_KEY) {
       console.log('[indexer] No OPENAI_API_KEY set — skipping embedding step.');
     } else {
       try {
         console.log(`[indexer] Starting semantic chunking and embedding for ${repoId}`);
 
-        // 10a. Wipe obsolete chunks and file contents (US-043)
+        // Wipe obsolete chunks before re-embedding
         await supabaseAdmin.from('code_chunks').delete().eq('repo_id', repoId);
-        await supabaseAdmin.from('file_contents').delete().eq('repo_id', repoId);
 
-        // 10b-i. Store full file contents (US-043) — 1 MB cap per file
-        const FILE_SIZE_CAP = 1024 * 1024; // 1 MB
-        const fileContentRows = [];
-        for (const file of pendingFiles) {
-          if (!file.content) continue;
-          const raw = file.content;
-          const truncated = raw.length > FILE_SIZE_CAP;
-          fileContentRows.push({
-            repo_id:   repoId,
-            file_path: file.path,
-            content:   truncated ? raw.slice(0, FILE_SIZE_CAP) + '\n\n/* [CodeLens] File truncated at 1 MB */' : raw,
-            byte_size: Buffer.byteLength(raw, 'utf8'),
-          });
-        }
-        if (fileContentRows.length > 0) {
-          const fcBatches = chunkArray(fileContentRows, 200);
-          for (const batch of fcBatches) {
-            const { error: fcErr } = await supabaseAdmin
-              .from('file_contents')
-              .upsert(batch, { onConflict: 'repo_id,file_path', ignoreDuplicates: false });
-            if (fcErr) console.error(`[indexer] file_contents insert error: ${fcErr.message}`);
-          }
-        }
-        console.log(`[indexer] Stored ${fileContentRows.length} file contents.`);
-
-        // 10b. Extract local raw chunks
+        // Extract local raw chunks
         const allExtractedChunks = [];
         for (const file of pendingFiles) {
           if (!file.content) continue;

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -2,6 +2,7 @@ const { parseFile } = require('../parsers/repositoryParser');
 const { extractChunksFromFile } = require('../parsers/chunkParser');
 const { scanFileForSecrets } = require('./secretScanner');
 const { scanFileForInsecurePatterns } = require('./sastEngine'); // US-046
+const { recordUsage } = require('./usageTracker'); // US-042
 const { OpenAI } = require('openai');
 const { supabaseAdmin } = require('../db/supabase');
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -93,6 +94,14 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
   try {
     console.log(`[indexer] Starting indexing for repoId: ${repoId} (source: ${source})`);
     console.time(`[indexer] Total pipeline (${repoId})`);
+
+    // Fetch repo owner for usage tracking (US-042)
+    const { data: repoMeta } = await supabaseAdmin
+      .from('repositories')
+      .select('user_id')
+      .eq('id', repoId)
+      .single();
+    const repoUserId = repoMeta?.user_id || null;
 
     // 1. fetch files & 2. filter
     console.time(`[indexer] Phase 1: File discovery (${repoId})`);
@@ -448,8 +457,34 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       try {
         console.log(`[indexer] Starting semantic chunking and embedding for ${repoId}`);
 
-        // 10a. Wipe obsolete chunks natively
+        // 10a. Wipe obsolete chunks and file contents (US-043)
         await supabaseAdmin.from('code_chunks').delete().eq('repo_id', repoId);
+        await supabaseAdmin.from('file_contents').delete().eq('repo_id', repoId);
+
+        // 10b-i. Store full file contents (US-043) — 1 MB cap per file
+        const FILE_SIZE_CAP = 1024 * 1024; // 1 MB
+        const fileContentRows = [];
+        for (const file of pendingFiles) {
+          if (!file.content) continue;
+          const raw = file.content;
+          const truncated = raw.length > FILE_SIZE_CAP;
+          fileContentRows.push({
+            repo_id:   repoId,
+            file_path: file.path,
+            content:   truncated ? raw.slice(0, FILE_SIZE_CAP) + '\n\n/* [CodeLens] File truncated at 1 MB */' : raw,
+            byte_size: Buffer.byteLength(raw, 'utf8'),
+          });
+        }
+        if (fileContentRows.length > 0) {
+          const fcBatches = chunkArray(fileContentRows, 200);
+          for (const batch of fcBatches) {
+            const { error: fcErr } = await supabaseAdmin
+              .from('file_contents')
+              .upsert(batch, { onConflict: 'repo_id,file_path', ignoreDuplicates: false });
+            if (fcErr) console.error(`[indexer] file_contents insert error: ${fcErr.message}`);
+          }
+        }
+        console.log(`[indexer] Stored ${fileContentRows.length} file contents.`);
 
         // 10b. Extract local raw chunks
         const allExtractedChunks = [];
@@ -476,6 +511,11 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
                   input: batch.map(c => c.content),
                   model: "text-embedding-3-small"
                 });
+
+                // Record embedding token usage (US-042)
+                if (repoUserId && res.usage?.total_tokens) {
+                  recordUsage({ userId: repoUserId, endpoint: 'indexer/embed', provider: 'openai', embeddingTokens: res.usage.total_tokens });
+                }
 
                 for (let i = 0; i < batch.length; i++) {
                   mappedPayloads.push({

--- a/backend/src/services/secretScanner.js
+++ b/backend/src/services/secretScanner.js
@@ -21,7 +21,7 @@ const loadRules = async () => {
     const data = await fs.readFile(rulesPath, 'utf8');
     compiledRules = JSON.parse(data).map(r => ({
       ...r,
-      regex: new RegExp(r.pattern, 'g') // pre-compile for speed
+      regex: new RegExp(r.pattern, r.flags || 'g'),
     }));
   }
   return compiledRules;

--- a/backend/src/services/usageTracker.js
+++ b/backend/src/services/usageTracker.js
@@ -1,0 +1,25 @@
+/**
+ * Usage tracker (US-042)
+ * Records per-request token consumption into api_usage.
+ * Non-fatal — a failure here never breaks the main request.
+ */
+
+const { supabaseAdmin } = require('../db/supabase');
+
+async function recordUsage({ userId, endpoint, provider, promptTokens = 0, completionTokens = 0, embeddingTokens = 0 }) {
+  if (!userId) return;
+  try {
+    await supabaseAdmin.from('api_usage').insert({
+      user_id:           userId,
+      endpoint,
+      provider,
+      prompt_tokens:     promptTokens,
+      completion_tokens: completionTokens,
+      embedding_tokens:  embeddingTokens,
+    });
+  } catch (err) {
+    console.warn('[usageTracker] Failed to record usage:', err.message);
+  }
+}
+
+module.exports = { recordUsage };

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,9 +4,29 @@ import { useAuth } from '../context/AuthContext';
 import { useRepo } from '../context/RepoContext';
 import OnboardingModal from './OnboardingModal';
 
+function useTokenUsage(session) {
+  const [usage, setUsage] = useState(null);
+
+  useEffect(() => {
+    if (!session?.access_token) return;
+    let cancelled = false;
+    const fetch_ = () =>
+      fetch('/api/usage/today', { headers: { Authorization: `Bearer ${session.access_token}` } })
+        .then(r => r.ok ? r.json() : null)
+        .then(d => { if (!cancelled && d) setUsage(d); })
+        .catch(() => {});
+    fetch_();
+    const id = setInterval(fetch_, 60_000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [session?.access_token]);
+
+  return usage;
+}
+
 export default function Layout() {
-  const { user, signOut } = useAuth();
+  const { user, session, signOut } = useAuth();
   const { repo, issueCount } = useRepo();
+  const tokenUsage = useTokenUsage(session);
   const location = useLocation();
   const { repoId } = useParams();
   const [searchParams] = useSearchParams();
@@ -146,6 +166,25 @@ export default function Layout() {
               </span>
             </div>
           </div>
+
+          {/* Token usage indicator (US-042) */}
+          {tokenUsage && (
+            <div className="hidden lg:block mb-2 px-2">
+              <div className="flex justify-between text-xs text-gray-500 mb-1">
+                <span>Today</span>
+                <span>{(tokenUsage.used / 1000).toFixed(1)}K / {(tokenUsage.limit / 1000).toFixed(0)}K tokens</span>
+              </div>
+              <div className="h-1 w-full rounded-full bg-gray-800 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    tokenUsage.used / tokenUsage.limit > 0.9 ? 'bg-red-500' :
+                    tokenUsage.used / tokenUsage.limit > 0.7 ? 'bg-yellow-500' : 'bg-indigo-500'
+                  }`}
+                  style={{ width: `${Math.min(100, (tokenUsage.used / tokenUsage.limit) * 100).toFixed(1)}%` }}
+                />
+              </div>
+            </div>
+          )}
 
           {/* Show introduction again */}
           <button

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -119,15 +119,11 @@ export default function Dashboard() {
   }, [fetchRepos]);
 
   useEffect(() => {
-    let timeoutId;
     const isWorking = repos.some(r => r.status === 'pending' || r.status === 'indexing');
-    if (isWorking) {
-      timeoutId = setTimeout(() => {
-        fetchRepos();
-      }, 5000);
-    }
-    return () => clearTimeout(timeoutId);
-  }, [repos, fetchRepos]);
+    if (!isWorking) return;
+    const id = setInterval(fetchRepos, 3000);
+    return () => clearInterval(id);
+  }, [repos.map(r => r.status).join(','), fetchRepos]);
 
   const handleRetry = async (e, repoId) => {
     e.preventDefault(); // prevent link navigation

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -635,13 +635,9 @@ export default function RepoView() {
   }, [fetchRepo]);
 
   useEffect(() => {
-    let timeoutId;
-    if (repo?.status === 'pending' || repo?.status === 'indexing') {
-      timeoutId = setTimeout(() => {
-        fetchRepo();
-      }, 5000);
-    }
-    return () => clearTimeout(timeoutId);
+    if (repo?.status !== 'pending' && repo?.status !== 'indexing') return;
+    const id = setInterval(fetchRepo, 3000);
+    return () => clearInterval(id);
   }, [repo?.status, fetchRepo]);
 
   useEffect(() => {

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -290,5 +290,62 @@ ALTER TABLE repositories
 ADD COLUMN IF NOT EXISTS sast_disabled_rules TEXT[] DEFAULT '{}';
 
 -- =============================================================================
+-- API USAGE (US-042)
+-- Records per-request token consumption for rate limiting and cost control.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS api_usage (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint          TEXT        NOT NULL,
+  provider          TEXT        NOT NULL,
+  prompt_tokens     INT         NOT NULL DEFAULT 0,
+  completion_tokens INT         NOT NULL DEFAULT 0,
+  embedding_tokens  INT         NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index supports the rolling 24-hour budget query (US-042)
+CREATE INDEX IF NOT EXISTS api_usage_user_created_idx ON api_usage (user_id, created_at);
+
+-- api_usage has no RLS — only readable via service_role key used by the backend.
+-- Users access their own data through the /api/usage/today endpoint.
+
+-- =============================================================================
+-- FILE CONTENTS (US-043)
+-- Stores the full raw source of each indexed file so the file browser
+-- shows complete content instead of a reconstruction from code_chunks.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS file_contents (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id    UUID        NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  file_path  TEXT        NOT NULL,
+  content    TEXT        NOT NULL,
+  byte_size  INT         NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (repo_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS file_contents_repo_id_idx ON file_contents (repo_id);
+
+ALTER TABLE file_contents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Access file contents via repo ownership"
+  ON file_contents FOR SELECT
+  USING (
+    repo_id IN (
+      SELECT id FROM repositories
+      WHERE  user_id = auth.uid()
+      OR id IN (
+        SELECT repo_id FROM team_repositories
+        WHERE team_id IN (
+          SELECT team_id FROM team_members WHERE user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+-- =============================================================================
 -- END OF SCHEMA
 -- =============================================================================

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- CodeLens Hub – Full Schema
+-- CodeLens Hub – Full Schema (idempotent — safe to re-run on any existing DB)
 -- Run this in the Supabase SQL Editor (Dashboard → SQL Editor → New query)
 -- PRE-REQUISITE: Enable the pgvector extension first via
 --   Dashboard → Database → Extensions → enable "vector"
@@ -10,14 +10,38 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS supabase_vault CASCADE;
 
 -- =============================================================================
--- FUNCTIONS (Vault wrappers for US-039)
+-- ENUMS
+-- Wrapped in DO blocks so re-runs skip already-existing types.
 -- =============================================================================
 
+DO $$ BEGIN
+  CREATE TYPE repo_status AS ENUM ('pending', 'indexing', 'ready', 'failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE repo_source AS ENUM ('github', 'upload');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE issue_type AS ENUM ('circular_dependency', 'god_file', 'dead_code', 'high_coupling');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Add enum values introduced in later sprints (safe to re-run)
+ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'insecure_pattern';
+ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'hardcoded_secret';
+
+-- =============================================================================
+-- FUNCTIONS — Vault wrappers (US-039)
+-- CREATE OR REPLACE is always safe to re-run.
+-- =============================================================================
+
+-- Each call generates a unique vault secret name so the name uniqueness
+-- constraint on vault.secrets is never violated across multiple users.
 CREATE OR REPLACE FUNCTION create_github_token_secret(token text)
 RETURNS uuid
 LANGUAGE sql SECURITY DEFINER
 AS $$
-  SELECT vault.create_secret(token, 'github_access_token');
+  SELECT vault.create_secret(token, 'github_token_' || gen_random_uuid());
 $$;
 
 CREATE OR REPLACE FUNCTION get_github_token_secret(secret_id uuid)
@@ -27,144 +51,13 @@ AS $$
   SELECT decrypted_secret FROM vault.decrypted_secrets WHERE id = secret_id;
 $$;
 
--- Secure decryption function
 REVOKE EXECUTE ON FUNCTION get_github_token_secret FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION get_github_token_secret TO service_role;
+GRANT  EXECUTE ON FUNCTION get_github_token_secret TO   service_role;
 
 -- =============================================================================
--- ENUMS
+-- FUNCTIONS — Vector search (US-041)
 -- =============================================================================
 
-CREATE TYPE repo_status AS ENUM ('pending', 'indexing', 'ready', 'failed');
-CREATE TYPE repo_source AS ENUM ('github', 'upload');
-CREATE TYPE issue_type  AS ENUM ('circular_dependency', 'god_file', 'dead_code', 'high_coupling');
-
--- =============================================================================
--- PROFILES
--- Extends Supabase auth.users with app-level data.
--- =============================================================================
-
-CREATE TABLE profiles (
-  id                     UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-  github_username        TEXT,
-  -- Replaced by Vault: plaintext migration was processed in US-039.
-  -- Original field was github_access_token TEXT.
-  github_token_secret_id UUID,
-  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY "Users can only access their own profile"
-  ON profiles
-  FOR ALL
-  USING (auth.uid() = id);
-
--- =============================================================================
--- REPOSITORIES
--- One row per repo connected or uploaded by a user.
--- =============================================================================
-
-CREATE TABLE repositories (
-  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  name             TEXT        NOT NULL,
-  full_name        TEXT,
-  source           repo_source NOT NULL DEFAULT 'github',
-  status           repo_status NOT NULL DEFAULT 'pending',
-  github_url       TEXT,
-  default_branch   TEXT        DEFAULT 'main',
-  file_count       INT         DEFAULT 0,
-  indexed_at       TIMESTAMPTZ,
-  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  webhook_secret    TEXT,
-  auto_sync_enabled BOOLEAN    NOT NULL DEFAULT false
-);
-
-ALTER TABLE repositories ENABLE ROW LEVEL SECURITY;
-
--- Replaced by the broader team-access policy below.
--- CREATE POLICY "Users can only access their own repos" ...
-
-CREATE POLICY "Users can access own repos or team-shared repos"
-  ON repositories FOR ALL
-  USING (
-    auth.uid() = user_id
-    OR id IN (
-      SELECT repo_id
-      FROM   team_repositories
-      WHERE  team_id IN (
-        SELECT team_id FROM team_members WHERE user_id = auth.uid()
-      )
-    )
-  );
-
--- =============================================================================
--- GRAPH NODES
--- One node per file in an indexed repository.
--- =============================================================================
-
-CREATE TABLE graph_nodes (
-  id               UUID  PRIMARY KEY DEFAULT gen_random_uuid(),
-  repo_id          UUID  NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-  file_path        TEXT  NOT NULL,
-  language         TEXT,
-  line_count       INT   DEFAULT 0,
-  outgoing_count   INT   DEFAULT 0,
-  incoming_count   INT   DEFAULT 0,
-  complexity_score FLOAT DEFAULT 0,
-  UNIQUE (repo_id, file_path)
-);
-
-CREATE INDEX ON graph_nodes (repo_id);
-
--- NOTE: graph_nodes does NOT need per-user RLS because access is mediated
--- through the repositories table (which is already RLS-protected).
--- All queries should join through repositories to enforce ownership.
-
--- =============================================================================
--- GRAPH EDGES
--- Directed dependency relationships between files.
--- =============================================================================
-
-CREATE TABLE graph_edges (
-  id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  repo_id   UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-  from_path TEXT NOT NULL,
-  to_path   TEXT NOT NULL,
-  UNIQUE (repo_id, from_path, to_path)
-);
-
-CREATE INDEX ON graph_edges (repo_id);
-CREATE INDEX ON graph_edges (from_path);
-CREATE INDEX ON graph_edges (to_path);
-
--- =============================================================================
--- CODE CHUNKS
--- Chunked file content with vector embeddings for RAG / semantic search.
--- =============================================================================
-
-CREATE TABLE code_chunks (
-  id         UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
-  repo_id    UUID    NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-  file_path  TEXT    NOT NULL,
-  content    TEXT    NOT NULL,
-  start_line INT,
-  end_line   INT,
-  embedding  vector(1536)
-);
-
--- HNSW index for approximate nearest-neighbour cosine similarity search. (US-041)
--- Migrated from IVFFlat: HNSW gives lower latency and higher recall on read-heavy RAG workloads.
--- m=16 controls graph connectivity; ef_construction=64 controls build-time quality.
-CREATE INDEX ON code_chunks USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
-
--- =============================================================================
--- FUNCTIONS (Vector search with tunable ef_search for US-041)
--- =============================================================================
-
--- match_code_chunks: Finds top-k code chunks for a given embedding.
--- Uses SET LOCAL to bump ef_search to 100 for higher recall per request.
 CREATE OR REPLACE FUNCTION match_code_chunks(
   p_repo_id   UUID,
   p_embedding vector(1536),
@@ -198,11 +91,126 @@ END;
 $$;
 
 -- =============================================================================
--- ANALYSIS ISSUES
--- Architectural issues detected during repo analysis.
+-- PROFILES
 -- =============================================================================
 
-CREATE TABLE analysis_issues (
+CREATE TABLE IF NOT EXISTS profiles (
+  id                     UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  github_username        TEXT,
+  github_token_secret_id UUID,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Column added in US-039 — safe to re-run
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS github_token_secret_id UUID;
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can only access their own profile" ON profiles;
+CREATE POLICY "Users can only access their own profile"
+  ON profiles FOR ALL
+  USING (auth.uid() = id);
+
+-- =============================================================================
+-- REPOSITORIES
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS repositories (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name              TEXT        NOT NULL,
+  full_name         TEXT,
+  source            repo_source NOT NULL DEFAULT 'github',
+  status            repo_status NOT NULL DEFAULT 'pending',
+  github_url        TEXT,
+  default_branch    TEXT        DEFAULT 'main',
+  file_count        INT         DEFAULT 0,
+  indexed_at        TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  webhook_secret    TEXT,
+  auto_sync_enabled BOOLEAN     NOT NULL DEFAULT false,
+  sast_disabled_rules TEXT[]    DEFAULT '{}'
+);
+
+-- Columns added in later sprints — safe to re-run
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS webhook_secret     TEXT;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS auto_sync_enabled  BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS sast_disabled_rules TEXT[] DEFAULT '{}';
+
+ALTER TABLE repositories ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can only access their own repos"              ON repositories;
+DROP POLICY IF EXISTS "Users can access own repos or team-shared repos"    ON repositories;
+CREATE POLICY "Users can access own repos or team-shared repos"
+  ON repositories FOR ALL
+  USING (
+    auth.uid() = user_id
+    OR id IN (
+      SELECT repo_id FROM team_repositories
+      WHERE  team_id IN (
+        SELECT team_id FROM team_members WHERE user_id = auth.uid()
+      )
+    )
+  );
+
+-- =============================================================================
+-- GRAPH NODES
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS graph_nodes (
+  id               UUID  PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id          UUID  NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  file_path        TEXT  NOT NULL,
+  language         TEXT,
+  line_count       INT   DEFAULT 0,
+  outgoing_count   INT   DEFAULT 0,
+  incoming_count   INT   DEFAULT 0,
+  complexity_score FLOAT DEFAULT 0,
+  UNIQUE (repo_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS graph_nodes_repo_id_idx ON graph_nodes (repo_id);
+
+-- =============================================================================
+-- GRAPH EDGES
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS graph_edges (
+  id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id   UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  from_path TEXT NOT NULL,
+  to_path   TEXT NOT NULL,
+  UNIQUE (repo_id, from_path, to_path)
+);
+
+CREATE INDEX IF NOT EXISTS graph_edges_repo_id_idx   ON graph_edges (repo_id);
+CREATE INDEX IF NOT EXISTS graph_edges_from_path_idx ON graph_edges (from_path);
+CREATE INDEX IF NOT EXISTS graph_edges_to_path_idx   ON graph_edges (to_path);
+
+-- =============================================================================
+-- CODE CHUNKS
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS code_chunks (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id    UUID        NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  file_path  TEXT        NOT NULL,
+  content    TEXT        NOT NULL,
+  start_line INT,
+  end_line   INT,
+  embedding  vector(1536)
+);
+
+-- HNSW index (US-041): lower latency and higher recall than IVFFlat.
+CREATE INDEX IF NOT EXISTS code_chunks_hnsw_idx
+  ON code_chunks USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- =============================================================================
+-- ANALYSIS ISSUES
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS analysis_issues (
   id          UUID       PRIMARY KEY DEFAULT gen_random_uuid(),
   repo_id     UUID       NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
   type        issue_type NOT NULL,
@@ -212,7 +220,25 @@ CREATE TABLE analysis_issues (
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX ON analysis_issues (repo_id);
+CREATE INDEX IF NOT EXISTS analysis_issues_repo_id_idx ON analysis_issues (repo_id);
+
+-- =============================================================================
+-- ISSUE SUPPRESSIONS (US-044 / US-046)
+-- Per-instance false-positive suppression — rule-agnostic so US-049 can reuse it.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS issue_suppressions (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id     UUID        NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  file_path   TEXT        NOT NULL,
+  rule_id     TEXT        NOT NULL,
+  line_number INT,
+  created_by  UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (repo_id, file_path, rule_id, line_number)
+);
+
+CREATE INDEX IF NOT EXISTS issue_suppressions_repo_id_idx ON issue_suppressions (repo_id);
 
 -- =============================================================================
 -- TEAMS / ORGANIZATIONS
@@ -249,19 +275,18 @@ CREATE TABLE IF NOT EXISTS team_repositories (
 CREATE INDEX IF NOT EXISTS team_repositories_team_id_idx ON team_repositories (team_id);
 CREATE INDEX IF NOT EXISTS team_repositories_repo_id_idx ON team_repositories (repo_id);
 
--- ── Row Level Security ────────────────────────────────────────────────────────
-
 ALTER TABLE teams             ENABLE ROW LEVEL SECURITY;
 ALTER TABLE team_members      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE team_repositories ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Team members can view their teams"           ON teams;
+DROP POLICY IF EXISTS "Team owners can manage their teams"          ON teams;
+DROP POLICY IF EXISTS "Team members can view members of their teams" ON team_members;
+DROP POLICY IF EXISTS "Team members can view team repositories"     ON team_repositories;
+
 CREATE POLICY "Team members can view their teams"
   ON teams FOR SELECT
-  USING (
-    id IN (
-      SELECT team_id FROM team_members WHERE user_id = auth.uid()
-    )
-  );
+  USING (id IN (SELECT team_id FROM team_members WHERE user_id = auth.uid()));
 
 CREATE POLICY "Team owners can manage their teams"
   ON teams FOR ALL
@@ -269,25 +294,11 @@ CREATE POLICY "Team owners can manage their teams"
 
 CREATE POLICY "Team members can view members of their teams"
   ON team_members FOR SELECT
-  USING (
-    team_id IN (
-      SELECT team_id FROM team_members WHERE user_id = auth.uid()
-    )
-  );
+  USING (team_id IN (SELECT team_id FROM team_members WHERE user_id = auth.uid()));
 
 CREATE POLICY "Team members can view team repositories"
   ON team_repositories FOR SELECT
-  USING (
-    team_id IN (
-      SELECT team_id FROM team_members WHERE user_id = auth.uid()
-    )
-  );
-
--- US-046: SAST Queries
-ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'insecure_pattern';
-
-ALTER TABLE repositories
-ADD COLUMN IF NOT EXISTS sast_disabled_rules TEXT[] DEFAULT '{}';
+  USING (team_id IN (SELECT team_id FROM team_members WHERE user_id = auth.uid()));
 
 -- =============================================================================
 -- API USAGE (US-042)
@@ -305,16 +316,13 @@ CREATE TABLE IF NOT EXISTS api_usage (
   created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Index supports the rolling 24-hour budget query (US-042)
+-- Supports the rolling 24-hour budget query
 CREATE INDEX IF NOT EXISTS api_usage_user_created_idx ON api_usage (user_id, created_at);
-
--- api_usage has no RLS — only readable via service_role key used by the backend.
--- Users access their own data through the /api/usage/today endpoint.
 
 -- =============================================================================
 -- FILE CONTENTS (US-043)
--- Stores the full raw source of each indexed file so the file browser
--- shows complete content instead of a reconstruction from code_chunks.
+-- Full raw source per indexed file — fixes the chunk-reconstruction gap in
+-- the file browser. 1 MB cap enforced by the indexing pipeline.
 -- =============================================================================
 
 CREATE TABLE IF NOT EXISTS file_contents (
@@ -331,6 +339,7 @@ CREATE INDEX IF NOT EXISTS file_contents_repo_id_idx ON file_contents (repo_id);
 
 ALTER TABLE file_contents ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Access file contents via repo ownership" ON file_contents;
 CREATE POLICY "Access file contents via repo ownership"
   ON file_contents FOR SELECT
   USING (

--- a/scripts/us039_migration.sql
+++ b/scripts/us039_migration.sql
@@ -10,11 +10,12 @@ CREATE EXTENSION IF NOT EXISTS supabase_vault CASCADE;
 ALTER TABLE profiles ADD COLUMN IF NOT EXISTS github_token_secret_id UUID;
 
 -- 3. Create wrapper RPCs in public so the backend can securely interact with Vault
+-- Each secret gets a unique name so vault's name uniqueness constraint is satisfied.
 CREATE OR REPLACE FUNCTION create_github_token_secret(token text)
 RETURNS uuid
 LANGUAGE sql SECURITY DEFINER
 AS $$
-  SELECT vault.create_secret(token, 'github_access_token');
+  SELECT vault.create_secret(token, 'github_token_' || gen_random_uuid());
 $$;
 
 CREATE OR REPLACE FUNCTION get_github_token_secret(secret_id uuid)
@@ -39,8 +40,8 @@ BEGIN
     FROM profiles 
     WHERE github_token_secret_id IS NULL AND github_access_token IS NOT NULL
   LOOP
-    -- Insert into vault
-    SELECT vault.create_secret(profile_row.github_access_token, 'github_access_token') INTO new_secret_id;
+    -- Insert into vault with a per-user unique name
+    SELECT vault.create_secret(profile_row.github_access_token, 'github_token_' || profile_row.id) INTO new_secret_id;
     
     -- Update profile
     UPDATE profiles 

--- a/scripts/us043_migration.sql
+++ b/scripts/us043_migration.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- US-043 Migration: Full file content storage
+-- Run once in the Supabase SQL Editor after applying schema.sql changes.
+-- Safe to re-run (idempotent).
+-- =============================================================================
+
+-- Mark all currently-ready repos as pending so the next visit triggers a
+-- re-index that populates the new file_contents table.
+-- Users will see a brief "Indexing" state — this is expected and documented.
+UPDATE repositories
+SET status = 'pending'
+WHERE status = 'ready';


### PR DESCRIPTION
US-042 — Rate limiting & AI cost controls

[backend/src/middleware/aiRateLimit.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/middleware/aiRateLimit.js): In-memory per-user window counters (30 req/min, 500 req/hour) + Supabase-persisted daily token budget check. Returns 429 { error, retryAfterSeconds } when any limit is exceeded.
[backend/src/services/usageTracker.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/services/usageTracker.js): Non-fatal helper that records each AI call's token usage into api_usage.
aiRateLimit middleware wired into both [search](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/routes/search.js) and [review](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/routes/review.js) routes.
[searchController.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/controllers/searchController.js) and [reviewController.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/controllers/reviewController.js): capture message_start/message_delta Anthropic events for prompt/completion tokens; capture res.usage.total_tokens from OpenAI embeddings.
[indexerService.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/services/indexerService.js): records embedding token usage per batch, keyed to the repo owner.
[usageController.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/controllers/usageController.js): GET /api/usage/today (user's daily total) + GET /api/admin/usage (aggregate, gated by ADMIN_USER_IDS).
Layout.jsx: "Today: X / Y tokens" progress bar in the sidebar footer, polling every 60s.
schema.sql + .env.example: api_usage table, new env vars.

US-043 — Full file content storage

schema.sql: file_contents table with UNIQUE(repo_id, file_path), 1 MB truncation note, RLS mirroring repositories access.
[indexerService.js](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/services/indexerService.js): after the code_chunks wipe, also wipes file_contents, then bulk-inserts each file's full content (1 MB cap with truncation marker) before embedding.
[repoController.js:getFileContent](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/backend/src/controllers/repoController.js): reads from file_contents first, falls back to chunk-concatenation for repos indexed before this change.
reindexRepo now also deletes file_contents rows on re-index.
[scripts/us043_migration.sql](vscode-webview://1k9q328digre4r5rtk6dio9rd3ib0tsisu2dn1mjgagaqii1tpld/scripts/us043_migration.sql): one-time migration that resets ready repos to pending to trigger re-indexing.