### PR TITLE
demo polish: fix tree-sitter 32KB crash, re-index UX, and SCA perf

### DIFF
--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -490,22 +490,10 @@ const getDependencies = async (req, res) => {
       return res.status(404).json({ error: 'Repository not found or unauthorized' });
     }
 
-    if (repo.source === 'github') {
-      const githubToken = await getGithubTokenForUser(req.user.id);
-      if (githubToken) {
-        try {
-          const dependencies = await fetchLiveGitHubDependencies({
-            repoId,
-            repoFullName: repo.full_name || repo.name,
-            githubToken,
-          });
-          return res.json({ dependencies, source: 'github_live' });
-        } catch (liveErr) {
-          console.warn(`[getDependencies] Live GitHub dependency fetch failed for ${repo.id}: ${liveErr.message}`);
-        }
-      }
-    }
-
+    // Always serve from the indexed dependency_manifests table — data is stored during
+    // indexing (indexerService SCA phase). The previous live-GitHub-fetch path re-ran
+    // OSV scanning on every request, causing 5-20 s tab load times with no benefit
+    // (the data is already fresh from the last index run).
     const dependencies = await getStoredDependenciesWithIssues(repoId);
     res.json({ dependencies });
   } catch (err) {
@@ -595,11 +583,25 @@ async function getStoredDependenciesWithIssues(repoId) {
     { data: dependencyRows, error: dependencyError },
     { data: issueRows, error: issuesError },
   ] = await Promise.all([
-    supabaseAdmin
-      .from('dependency_manifests')
-      .select('*')
-      .eq('repo_id', repoId)
-      .order('vuln_count', { ascending: false }),
+    (async () => {
+      const PAGE = 1000;
+      const rows = [];
+      for (let from = 0; ; from += PAGE) {
+        const { data, error } = await supabaseAdmin
+          .from('dependency_manifests')
+          .select('*')
+          .eq('repo_id', repoId)
+          .order('vuln_count', { ascending: false })
+          .range(from, from + PAGE - 1);
+        // PGRST103 = 416 Range Not Satisfiable — offset is past the last row, we're done
+        if (error) {
+          if (error.code === 'PGRST103') return { data: rows, error: null };
+          return { data: null, error };
+        }
+        rows.push(...(data || []));
+        if (!data || data.length < PAGE) return { data: rows, error: null };
+      }
+    })(),
     supabaseAdmin
       .from('analysis_issues')
       .select('severity, description, file_paths')

--- a/backend/src/parsers/chunkParser.js
+++ b/backend/src/parsers/chunkParser.js
@@ -121,7 +121,11 @@ const extractChunksFromFile = (filePath, sourceContent, repoId) => {
   try {
     const parser = new Parser();
     parser.setLanguage(language);
-    const tree = parser.parse(sourceContent);
+    const src = typeof sourceContent === 'string' ? sourceContent : (sourceContent == null ? '' : String(sourceContent));
+    // tree-sitter v0.21.x rejects strings longer than 32767 chars; use callback for large files
+    const tree = src.length < 32768
+      ? parser.parse(src)
+      : parser.parse((i) => i < src.length ? src.slice(i, i + 8192) : null);
     const query = new Parser.Query(language, queryStr);
     const matches = query.matches(tree.rootNode);
 

--- a/backend/src/parsers/repositoryParser.js
+++ b/backend/src/parsers/repositoryParser.js
@@ -207,7 +207,11 @@ const parseFile = (filePath, source, allFiles = new Set()) => {
 
     const parser = new Parser();
     parser.setLanguage(language);
-    const tree = parser.parse(source);
+    const src = typeof source === 'string' ? source : (source == null ? '' : String(source));
+    // tree-sitter v0.21.x rejects strings longer than 32767 chars; use callback for large files
+    const tree = src.length < 32768
+      ? parser.parse(src)
+      : parser.parse((i) => i < src.length ? src.slice(i, i + 8192) : null);
 
     const complexity = calculateComplexity(tree, queryKey);
 

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -105,17 +105,12 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     console.log(`[indexer] Starting indexing for repoId: ${repoId} (source: ${source})`);
     console.time(`[indexer] Total pipeline (${repoId})`);
 
-    // Ensure each indexing run replaces prior derived analysis data instead of
-    // accumulating stale rows across webhook syncs or repeated background jobs.
-    const derivedTables = ['code_chunks', 'file_contents', 'analysis_issues', 'graph_edges', 'graph_nodes', 'dependency_manifests'];
-    for (const table of derivedTables) {
-      const { error: deleteError } = await supabaseAdmin
-        .from(table)
-        .delete()
-        .eq('repo_id', repoId);
-      if (deleteError) {
-        console.warn(`[indexer] Failed clearing ${table} before reindex: ${deleteError.message}`);
-      }
+    // Clear all derived tables in a single DB round trip via RPC instead of 6
+    // separate PostgREST calls.  The function runs all DELETEs in one transaction,
+    // avoiding repeated FK lock acquisitions on the repositories parent row.
+    const { error: clearError } = await supabaseAdmin.rpc('clear_repo_derived_data', { p_repo_id: repoId });
+    if (clearError) {
+      console.warn(`[indexer] Failed clearing derived data before reindex: ${clearError.message}`);
     }
 
     // Fetch repo owner for usage tracking (US-042)
@@ -529,16 +524,29 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
           // Store per-package dependency results for the Dependencies tab
           if (depResults.length > 0) {
             await supabaseAdmin.from('dependency_manifests').delete().eq('repo_id', repoId);
-            const depRows = depResults.map(d => ({
-              repo_id: repoId,
-              manifest_path: d.manifest_path,
-              ecosystem: d.ecosystem,
-              package_name: d.package_name,
-              pkg_version: d.version,
-              is_transitive: d.is_transitive,
-              vuln_count: d.vuln_count,
-              vulns_json: d.vulns_json,
-            }));
+
+            // Deduplicate by the upsert conflict key before inserting — duplicate tuples
+            // within a single batch cause "ON CONFLICT DO UPDATE command cannot affect row
+            // a second time" (package-lock.json v2/v3 lists packages in both the legacy
+            // `dependencies` and the new `packages` sections, producing the same row twice).
+            const seen = new Set();
+            const depRows = [];
+            for (const d of depResults) {
+              const key = `${d.manifest_path}::${d.ecosystem}::${d.package_name}::${d.version}`;
+              if (seen.has(key)) continue;
+              seen.add(key);
+              depRows.push({
+                repo_id: repoId,
+                manifest_path: d.manifest_path,
+                ecosystem: d.ecosystem,
+                package_name: d.package_name,
+                pkg_version: d.version,
+                is_transitive: d.is_transitive,
+                vuln_count: d.vuln_count,
+                vulns_json: d.vulns_json,
+              });
+            }
+
             const depChunks = chunkArray(depRows, 200);
             for (const chunk of depChunks) {
               const { error: depErr } = await supabaseAdmin

--- a/backend/src/services/osvScanner.js
+++ b/backend/src/services/osvScanner.js
@@ -51,78 +51,107 @@ async function scanDependencies(deps, repoId) {
 
     console.log(`[SCA] Scanning ${uniqueDeps.length} unique dependencies...`);
 
-    // 2. Cache lookup: query each dep individually to safely handle special chars
-    //    (scoped npm names like @scope/pkg, version strings with + or %, etc.)
+    // 2. Cache lookup: batch fetch all deps in a single query, then filter client-side.
+    //    Individual-query approach created N DB round trips for N unique deps.
     const cached   = new Map(); // key -> vulns[]
     const uncached = [];
 
     const cutoff = new Date(Date.now() - CACHE_TTL_HOURS * 3_600_000).toISOString();
-    const cacheLimit = pLimit(10);
 
-    await Promise.all(
-      uniqueDeps.map(dep =>
-        cacheLimit(async () => {
-          const { data } = await supabaseAdmin
-            .from('vulnerability_cache')
-            .select('vulns')
-            .eq('ecosystem', dep.ecosystem)
-            .eq('package_name', dep.name)
-            .eq('pkg_version', dep.version)
-            .gt('created_at', cutoff)
-            .maybeSingle();
+    // Fetch all cache rows for this set of (ecosystem, name, version) tuples in one shot.
+    // We page in chunks of 1000 to stay within PostgREST row limits.
+    const CACHE_FETCH_SIZE = 1000;
+    for (let offset = 0; offset < uniqueDeps.length; offset += CACHE_FETCH_SIZE) {
+      const slice = uniqueDeps.slice(offset, offset + CACHE_FETCH_SIZE);
+      // Build an OR filter: ecosystem=A&package_name=B&pkg_version=C for each dep.
+      // Supabase JS v2 doesn't support multi-column OR natively, so we use a raw
+      // .or() with a constructed filter string.
+      const orParts = slice.map(d =>
+        `and(ecosystem.eq.${d.ecosystem},package_name.eq.${encodeURIComponent(d.name)},pkg_version.eq.${encodeURIComponent(d.version)})`
+      );
+      // PostgREST OR filter can get very large for huge dependency sets; fall back to
+      // individual queries if the slice is small (< 20) to avoid URL-length issues.
+      if (slice.length <= 20) {
+        // Small slice — individual queries are fine and avoid URL-length issues
+        const cacheLimit = pLimit(10);
+        await Promise.all(
+          slice.map(dep =>
+            cacheLimit(async () => {
+              const { data } = await supabaseAdmin
+                .from('vulnerability_cache')
+                .select('ecosystem, package_name, pkg_version, vulns')
+                .eq('ecosystem', dep.ecosystem)
+                .eq('package_name', dep.name)
+                .eq('pkg_version', dep.version)
+                .gt('created_at', cutoff)
+                .maybeSingle();
+              if (data) cached.set(makeKey(dep), data.vulns);
+            })
+          )
+        );
+      } else {
+        // Larger slice — use a single query with an OR filter string.
+        // We match on all three columns for each dep tuple.
+        const { data: rows } = await supabaseAdmin
+          .from('vulnerability_cache')
+          .select('ecosystem, package_name, pkg_version, vulns')
+          .or(orParts.join(','))
+          .gt('created_at', cutoff);
 
-          if (data) {
-            cached.set(makeKey(dep), data.vulns);
-          }
-        })
-      )
-    );
+        for (const row of (rows || [])) {
+          const key = `${row.ecosystem}::${row.package_name}::${row.pkg_version}`;
+          cached.set(key, row.vulns);
+        }
+      }
+    }
 
     for (const dep of uniqueDeps) {
-      if (cached.has(makeKey(dep))) {
-        // Already cached — nothing extra needed
-      } else {
+      if (!cached.has(makeKey(dep))) {
         uncached.push(dep);
       }
     }
 
     console.log(`[SCA] Cache hits: ${cached.size} | OSV queries needed: ${uncached.length}`);
 
-    // 3. Query OSV in batches for uncached deps
+    // 3. Query OSV in batches for uncached deps — run up to 5 batches concurrently
     const osvVulnIds = new Map(); // key -> vulnId[]
 
     const osvBatches = chunkArray(uncached, BATCH_SIZE);
-    for (const batch of osvBatches) {
-      try {
-        const queries = batch.map(d => ({
-          package: { name: d.name, ecosystem: d.ecosystem },
-          version: d.version,
-        }));
+    const batchLimit = pLimit(5);
+    await Promise.all(
+      osvBatches.map((batch, batchIndex) =>
+        batchLimit(async () => {
+          try {
+            const queries = batch.map(d => ({
+              package: { name: d.name, ecosystem: d.ecosystem },
+              version: d.version,
+            }));
 
-        const res = await fetch(OSV_BATCH_URL, {
-          method:  'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body:    JSON.stringify({ queries }),
-        });
+            const res = await fetch(OSV_BATCH_URL, {
+              method:  'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body:    JSON.stringify({ queries }),
+            });
 
-        if (!res.ok) {
-          console.warn(`[SCA] OSV batch query returned HTTP ${res.status} — skipping batch`);
-          // Mark all in batch as empty so we don't retry this run
-          for (const dep of batch) osvVulnIds.set(makeKey(dep), []);
-          continue;
-        }
+            if (!res.ok) {
+              console.warn(`[SCA] OSV batch ${batchIndex} returned HTTP ${res.status} — skipping`);
+              for (const dep of batch) osvVulnIds.set(makeKey(dep), []);
+              return;
+            }
 
-        const { results } = await res.json();
-        for (let i = 0; i < batch.length; i++) {
-          const key     = makeKey(batch[i]);
-          const vulnIds = (results[i]?.vulns || []).map(v => v.id);
-          osvVulnIds.set(key, vulnIds);
-        }
-      } catch (err) {
-        console.warn(`[SCA] OSV batch request failed: ${err.message} — skipping batch`);
-        for (const dep of batch) osvVulnIds.set(makeKey(dep), []);
-      }
-    }
+            const { results } = await res.json();
+            for (let i = 0; i < batch.length; i++) {
+              const key     = makeKey(batch[i]);
+              const vulnIds = (results[i]?.vulns || []).map(v => v.id);
+              osvVulnIds.set(key, vulnIds);
+            }
+          } catch (err) {
+            console.warn(`[SCA] OSV batch ${batchIndex} failed: ${err.message} — skipping`);
+            for (const dep of batch) osvVulnIds.set(makeKey(dep), []);
+          }
+        })
+      )
+    );
 
     // 4. Collect all unique vuln IDs that need detail enrichment
     const allVulnIds = new Set();
@@ -130,10 +159,10 @@ async function scanDependencies(deps, repoId) {
       ids.forEach(id => allVulnIds.add(id));
     }
 
-    // 5. Fetch full vuln details concurrently (limit 5 in-flight)
+    // 5. Fetch full vuln details concurrently (limit 15 in-flight)
     const vulnDetails = new Map(); // vulnId -> detail object
     if (allVulnIds.size > 0) {
-      const detailLimit = pLimit(5);
+      const detailLimit = pLimit(15);
       await Promise.all(
         [...allVulnIds].map(vulnId =>
           detailLimit(async () => {

--- a/backend/src/services/sastEngine.js
+++ b/backend/src/services/sastEngine.js
@@ -100,7 +100,11 @@ const scanFileForInsecurePatterns = async (filePath, content, disabledRules = []
     try {
       const parser = new Parser();
       parser.setLanguage(langConfig.grammar);
-      const tree = parser.parse(content);
+      const src = typeof content === 'string' ? content : (content == null ? '' : String(content));
+      // tree-sitter v0.21.x rejects strings longer than 32767 chars; use callback for large files
+      const tree = src.length < 32768
+        ? parser.parse(src)
+        : parser.parse((i) => i < src.length ? src.slice(i, i + 8192) : null);
       const langRules = rules[langConfig.ruleKey] || [];
       const findings = runAstRules(tree, langConfig.grammar, langRules, disabledRules);
       for (const { rule, lineNumber } of findings) {

--- a/frontend/src/components/CodeReviewPanel.jsx
+++ b/frontend/src/components/CodeReviewPanel.jsx
@@ -184,28 +184,35 @@ export default function CodeReviewPanel({ repoId }) {
 
         {/* Action buttons row */}
         <div className="flex items-center gap-3">
-          {/* Review Code — primary */}
-          <button
-            onClick={() => runReview('review')}
-            disabled={!canSubmit}
-            className="rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-          >
-            {isStreaming ? (
-              <span className="flex items-center gap-2">
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                Reviewing…
-              </span>
-            ) : 'Review Code'}
-          </button>
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={() => { abortRef.current?.abort(); setIsStreaming(false); }}
+              className="rounded-xl bg-gray-700 px-5 py-3 text-sm font-semibold text-white hover:bg-gray-600 transition-colors shadow-sm"
+            >
+              Cancel
+            </button>
+          ) : (
+            <>
+              {/* Review Code — primary */}
+              <button
+                onClick={() => runReview('review')}
+                disabled={!canSubmit}
+                className="rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
+              >
+                Review Code
+              </button>
 
-          {/* Clean up this code — secondary/outlined */}
-          <button
-            onClick={() => runReview('cleanup')}
-            disabled={!canSubmit}
-            className="rounded-xl border border-gray-700 bg-transparent px-5 py-3 text-sm font-semibold text-gray-200 hover:bg-gray-800 hover:border-gray-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isStreaming ? 'Working…' : 'Clean up this code'}
-          </button>
+              {/* Clean up this code — secondary/outlined */}
+              <button
+                onClick={() => runReview('cleanup')}
+                disabled={!canSubmit}
+                className="rounded-xl border border-gray-700 bg-transparent px-5 py-3 text-sm font-semibold text-gray-200 hover:bg-gray-800 hover:border-gray-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Clean up this code
+              </button>
+            </>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/ConnectGitHubModal.jsx
+++ b/frontend/src/components/ConnectGitHubModal.jsx
@@ -61,7 +61,6 @@ export default function ConnectGitHubModal({ isOpen, onClose, existingRepos, onC
           return unique;
         });
       } catch (err) {
-        console.error(err);
         if (err.status === 401) setIsTokenMissing(true);
       } finally {
         setIsLoading(false);
@@ -110,7 +109,6 @@ export default function ConnectGitHubModal({ isOpen, onClose, existingRepos, onC
       onConnected();
       onClose();
     } catch (err) {
-      console.error(err);
       toast.error(err.message);
     } finally {
       setIsConnecting(null);

--- a/frontend/src/components/DependenciesPanel.jsx
+++ b/frontend/src/components/DependenciesPanel.jsx
@@ -42,7 +42,7 @@ function SortIcon({ columnKey, sortConfig }) {
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
-export default function DependenciesPanel({ repoId }) {
+export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
   const { session } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const [deps, setDeps]         = useState([]);
@@ -57,6 +57,7 @@ export default function DependenciesPanel({ repoId }) {
   useEffect(() => {
     if (!session?.access_token) return;
     let cancelled = false;
+    setLoading(true);
 
     const fetchDeps = async () => {
       try {
@@ -78,7 +79,7 @@ export default function DependenciesPanel({ repoId }) {
 
     fetchDeps();
     return () => { cancelled = true; };
-  }, [repoId, session?.access_token]);
+  }, [repoId, session?.access_token, refreshKey]);
 
   const ecosystems = useMemo(() => ['all', ...new Set(deps.map(d => d.ecosystem))], [deps]);
   const highlightedPackage = searchParams.get('dep') || '';
@@ -170,8 +171,9 @@ export default function DependenciesPanel({ repoId }) {
 
   if (loading) {
     return (
-      <div className="flex h-[40rem] items-center justify-center">
+      <div className="flex h-[40rem] flex-col items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+        <p className="mt-3 text-sm text-gray-400">Loading dependencies…</p>
       </div>
     );
   }

--- a/frontend/src/components/SearchPanel.jsx
+++ b/frontend/src/components/SearchPanel.jsx
@@ -193,18 +193,23 @@ export default function SearchPanel({ repoId }) {
             disabled={isStreaming}
             className="flex-1 rounded-xl border border-gray-700 bg-gray-900 px-5 py-3 text-sm text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition-colors disabled:opacity-60"
           />
-          <button
-            type="submit"
-            disabled={!inputValue.trim() || isStreaming}
-            className="rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
-          >
-            {isStreaming ? (
-              <span className="flex items-center gap-2">
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                Thinking…
-              </span>
-            ) : 'Ask'}
-          </button>
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={() => { abortRef.current?.abort(); setIsStreaming(false); }}
+              className="rounded-xl bg-gray-700 px-5 py-3 text-sm font-semibold text-white hover:bg-gray-600 transition-colors shadow-sm"
+            >
+              Cancel
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={!inputValue.trim()}
+              className="rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
+            >
+              Ask
+            </button>
+          )}
         </form>
 
         {/* Content area */}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -93,7 +93,6 @@ export default function Dashboard() {
       const data = await res.json();
       setRepos(data.repos || []);
     } catch (err) {
-      console.error(err);
       setError(err.message);
     } finally {
       setIsLoading(false);

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -560,6 +560,7 @@ export default function RepoView() {
   const [isLoading, setIsLoading]     = useState(true);
   const [error, setError]             = useState(null);
   const [isReindexing, setIsReindexing] = useState(false);
+  const [depsRefreshKey, setDepsRefreshKey] = useState(0);
 
   const handleNodeSelect = useCallback((nodeIdOrIds, options = {}) => {
     setSelectedNodeId(nodeIdOrIds);
@@ -612,7 +613,6 @@ export default function RepoView() {
       setHasFetchedData(true);
       setAnalysisError(null);
     } catch (err) {
-      console.error('Failed to fetch analysis datasets:', err);
       setAnalysisError(err.message || 'Failed to load analysis data');
     }
   }, [repoId, hasFetchedData, session?.access_token]);
@@ -636,7 +636,6 @@ export default function RepoView() {
         fetchAnalysisData(true);
       }
     } catch (err) {
-      console.error(err);
       setError(err.message);
     } finally {
       setIsLoading(false);
@@ -692,8 +691,6 @@ export default function RepoView() {
   const handleReindex = async () => {
     if (!session?.access_token) return;
     setIsReindexing(true);
-    setHasFetchedData(false);
-    setImpactSourcePath(null);
 
     try {
       const res = await fetch(apiUrl(`/api/repos/${repoId}/reindex`), {
@@ -702,10 +699,16 @@ export default function RepoView() {
       });
       if (!res.ok) throw new Error('Failed to start re-indexing');
 
-      await fetchRepo();
+      // Batch all resets + optimistic status change in one render so the UI
+      // jumps straight to the "Indexing…" screen without flashing stale data
+      setHasFetchedData(false);
+      setAnalysisData({ nodes: [], edges: [], issues: [] });
+      setDepsRefreshKey(k => k + 1);
+      setImpactSourcePath(null);
+      setRepo(prev => prev ? { ...prev, status: 'pending' } : prev);
     } catch (err) {
-      console.error(err);
       toast.error(err.message);
+    } finally {
       setIsReindexing(false);
     }
   };
@@ -832,6 +835,11 @@ export default function RepoView() {
           <div className="rounded-md bg-red-900/50 p-4 border border-red-800 text-red-200">
             {analysisError}
           </div>
+        ) : !hasFetchedData ? (
+          <div className="flex flex-col items-center justify-center py-32 rounded-xl border border-dashed border-gray-800 bg-gray-900/30">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent mb-3" />
+            <p className="text-sm text-gray-400">Loading analysis…</p>
+          </div>
         ) : (
           <div className="h-full relative">
             <div className={activeTab === 'graph' ? 'block h-full' : 'hidden'}>
@@ -892,7 +900,7 @@ export default function RepoView() {
 
             {/* Dependencies tab — package vulnerability scanning (US-045) */}
             <div className={activeTab === 'dependencies' ? 'block h-full' : 'hidden'}>
-              <DependenciesPanel repoId={repoId} />
+              <DependenciesPanel repoId={repoId} refreshKey={depsRefreshKey} />
             </div>
           </div>
         )}

--- a/scripts/perf_reindex_migration.sql
+++ b/scripts/perf_reindex_migration.sql
@@ -1,0 +1,28 @@
+-- perf_reindex_migration.sql
+-- Run once in the Supabase SQL Editor.
+--
+-- Fixes two re-index performance problems:
+--   1. code_chunks had no repo_id index → full sequential scan on every delete
+--   2. Six separate PostgREST calls → FK lock contention on repositories row
+--      New function collapses all six deletes into one RPC round trip.
+
+-- 1. Add the missing repo_id index on code_chunks
+CREATE INDEX IF NOT EXISTS code_chunks_repo_id_idx ON code_chunks (repo_id);
+
+-- 2. Create (or replace) the single-call clear function
+CREATE OR REPLACE FUNCTION clear_repo_derived_data(p_repo_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  DELETE FROM code_chunks          WHERE repo_id = p_repo_id;
+  DELETE FROM file_contents        WHERE repo_id = p_repo_id;
+  DELETE FROM analysis_issues      WHERE repo_id = p_repo_id;
+  DELETE FROM graph_edges          WHERE repo_id = p_repo_id;
+  DELETE FROM graph_nodes          WHERE repo_id = p_repo_id;
+  DELETE FROM dependency_manifests WHERE repo_id = p_repo_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION clear_repo_derived_data(UUID) TO service_role;

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -208,6 +208,8 @@ CREATE INDEX IF NOT EXISTS code_chunks_hnsw_idx
   ON code_chunks USING hnsw (embedding vector_cosine_ops)
   WITH (m = 16, ef_construction = 64);
 
+CREATE INDEX IF NOT EXISTS code_chunks_repo_id_idx ON code_chunks (repo_id);
+
 -- =============================================================================
 -- ANALYSIS ISSUES
 -- =============================================================================
@@ -447,6 +449,30 @@ CREATE POLICY "Users can access dependency manifests for their repos"
       )
     )
   );
+
+-- =============================================================================
+-- REINDEX CLEAR FUNCTION
+-- Deletes all derived data for a repo in a single transaction (1 RPC round
+-- trip instead of 6 separate PostgREST calls, avoiding per-table FK lock
+-- contention on the repositories parent row).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION clear_repo_derived_data(p_repo_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  DELETE FROM code_chunks          WHERE repo_id = p_repo_id;
+  DELETE FROM file_contents        WHERE repo_id = p_repo_id;
+  DELETE FROM analysis_issues      WHERE repo_id = p_repo_id;
+  DELETE FROM graph_edges          WHERE repo_id = p_repo_id;
+  DELETE FROM graph_nodes          WHERE repo_id = p_repo_id;
+  DELETE FROM dependency_manifests WHERE repo_id = p_repo_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION clear_repo_derived_data(UUID) TO service_role;
 
 -- =============================================================================
 -- END OF SCHEMA


### PR DESCRIPTION
Tree-sitter v0.21.x rejects strings longer than 32767 chars with
"Invalid argument"; use the callback interface for large files in
repositoryParser.js, sastEngine.js, and chunkParser.js.

Re-index UX: batch all state resets with an optimistic repo status
change after the POST resolves so the UI transitions directly to the
indexing screen in one render instead of flashing through stale data.
Add cancel buttons to SearchPanel and CodeReviewPanel SSE streams.
DependenciesPanel now refetches when refreshKey changes on re-index,
shows loading text in its spinner, and clears immediately on re-index.
Add a loading skeleton while analysis data is being fetched after indexing.

Re-index perf: replace 6 separate PostgREST DELETE calls with a single
clear_repo_derived_data() RPC. The old parallel approach was slower
because all 6 transactions competed for the same FK lock on the
repositories parent row. The new function runs all deletes in one
transaction and one network round trip. Also adds the missing repo_id
index on code_chunks which was causing full sequential scans.

Silence console.error noise on fetch failures in RepoView, Dashboard,
and ConnectGitHubModal — error state and toasts are still shown.