### PR TITLE
feat: overhaul UI/UX, graph visuals, and metrics panel

### DIFF
--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -147,6 +147,30 @@ const listRepos = async (req, res) => {
     ...Array.from(sharedById.values()),
   ];
 
+  // Enrich repos with language distribution for dashboard cards
+  const repoIds = repos.map((r) => r.id);
+  if (repoIds.length > 0) {
+    const { data: langRows } = await supabaseAdmin
+      .from('graph_nodes')
+      .select('repo_id, language')
+      .in('repo_id', repoIds)
+      .limit(10000);
+
+    if (langRows && langRows.length > 0) {
+      const langByRepo = {};
+      langRows.forEach(({ repo_id, language }) => {
+        if (!langByRepo[repo_id]) langByRepo[repo_id] = {};
+        const lang = language || 'unknown';
+        langByRepo[repo_id][lang] = (langByRepo[repo_id][lang] || 0) + 1;
+      });
+      repos.forEach((r) => {
+        r.languages = Object.entries(langByRepo[r.id] || {})
+          .map(([language, count]) => ({ language, count }))
+          .sort((a, b) => b.count - a.count);
+      });
+    }
+  }
+
   res.json({ repos });
 };
 

--- a/frontend/src/components/CodeReviewPanel.jsx
+++ b/frontend/src/components/CodeReviewPanel.jsx
@@ -139,7 +139,7 @@ export default function CodeReviewPanel({ repoId }) {
   // ---------------------------------------------------------------------------
 
   return (
-    <div className="flex h-[40rem] flex-col gap-4">
+    <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] flex-col gap-4">
 
       {/* Input area */}
       <div className="flex flex-col gap-3">

--- a/frontend/src/components/DependenciesPanel.jsx
+++ b/frontend/src/components/DependenciesPanel.jsx
@@ -171,7 +171,7 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
 
   if (loading) {
     return (
-      <div className="flex h-[40rem] flex-col items-center justify-center">
+      <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] flex-col items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
         <p className="mt-3 text-sm text-gray-400">Loading dependencies…</p>
       </div>
@@ -193,7 +193,7 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
   if (deps.length === 0) {
     if (fallbackIssue) {
       return (
-        <div className="flex flex-col gap-5 h-[40rem]">
+        <div className="flex flex-col gap-5 h-[calc(100vh-12rem)] min-h-[30rem]">
           <div className="shrink-0 rounded-xl border border-indigo-500/30 bg-indigo-500/10 px-4 py-3 text-sm text-indigo-200">
             Dependency inventory data is unavailable for this repository, but the issue you clicked is preserved below so you can still inspect it.
           </div>
@@ -203,7 +203,7 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
     }
 
     return (
-      <div className="flex h-[40rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
+      <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
         <div className="flex items-center justify-center w-16 h-16 rounded-full bg-indigo-500/10 mb-4">
           <svg className="w-8 h-8 text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
@@ -220,19 +220,19 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
   // ── Main render ─────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex flex-col gap-5 h-[40rem]">
+    <div className="flex flex-col gap-5 h-[calc(100vh-12rem)] min-h-[30rem]">
 
       {/* Summary Cards */}
       <div className="grid grid-cols-3 gap-4 shrink-0">
-        <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-4">
+        <div className="rounded-xl border border-gray-700 bg-gray-900/50 p-4 border-l-4 border-l-indigo-500">
           <p className="text-xs uppercase tracking-widest text-gray-500 mb-1">Total Packages</p>
           <p className="text-2xl font-bold text-white">{deps.length}</p>
         </div>
-        <div className="rounded-xl border border-red-900/40 bg-red-900/10 p-4">
+        <div className="rounded-xl border border-red-900/40 bg-red-900/10 p-4 border-l-4 border-l-red-500">
           <p className="text-xs uppercase tracking-widest text-red-400/80 mb-1">Vulnerable</p>
           <p className="text-2xl font-bold text-red-400">{totalVulnerable}</p>
         </div>
-        <div className="rounded-xl border border-green-900/40 bg-green-900/10 p-4">
+        <div className="rounded-xl border border-green-900/40 bg-green-900/10 p-4 border-l-4 border-l-emerald-500">
           <p className="text-xs uppercase tracking-widest text-green-400/80 mb-1">Clean</p>
           <p className="text-2xl font-bold text-green-400">{totalClean}</p>
         </div>

--- a/frontend/src/components/DependencyGraph.jsx
+++ b/frontend/src/components/DependencyGraph.jsx
@@ -365,13 +365,42 @@ export default function DependencyGraph({
   const containerRef = useRef(null);
   const svgRef = useRef(null);
   const canvasRef = useRef(null);
+  const searchInputRef = useRef(null);
   const [toastVisible, setToastVisible] = useState(false);
   const [contextMenu, setContextMenu] = useState(null);
   const [clusteringEnabled, setClusteringEnabled] = useState(true);
   const [expandedClusters, setExpandedClusters] = useState(new Set());
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
 
+  // Hover tooltip state
+  const [hoveredNode, setHoveredNode] = useState(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+
+  // Search state
+  const [searchBarOpen, setSearchBarOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchCurrent, setSearchCurrent] = useState(0);
+
   const exportFilename = repoName ? repoName.replace(/[^\w.-]/g, '_') : 'graph';
+
+  // Ctrl+F / Cmd+F opens search
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchBarOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (searchBarOpen) {
+      const id = setTimeout(() => searchInputRef.current?.focus(), 50);
+      return () => clearTimeout(id);
+    }
+  }, [searchBarOpen]);
 
   const exportSVG = () => {
     const svgEl = svgRef.current;
@@ -538,6 +567,31 @@ export default function DependencyGraph({
     return simNodes.find((node) => node.graphId === primaryId) || null;
   }, [simNodes, selection.primaryId]);
 
+  // Search: filter simNodes by file path query
+  const searchMatchNodes = useMemo(() => {
+    if (!searchQuery.trim()) return [];
+    const q = searchQuery.toLowerCase();
+    return simNodes.filter((n) => !n.isCluster && n.file_path.toLowerCase().includes(q));
+  }, [simNodes, searchQuery]);
+
+  const searchCurrentNode = searchMatchNodes.length > 0
+    ? searchMatchNodes[searchCurrent % searchMatchNodes.length]
+    : null;
+
+  // When searching, override the selection to highlight matched nodes
+  const effectiveSelection = useMemo(() => {
+    if (searchMatchNodes.length > 0) {
+      const highlightedNodeIds = new Set(searchMatchNodes.map((n) => n.graphId));
+      return {
+        isActive: true,
+        primaryId: searchCurrentNode?.graphId || null,
+        highlightedNodeIds,
+        highlightedEdgeIds: new Set(),
+      };
+    }
+    return selection;
+  }, [selection, searchMatchNodes, searchCurrentNode]);
+
   const renderMode = graphNodes.length > 300 ? 'canvas' : 'svg';
 
   useEffect(() => {
@@ -565,9 +619,17 @@ export default function DependencyGraph({
     nodes: simNodes,
     edges: simEdges,
     renderMode,
-    selection,
+    selection: effectiveSelection,
     impactAnalysis,
-    focusNodeId: selection.primaryId,
+    focusNodeId: searchCurrentNode?.graphId || selection.primaryId,
+    onNodeHover: useCallback((node, event) => {
+      if (node && event) {
+        setHoveredNode(node);
+        setTooltipPos({ x: event.clientX + 14, y: event.clientY - 8 });
+      } else {
+        setHoveredNode(null);
+      }
+    }, []),
     onNodeClick: (node) => {
       // If it's a cluster node, toggle expansion instead of selecting
       if (node.isCluster && handleClusterClick(node)) return;
@@ -602,7 +664,7 @@ export default function DependencyGraph({
 
   if (graphNodes.length === 0) {
     return (
-      <div className="flex h-[40rem] items-center justify-center rounded-2xl border border-dashed border-gray-800 bg-gray-900/40 text-center">
+      <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] items-center justify-center rounded-2xl border border-dashed border-gray-800 bg-gray-900/40 text-center">
         <div>
           <p className="text-base text-gray-300">No graph data yet for this repository.</p>
           <p className="mt-2 text-sm text-gray-500">Re-index the repo once parsing finishes and the dependency map will appear here.</p>
@@ -612,8 +674,41 @@ export default function DependencyGraph({
   }
 
   return (
-    <div className="flex h-[40rem] gap-4">
+    <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] gap-4">
       <div className="relative flex-1 overflow-hidden rounded-2xl border border-gray-800 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_30%),linear-gradient(180deg,_rgba(2,6,23,0.95),_rgba(15,23,42,0.92))]">
+        {/* Search bar */}
+        {searchBarOpen && (
+          <div className="absolute left-4 top-16 z-20 flex items-center gap-2 rounded-xl border border-gray-600 bg-gray-900/96 px-3 py-2 shadow-2xl shadow-black/60 backdrop-blur-sm">
+            <svg className="h-3.5 w-3.5 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search files…"
+              value={searchQuery}
+              onChange={(e) => { setSearchQuery(e.target.value); setSearchCurrent(0); }}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') { setSearchQuery(''); setSearchBarOpen(false); setSearchCurrent(0); }
+                if (e.key === 'Enter') setSearchCurrent((c) => (c + 1) % Math.max(1, searchMatchNodes.length));
+              }}
+              className="w-52 bg-transparent text-sm text-white outline-none placeholder:text-gray-500"
+            />
+            {searchQuery && (
+              <span className={`shrink-0 text-xs font-medium ${searchMatchNodes.length === 0 ? 'text-red-400' : 'text-gray-400'}`}>
+                {searchMatchNodes.length === 0 ? 'No matches' : `${(searchCurrent % searchMatchNodes.length) + 1} / ${searchMatchNodes.length}`}
+              </span>
+            )}
+            {searchMatchNodes.length > 1 && (
+              <div className="flex gap-0.5">
+                <button onClick={() => setSearchCurrent((c) => (c - 1 + searchMatchNodes.length) % searchMatchNodes.length)} className="rounded px-1.5 py-0.5 text-gray-400 hover:bg-gray-700 hover:text-white transition text-xs">↑</button>
+                <button onClick={() => setSearchCurrent((c) => (c + 1) % searchMatchNodes.length)} className="rounded px-1.5 py-0.5 text-gray-400 hover:bg-gray-700 hover:text-white transition text-xs">↓</button>
+              </div>
+            )}
+            <button onClick={() => { setSearchQuery(''); setSearchBarOpen(false); setSearchCurrent(0); }} className="shrink-0 text-gray-500 hover:text-gray-200 transition ml-1 text-sm">✕</button>
+          </div>
+        )}
+
         <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-center justify-between gap-3">
           <GraphLegend />
           <div className="flex items-center gap-2">
@@ -672,6 +767,13 @@ export default function DependencyGraph({
               )}
             </div>
             <button
+              onClick={() => setSearchBarOpen((v) => !v)}
+              title="Search files (Ctrl+F)"
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${searchBarOpen ? 'border-indigo-500/50 bg-indigo-500/15 text-indigo-300' : 'border-gray-700 bg-gray-950/80 text-gray-400 hover:border-gray-500 hover:text-gray-200'}`}
+            >
+              Search
+            </button>
+            <button
               onClick={resetView}
               className="rounded-full border border-gray-700 bg-gray-950/80 px-4 py-2 text-sm font-medium text-gray-100 transition hover:border-gray-500 hover:bg-gray-900"
             >
@@ -691,6 +793,33 @@ export default function DependencyGraph({
         </div>
 
         <GraphToast message="File path copied to clipboard" visible={toastVisible} />
+
+        {/* Hover tooltip */}
+        {hoveredNode && !contextMenu && (
+          <div
+            className="pointer-events-none fixed z-50"
+            style={{ left: tooltipPos.x, top: tooltipPos.y }}
+          >
+            <div
+              className="rounded-xl border border-gray-700 bg-gray-900/96 p-3 shadow-2xl shadow-black/50 backdrop-blur-sm min-w-[200px]"
+              style={{ borderLeftColor: LANGUAGE_COLORS[hoveredNode.language] || LANGUAGE_COLORS.unknown, borderLeftWidth: 3 }}
+            >
+              <p className="mb-2 break-all font-mono text-xs font-medium text-gray-200">
+                {hoveredNode.file_path.split('/').pop()}
+              </p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                <span className="text-gray-500">Language</span>
+                <span className="text-gray-300">{formatLanguage(hoveredNode.language)}</span>
+                <span className="text-gray-500">Lines</span>
+                <span className="text-gray-300">{hoveredNode.line_count || 0}</span>
+                <span className="text-gray-500">Complexity</span>
+                <span className="text-gray-300">{Number(hoveredNode.complexity_score || 0).toFixed(1)}</span>
+                <span className="text-gray-500">Dependents</span>
+                <span className="text-gray-300">{hoveredNode.incoming_count || 0}</span>
+              </div>
+            </div>
+          </div>
+        )}
 
         {contextMenu && (
           <div

--- a/frontend/src/components/FileBrowser.jsx
+++ b/frontend/src/components/FileBrowser.jsx
@@ -224,14 +224,14 @@ export default function FileBrowser({ repoId, nodes }) {
 
   if (nodes.length === 0) {
     return (
-      <div className="flex h-[40rem] items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-900/30">
+      <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-900/30">
         <p className="text-sm text-gray-500">No files indexed yet. Re-index the repository first.</p>
       </div>
     );
   }
 
   return (
-    <div className="flex h-[40rem] gap-4">
+    <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] gap-4">
       {/* File tree — left panel */}
       <div className="w-64 shrink-0 overflow-y-auto rounded-xl border border-gray-800 bg-gray-900/30 py-2">
         {/* Root-level files */}

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { apiUrl } from '../lib/api';
 
-export default function IssuesPanel({ nodes, issues, onNodeSelect, repoId }) {
+export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDependencies, repoId }) {
   const { session } = useAuth();
   // Local state to hide suppressed issues instantly without full page reload
   const [localIssues, setLocalIssues] = useState(issues || []);
@@ -19,7 +19,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, repoId }) {
 
   if (!localIssues || localIssues.length === 0) {
     return (
-      <div className="flex h-[40rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
+      <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
         <div className="flex items-center justify-center w-16 h-16 rounded-full bg-green-500/10 mb-4">
           <svg className="w-8 h-8 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -50,6 +50,11 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, repoId }) {
   };
 
   const handleIssueClick = (issue) => {
+    if (issue.type === 'vulnerable_dependency') {
+      onOpenDependencies(issue);
+      return;
+    }
+
     const resolvedIds = issue.file_paths
       .map(path => nodeMap.get(path))
       .filter(Boolean);
@@ -144,7 +149,10 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, repoId }) {
   };
 
   return (
-    <div className="flex flex-col h-[40rem] overflow-auto bg-gray-950 rounded-xl space-y-8 p-1 relative">
+    <div className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] overflow-auto bg-gray-950 rounded-xl space-y-8 p-1 relative">
+      <div className="rounded-xl border border-gray-800 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
+        Issues is the triage view. It shows only actionable problems, including vulnerable dependencies. Click a dependency issue to jump into the `Dependencies` tab with that package pre-filtered.
+      </div>
       {GROUP_ORDER.map(({ type, label }) => {
         const groupIssues = localIssues.filter(i => i.type === type);
         if (groupIssues.length === 0) return null;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -61,14 +61,14 @@ export default function Layout() {
   ];
 
   return (
-    <div className="flex min-h-screen bg-gray-950">
+    <div className="flex min-h-screen bg-[#0c0d14]">
       {/* ── Sidebar ───────────────────────────────────────────────────── */}
       {/*
         Responsive behaviour:
         - < lg  (< 1024px): icon-only, w-14
         - >= lg (≥ 1024px): full width, w-64
       */}
-      <div className="flex w-14 lg:w-64 shrink-0 flex-col border-r border-gray-800 bg-gray-900">
+      <div className="flex w-14 lg:w-64 shrink-0 flex-col border-r border-gray-800/60 bg-[#111218]">
 
         {/* Brand */}
         <div className="flex h-16 items-center justify-center lg:justify-start px-0 lg:px-6 border-b border-gray-800">
@@ -116,10 +116,10 @@ export default function Layout() {
                     key={tab}
                     to={`/repo/${repoId}?tab=${tab}`}
                     title={label}
-                    className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors ${
+                    className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors border-l-2 ${
                       isActive
-                        ? 'bg-gray-800 text-white'
-                        : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                        ? 'bg-indigo-500/10 border-indigo-500 text-white'
+                        : 'text-gray-400 border-transparent hover:bg-gray-800/60 hover:text-white'
                     }`}
                   >
                     <Icon className="h-5 w-5 shrink-0" />
@@ -138,10 +138,10 @@ export default function Layout() {
             <Link
               to="/dashboard"
               title="Dashboard"
-              className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors ${
+              className={`flex items-center justify-center lg:justify-start gap-3 rounded-md px-2 lg:px-3 py-2 text-sm font-medium transition-colors border-l-2 ${
                 location.pathname.startsWith('/dashboard') || location.pathname === '/'
-                  ? 'bg-gray-800 text-white'
-                  : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                  ? 'bg-indigo-500/10 border-indigo-500 text-white'
+                  : 'text-gray-400 border-transparent hover:bg-gray-800/60 hover:text-white'
               }`}
             >
               <HomeIcon className="h-5 w-5 shrink-0" />

--- a/frontend/src/components/MetricsPanel.jsx
+++ b/frontend/src/components/MetricsPanel.jsx
@@ -1,5 +1,18 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import * as d3 from 'd3';
 import VirtualTable from './VirtualTable';
+
+const LANGUAGE_COLORS = {
+  javascript: '#60a5fa',
+  typescript: '#60a5fa',
+  python: '#facc15',
+  c_sharp: '#a78bfa',
+  go: '#06b6d4',
+  java: '#f97316',
+  rust: '#ea580c',
+  ruby: '#ef4444',
+  unknown: '#94a3b8',
+};
 
 function formatLanguage(str) {
   if (!str) return 'Unknown';
@@ -7,52 +20,197 @@ function formatLanguage(str) {
   if (str === 'typescript') return 'TypeScript';
   if (str === 'python') return 'Python';
   if (str === 'c_sharp') return 'C#';
+  if (str === 'go') return 'Go';
+  if (str === 'java') return 'Java';
+  if (str === 'rust') return 'Rust';
+  if (str === 'ruby') return 'Ruby';
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 export default function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnalyseImpact }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortConfig, setSortConfig] = useState({ key: 'complexity_score', direction: 'desc' });
+  const [showHistogram, setShowHistogram] = useState(false);
+  const [complexityFilter, setComplexityFilter] = useState(null);
 
-  const filteredNodes = nodes.filter(n => n.file_path.toLowerCase().includes(searchQuery.toLowerCase()));
-
-  const sortedNodes = [...filteredNodes].sort((a, b) => {
-    const valA = a[sortConfig.key] || 0;
-    const valB = b[sortConfig.key] || 0;
-
-    if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
-    if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
-    return 0;
-  });
-
-  const handleSort = (key) => {
-    setSortConfig(prev => {
-      if (prev.key === key) {
-        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
-      }
-      return { key, direction: 'desc' };
-    });
-  };
+  const ringRef = useRef(null);
+  const histRef = useRef(null);
 
   const calc90th = (arr, key) => {
     if (!arr || arr.length === 0) return 0;
-    const sortedVals = arr.map(n => n[key] || 0).sort((a, b) => a - b);
+    const sortedVals = arr.map((n) => n[key] || 0).sort((a, b) => a - b);
     const index = Math.floor(0.9 * sortedVals.length);
     return sortedVals[Math.min(index, sortedVals.length - 1)] || 0;
   };
 
-  const p90Complexity = calc90th(nodes, 'complexity_score');
-  const p90Incoming = calc90th(nodes, 'incoming_count');
+  const p90Complexity = useMemo(() => calc90th(nodes, 'complexity_score'), [nodes]);
+  const p90Incoming = useMemo(() => calc90th(nodes, 'incoming_count'), [nodes]);
 
-  let criticalCount = 0;
-  let atRiskCount = 0;
+  const { criticalCount, atRiskCount, totalLines, avgComplexity, langCounts } = useMemo(() => {
+    let critical = 0;
+    let atRisk = 0;
+    let lines = 0;
+    let complexitySum = 0;
+    const langs = {};
+    nodes.forEach((n) => {
+      const isHighComplex = n.complexity_score > p90Complexity;
+      const isHighIncoming = n.incoming_count > p90Incoming;
+      if (isHighComplex && isHighIncoming) critical++;
+      else if (isHighComplex || isHighIncoming) atRisk++;
+      lines += n.line_count || 0;
+      complexitySum += n.complexity_score || 0;
+      const lang = n.language || 'unknown';
+      langs[lang] = (langs[lang] || 0) + 1;
+    });
+    return {
+      criticalCount: critical,
+      atRiskCount: atRisk,
+      totalLines: lines,
+      avgComplexity: nodes.length > 0 ? complexitySum / nodes.length : 0,
+      langCounts: Object.entries(langs).sort((a, b) => b[1] - a[1]),
+    };
+  }, [nodes, p90Complexity, p90Incoming]);
 
-  nodes.forEach(n => {
-    const isHighComplex = n.complexity_score > p90Complexity;
-    const isHighIncoming = n.incoming_count > p90Incoming;
-    if (isHighComplex && isHighIncoming) criticalCount++;
-    else if (isHighComplex || isHighIncoming) atRiskCount++;
-  });
+  const healthScore = useMemo(() => {
+    if (nodes.length === 0) return 100;
+    return Math.max(0, Math.min(100, Math.round(100 - (criticalCount / nodes.length) * 100 * 2 - (atRiskCount / nodes.length) * 100 * 0.5)));
+  }, [nodes.length, criticalCount, atRiskCount]);
+
+  const scoreColor = healthScore >= 80 ? '#22c55e' : healthScore >= 50 ? '#f59e0b' : '#ef4444';
+
+  // Column maxes for spark bars
+  const maxLineCount = useMemo(() => Math.max(1, ...nodes.map((n) => n.line_count || 0)), [nodes]);
+  const maxOutgoing = useMemo(() => Math.max(1, ...nodes.map((n) => n.outgoing_count || 0)), [nodes]);
+  const maxIncoming = useMemo(() => Math.max(1, ...nodes.map((n) => n.incoming_count || 0)), [nodes]);
+  const maxComplexity = useMemo(() => Math.max(1, ...nodes.map((n) => n.complexity_score || 0)), [nodes]);
+
+  // D3 ring chart
+  useEffect(() => {
+    if (!ringRef.current || nodes.length === 0) return;
+    const svg = d3.select(ringRef.current);
+    svg.selectAll('*').remove();
+    const size = 72;
+    const r = size / 2;
+    const inner = r * 0.58;
+    const outer = r * 0.88;
+    const healthy = Math.max(0, nodes.length - criticalCount - atRiskCount);
+    const data = [
+      { v: criticalCount, c: '#ef4444' },
+      { v: atRiskCount, c: '#f59e0b' },
+      { v: healthy, c: '#22c55e' },
+    ].filter((d) => d.v > 0);
+    const safeData = data.length > 0 ? data : [{ v: 1, c: '#22c55e' }];
+    const pie = d3.pie().value((d) => d.v).sort(null).padAngle(0.04);
+    const arc = d3.arc().innerRadius(inner).outerRadius(outer).cornerRadius(2);
+    const g = svg.append('g').attr('transform', `translate(${r},${r})`);
+    g.selectAll('path')
+      .data(pie(safeData))
+      .join('path')
+      .attr('d', arc)
+      .attr('fill', (d) => d.data.c)
+      .attr('opacity', 0.9);
+    g.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'central')
+      .attr('fill', scoreColor)
+      .attr('font-size', '14px')
+      .attr('font-weight', '700')
+      .attr('font-family', 'ui-sans-serif, system-ui, sans-serif')
+      .text(`${healthScore}%`);
+  }, [nodes, criticalCount, atRiskCount, healthScore, scoreColor]);
+
+  // D3 histogram
+  useEffect(() => {
+    if (!showHistogram || !histRef.current || nodes.length === 0) return;
+    const container = histRef.current;
+    const width = container.clientWidth || 400;
+    const height = 110;
+    const margin = { top: 8, right: 12, bottom: 28, left: 28 };
+
+    const values = nodes.map((n) => n.complexity_score || 0);
+    const x = d3.scaleLinear()
+      .domain([0, d3.max(values) * 1.05])
+      .nice()
+      .range([margin.left, width - margin.right]);
+
+    const bins = d3.bin().value((d) => d).domain(x.domain()).thresholds(x.ticks(18))(values);
+
+    const y = d3.scaleLinear()
+      .domain([0, d3.max(bins, (d) => d.length)])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const svg = d3.select(container);
+    svg.selectAll('*').remove();
+    svg.attr('width', width).attr('height', height);
+
+    const barColor = (bin) => {
+      const mid = (bin.x0 + bin.x1) / 2;
+      if (mid > p90Complexity) return '#ef4444';
+      if (mid > p90Complexity * 0.65) return '#f59e0b';
+      return '#22c55e';
+    };
+
+    svg.selectAll('rect')
+      .data(bins)
+      .join('rect')
+      .attr('x', (d) => x(d.x0) + 1)
+      .attr('width', (d) => Math.max(0, x(d.x1) - x(d.x0) - 2))
+      .attr('y', (d) => y(d.length))
+      .attr('height', (d) => Math.max(0, y(0) - y(d.length)))
+      .attr('fill', barColor)
+      .attr('rx', 2)
+      .attr('opacity', (d) => complexityFilter?.x0 === d.x0 ? 1 : 0.7)
+      .attr('stroke', (d) => complexityFilter?.x0 === d.x0 ? '#6366f1' : 'transparent')
+      .attr('stroke-width', 2)
+      .attr('cursor', 'pointer')
+      .on('click', (_event, d) => {
+        setComplexityFilter((cf) => cf?.x0 === d.x0 ? null : d);
+      });
+
+    const xAxis = d3.axisBottom(x).ticks(5).tickSize(3);
+    svg.append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(xAxis)
+      .call((g) => g.select('.domain').attr('stroke', '#374151'))
+      .call((g) => g.selectAll('.tick line').attr('stroke', '#374151'))
+      .call((g) => g.selectAll('text').attr('fill', '#6b7280').attr('font-size', '10px'));
+
+    const yAxis = d3.axisLeft(y).ticks(3).tickSize(3);
+    svg.append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(yAxis)
+      .call((g) => g.select('.domain').attr('stroke', '#374151'))
+      .call((g) => g.selectAll('.tick line').attr('stroke', '#374151'))
+      .call((g) => g.selectAll('text').attr('fill', '#6b7280').attr('font-size', '10px'));
+  }, [showHistogram, nodes, p90Complexity, complexityFilter]);
+
+  const filteredNodes = useMemo(() => {
+    let result = nodes;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter((n) => n.file_path.toLowerCase().includes(q));
+    }
+    if (complexityFilter) {
+      result = result.filter((n) => (n.complexity_score || 0) >= complexityFilter.x0 && (n.complexity_score || 0) < complexityFilter.x1);
+    }
+    return result;
+  }, [nodes, searchQuery, complexityFilter]);
+
+  const sortedNodes = useMemo(() => [...filteredNodes].sort((a, b) => {
+    const valA = a[sortConfig.key] || 0;
+    const valB = b[sortConfig.key] || 0;
+    if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
+    if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
+    return 0;
+  }), [filteredNodes, sortConfig]);
+
+  const handleSort = (key) => {
+    setSortConfig((prev) => {
+      if (prev.key === key) return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      return { key, direction: 'desc' };
+    });
+  };
 
   const SortIcon = ({ columnKey }) => {
     if (sortConfig.key !== columnKey) return <span className="ml-2 text-gray-600 font-mono">↕</span>;
@@ -60,148 +218,240 @@ export default function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnal
   };
 
   return (
-    <div className="flex h-[40rem] gap-4">
-      <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-gray-800 bg-gray-900/30 relative">
-        <div className="flex items-center justify-between border-b border-gray-800 bg-gray-900/80 p-4">
-          <p className="text-sm text-gray-400 font-medium">
-            {nodes.length} files total &middot;
-            <span className="text-red-400 ml-2">{criticalCount} critical</span> &middot;
-            <span className="text-yellow-400 ml-2">{atRiskCount} at-risk</span>
-          </p>
-          <input
-            type="text"
-            placeholder="Search by file path..."
-            className="bg-gray-950 border border-gray-700 text-sm text-white rounded-md px-3 py-1.5 focus:outline-none focus:border-indigo-500 w-72 transition-colors placeholder:text-gray-600"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
+    <div
+      className="flex flex-col h-[calc(100vh-12rem)] min-h-[30rem] gap-3"
+      style={{ background: 'radial-gradient(ellipse at top, rgba(99,102,241,0.06), transparent 60%)' }}
+    >
+      {/* ── Summary cards row ── */}
+      <div className="flex gap-3 shrink-0">
+        {/* Health score ring */}
+        <div className="flex items-center gap-4 rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-3">
+          <svg ref={ringRef} width="72" height="72" />
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-0.5">Health Score</p>
+            <p className="text-xl font-bold" style={{ color: scoreColor }}>{healthScore}%</p>
+            <p className="text-xs text-gray-500 mt-0.5">
+              <span className="text-red-400">{criticalCount} critical</span>
+              {' · '}
+              <span className="text-yellow-400">{atRiskCount} at-risk</span>
+            </p>
+          </div>
         </div>
 
-        <div className="flex-1 overflow-hidden">
-          <VirtualTable
-            rows={sortedNodes}
-            rowHeight={44}
-            bufferRows={20}
-            containerHeight="100%"
-            tableClassName="w-full text-left text-sm whitespace-nowrap"
-            renderHeader={() => (
-              <thead className="bg-gray-800/95 backdrop-blur text-gray-300 z-10 shadow-sm border-b border-gray-700">
-                <tr>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('file_path')}>
-                    File Path <SortIcon columnKey="file_path" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('language')}>
-                    Language <SortIcon columnKey="language" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('line_count')}>
-                    Lines <SortIcon columnKey="line_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('outgoing_count')}>
-                    Imports (Outgoing) <SortIcon columnKey="outgoing_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('incoming_count')}>
-                    Dependents (Incoming) <SortIcon columnKey="incoming_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('complexity_score')}>
-                    Complexity Score <SortIcon columnKey="complexity_score" />
-                  </th>
-                </tr>
-              </thead>
-            )}
-            renderRow={(node) => {
-              const isHighComplex = node.complexity_score > p90Complexity;
-              const isHighIncoming = node.incoming_count > p90Incoming;
-              const isSelected = selectedNode && (selectedNode.id || selectedNode.file_path) === (node.id || node.file_path);
+        {/* Total LOC */}
+        <div className="flex flex-col justify-center rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-3 flex-1" style={{ borderTopColor: '#6366f1', borderTopWidth: 2 }}>
+          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-1">Total Lines</p>
+          <p className="text-xl font-bold text-white">{totalLines.toLocaleString()}</p>
+          <p className="text-xs text-gray-500 mt-0.5">{nodes.length} files</p>
+        </div>
 
-              let rowClass = 'hover:bg-gray-800/60 cursor-pointer transition-colors';
-              let textFade = 'text-gray-300';
-              let metaFade = 'text-gray-500';
+        {/* Avg complexity */}
+        <div className="flex flex-col justify-center rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-3 flex-1" style={{ borderTopColor: avgComplexity > p90Complexity ? '#ef4444' : avgComplexity > p90Complexity * 0.6 ? '#f59e0b' : '#22c55e', borderTopWidth: 2 }}>
+          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-1">Avg Complexity</p>
+          <p className="text-xl font-bold text-white">{avgComplexity.toFixed(1)}</p>
+          <p className="text-xs text-gray-500 mt-0.5">p90 threshold: {p90Complexity.toFixed(0)}</p>
+        </div>
 
-              if (isHighComplex && isHighIncoming) {
-                rowClass = 'bg-red-900/30 hover:bg-red-900/50 cursor-pointer transition-colors';
-                textFade = 'text-red-100 font-medium';
-                metaFade = 'text-red-300';
-              } else if (isHighComplex || isHighIncoming) {
-                rowClass = 'bg-yellow-900/20 hover:bg-yellow-900/40 cursor-pointer transition-colors';
-                textFade = 'text-yellow-100';
-                metaFade = 'text-yellow-300/80';
-              }
-
-              if (isSelected) {
-                rowClass = `${rowClass} ring-1 ring-inset ring-sky-400/70 bg-sky-500/10`;
-              }
-
-              return (
-                <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path, { openGraph: true })} className={rowClass} style={{ height: 44 }}>
-                  <td className={`px-6 py-3 font-mono text-xs ${textFade}`}>{node.file_path}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{formatLanguage(node.language)}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.line_count}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.outgoing_count}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.incoming_count}</td>
-                  <td className={`px-6 py-3 font-medium ${textFade}`}>{Number(node.complexity_score).toFixed(2)}</td>
-                </tr>
-              );
-            }}
-          />
-          {sortedNodes.length === 0 && (
-            <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
-              No files found matching &quot;{searchQuery}&quot;
-            </div>
-          )}
+        {/* Language distribution */}
+        <div className="flex flex-col justify-center rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-3 flex-1" style={{ borderTopColor: '#6366f1', borderTopWidth: 2 }}>
+          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-2">Languages</p>
+          <div className="flex flex-wrap gap-1.5">
+            {langCounts.slice(0, 5).map(([lang, count]) => (
+              <span
+                key={lang}
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium text-gray-300"
+                style={{ backgroundColor: (LANGUAGE_COLORS[lang] || LANGUAGE_COLORS.unknown) + '25', border: `1px solid ${(LANGUAGE_COLORS[lang] || LANGUAGE_COLORS.unknown)}50` }}
+              >
+                <span className="h-1.5 w-1.5 rounded-full shrink-0" style={{ backgroundColor: LANGUAGE_COLORS[lang] || LANGUAGE_COLORS.unknown }} />
+                {formatLanguage(lang)}
+                <span className="text-gray-500">{count}</span>
+              </span>
+            ))}
+          </div>
         </div>
       </div>
 
-      <aside
-        className={`w-72 shrink-0 rounded-2xl border border-gray-800 bg-gray-900/80 p-5 shadow-2xl shadow-black/20 transition-all duration-300 ${
-          selectedNode ? 'translate-x-0 opacity-100' : 'pointer-events-none translate-x-8 opacity-0 -mr-72'
-        }`}
-      >
-        {selectedNode && (
-          <div className="flex h-full flex-col">
-            <div className="mb-5">
-              <p className="text-xs uppercase tracking-[0.2em] text-gray-500">File Details</p>
-              <h3 className="mt-2 break-all font-mono text-sm text-gray-100">{selectedNode.file_path}</h3>
+      {/* ── Table + sidebar ── */}
+      <div className="flex flex-1 gap-4 min-h-0">
+        <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-gray-800 bg-gray-900/30 min-h-0">
+          {/* Table toolbar */}
+          <div className="flex items-center justify-between border-b border-gray-800 bg-gray-900/80 px-4 py-3 shrink-0 gap-3">
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => { setShowHistogram((v) => !v); if (showHistogram) setComplexityFilter(null); }}
+                className={`rounded-md border px-3 py-1.5 text-xs font-medium transition ${showHistogram ? 'border-indigo-500/40 bg-indigo-500/15 text-indigo-300' : 'border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-200'}`}
+              >
+                {showHistogram ? 'Hide chart' : 'Show distribution'}
+              </button>
+              {complexityFilter && (
+                <button
+                  onClick={() => setComplexityFilter(null)}
+                  className="flex items-center gap-1 rounded-md border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1.5 text-xs text-indigo-300 hover:bg-indigo-500/20 transition"
+                >
+                  Complexity {complexityFilter.x0.toFixed(0)}–{complexityFilter.x1.toFixed(0)} ✕
+                </button>
+              )}
             </div>
-
-            <div className="space-y-3 text-sm">
-              <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Language</p>
-                <p className="mt-1 text-gray-100">{formatLanguage(selectedNode.language)}</p>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Lines</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.line_count || 0}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Complexity</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{Number(selectedNode.complexity_score || 0).toFixed(2)}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Imports</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.outgoing_count || 0}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Dependents</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.incoming_count || 0}</p>
-                </div>
-              </div>
-            </div>
-
-            <button
-              onClick={() => onAnalyseImpact(selectedNode)}
-              className="mt-5 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-gray-950 transition hover:bg-amber-400"
-            >
-              Analyse impact
-            </button>
-
-            <p className="mt-auto pt-5 text-xs text-gray-500">
-              Select a row to inspect a file, then launch blast radius analysis from here.
-            </p>
+            <input
+              type="text"
+              placeholder="Search by file path…"
+              className="bg-gray-950 border border-gray-700 text-sm text-white rounded-md px-3 py-1.5 focus:outline-none focus:border-indigo-500 w-64 transition-colors placeholder:text-gray-600"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
           </div>
-        )}
-      </aside>
+
+          {/* Histogram */}
+          {showHistogram && (
+            <div className="shrink-0 border-b border-gray-800 bg-gray-950/40 px-4 pt-3 pb-2">
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500">Complexity distribution — click a bar to filter</p>
+                {complexityFilter && <span className="text-[10px] text-indigo-400">Filtered: {sortedNodes.length} files</span>}
+              </div>
+              <svg ref={histRef} className="w-full" />
+            </div>
+          )}
+
+          {/* Table */}
+          <div className="flex-1 overflow-hidden min-h-0">
+            <VirtualTable
+              rows={sortedNodes}
+              rowHeight={44}
+              bufferRows={20}
+              containerHeight="100%"
+              tableClassName="w-full text-left text-sm whitespace-nowrap"
+              renderHeader={() => (
+                <thead className="bg-gray-800/95 backdrop-blur text-gray-300 z-10 shadow-sm border-b border-gray-700">
+                  <tr>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('file_path')}>
+                      File Path <SortIcon columnKey="file_path" />
+                    </th>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('language')}>
+                      Language <SortIcon columnKey="language" />
+                    </th>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('line_count')}>
+                      Lines <SortIcon columnKey="line_count" />
+                    </th>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('outgoing_count')}>
+                      Imports <SortIcon columnKey="outgoing_count" />
+                    </th>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('incoming_count')}>
+                      Dependents <SortIcon columnKey="incoming_count" />
+                    </th>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('complexity_score')}>
+                      Complexity <SortIcon columnKey="complexity_score" />
+                    </th>
+                  </tr>
+                </thead>
+              )}
+              renderRow={(node) => {
+                const isHighComplex = node.complexity_score > p90Complexity;
+                const isHighIncoming = node.incoming_count > p90Incoming;
+                const isSelected = selectedNode && (selectedNode.id || selectedNode.file_path) === (node.id || node.file_path);
+
+                let rowClass = 'hover:bg-gray-800/60 cursor-pointer transition-colors';
+                let textFade = 'text-gray-300';
+                let metaFade = 'text-gray-500';
+
+                if (isHighComplex && isHighIncoming) {
+                  rowClass = 'bg-red-900/30 hover:bg-red-900/50 cursor-pointer transition-colors';
+                  textFade = 'text-red-100 font-medium';
+                  metaFade = 'text-red-300';
+                } else if (isHighComplex || isHighIncoming) {
+                  rowClass = 'bg-yellow-900/20 hover:bg-yellow-900/40 cursor-pointer transition-colors';
+                  textFade = 'text-yellow-100';
+                  metaFade = 'text-yellow-300/80';
+                }
+
+                if (isSelected) rowClass = `${rowClass} ring-1 ring-inset ring-sky-400/70 bg-sky-500/10`;
+
+                const complexityRatio = (node.complexity_score || 0) / maxComplexity;
+                const complexityBarColor = complexityRatio > 0.7 ? '#ef4444' : complexityRatio > 0.4 ? '#f59e0b' : '#22c55e';
+
+                return (
+                  <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path, { openGraph: true })} className={rowClass} style={{ height: 44 }}>
+                    <td className={`px-6 py-3 font-mono text-xs ${textFade}`}>{node.file_path}</td>
+                    <td className={`px-6 py-3 ${metaFade}`}>{formatLanguage(node.language)}</td>
+                    <td className="px-6 py-3 relative" style={{ minWidth: 80 }}>
+                      <span className={metaFade}>{node.line_count}</span>
+                      <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-sky-400" style={{ width: `${((node.line_count || 0) / maxLineCount) * 100}%` }} />
+                    </td>
+                    <td className="px-6 py-3 relative" style={{ minWidth: 70 }}>
+                      <span className={metaFade}>{node.outgoing_count}</span>
+                      <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-indigo-400" style={{ width: `${((node.outgoing_count || 0) / maxOutgoing) * 100}%` }} />
+                    </td>
+                    <td className="px-6 py-3 relative" style={{ minWidth: 80 }}>
+                      <span className={metaFade}>{node.incoming_count}</span>
+                      <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-violet-400" style={{ width: `${((node.incoming_count || 0) / maxIncoming) * 100}%` }} />
+                    </td>
+                    <td className="px-6 py-3 relative" style={{ minWidth: 90 }}>
+                      <span className={`font-medium ${textFade}`}>{Number(node.complexity_score).toFixed(2)}</span>
+                      <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-40" style={{ width: `${complexityRatio * 100}%`, backgroundColor: complexityBarColor }} />
+                    </td>
+                  </tr>
+                );
+              }}
+            />
+            {sortedNodes.length === 0 && (
+              <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+                {complexityFilter ? `No files in complexity range ${complexityFilter.x0.toFixed(0)}–${complexityFilter.x1.toFixed(0)}` : `No files matching "${searchQuery}"`}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Details sidebar */}
+        <aside
+          className={`w-72 shrink-0 rounded-2xl border border-gray-800 bg-gray-900/80 p-5 shadow-2xl shadow-black/20 transition-all duration-300 ${
+            selectedNode ? 'translate-x-0 opacity-100' : 'pointer-events-none translate-x-8 opacity-0 -mr-72'
+          }`}
+        >
+          {selectedNode && (
+            <div className="flex h-full flex-col">
+              <div className="mb-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-gray-500">File Details</p>
+                <h3 className="mt-2 break-all font-mono text-sm text-gray-100">{selectedNode.file_path}</h3>
+              </div>
+
+              <div className="space-y-3 text-sm">
+                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3" style={{ borderLeftColor: LANGUAGE_COLORS[selectedNode.language] || LANGUAGE_COLORS.unknown, borderLeftWidth: 3 }}>
+                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Language</p>
+                  <p className="mt-1 text-gray-100">{formatLanguage(selectedNode.language)}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Lines</p>
+                    <p className="mt-1 text-lg font-semibold text-white">{selectedNode.line_count || 0}</p>
+                  </div>
+                  <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Complexity</p>
+                    <p className="mt-1 text-lg font-semibold text-white">{Number(selectedNode.complexity_score || 0).toFixed(2)}</p>
+                  </div>
+                  <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Imports</p>
+                    <p className="mt-1 text-lg font-semibold text-white">{selectedNode.outgoing_count || 0}</p>
+                  </div>
+                  <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
+                    <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Dependents</p>
+                    <p className="mt-1 text-lg font-semibold text-white">{selectedNode.incoming_count || 0}</p>
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={() => onAnalyseImpact(selectedNode)}
+                className="mt-5 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-gray-950 transition hover:bg-amber-400"
+              >
+                Analyse impact
+              </button>
+
+              <p className="mt-auto pt-5 text-xs text-gray-500">
+                Select a row to inspect a file, then launch blast radius analysis from here.
+              </p>
+            </div>
+          )}
+        </aside>
+      </div>
     </div>
   );
 }
-

--- a/frontend/src/components/SearchPanel.jsx
+++ b/frontend/src/components/SearchPanel.jsx
@@ -163,7 +163,7 @@ export default function SearchPanel({ repoId }) {
   // ---------------------------------------------------------------------------
 
   return (
-    <div className="flex h-[40rem] gap-6">
+    <div className="flex h-[calc(100vh-12rem)] min-h-[30rem] gap-6">
 
       {/* Left: history sidebar (hidden when no history) */}
       {history.length > 0 && (

--- a/frontend/src/hooks/useGraphSimulation.js
+++ b/frontend/src/hooks/useGraphSimulation.js
@@ -50,6 +50,7 @@ export function useGraphSimulation({
   onNodeContextMenu,
   onNodeDoubleClick,
   onBackgroundClick,
+  onNodeHover,
 }) {
   const zoomBehaviorRef = useRef(null);
   const canvasTransformRef = useRef(d3.zoomIdentity);
@@ -113,7 +114,8 @@ export function useGraphSimulation({
       x: width / 2,
       y: height / 2,
     }));
-      const localLinks = edges.map((edge) => ({ ...edge }));
+    const localLinks = edges.map((edge) => ({ ...edge }));
+    const maxIncoming = Math.max(1, ...nodes.map((n) => n.incoming_count || 0));
 
     const pretickCount = nodes.length < 100 ? PRETICK_CLUSTERED : PRETICK_FULL;
 
@@ -210,6 +212,9 @@ export function useGraphSimulation({
       let lastClickAt = 0;
       let lastClickedNodeId = null;
 
+      let dashOffset = 0;
+      let animFrame = null;
+
       const draw = () => {
         context.save();
         context.clearRect(0, 0, width, height);
@@ -230,14 +235,24 @@ export function useGraphSimulation({
           const endY = target.y - ((target.radius + 8) * Math.sin(angle));
 
           const lineOpacity = getEdgeOpacity(link);
+          const isHighlightedEdge = highlightedEdgeIds.has(link.id) || isImpactActive;
           const edgeColor = isImpactActive ? `rgba(245, 158, 11, ${lineOpacity})` : `rgba(148, 163, 184, ${lineOpacity})`;
 
           context.strokeStyle = edgeColor;
-          context.lineWidth = isImpactActive ? 1.8 : highlightedEdgeIds.has(link.id) ? 1.8 : 1.2;
+          context.lineWidth = isImpactActive ? 1.8 : isHighlightedEdge ? 1.8 : 1.2;
+
+          if (isHighlightedEdge) {
+            context.setLineDash([6, 4]);
+            context.lineDashOffset = -dashOffset;
+          } else {
+            context.setLineDash([]);
+          }
+
           context.beginPath();
           context.moveTo(startX, startY);
           context.lineTo(endX, endY);
           context.stroke();
+          context.setLineDash([]);
 
           drawArrowhead(context, startX, startY, endX, endY, 7, edgeColor);
         });
@@ -246,7 +261,6 @@ export function useGraphSimulation({
           context.globalAlpha = getNodeOpacity(node.graphId);
 
           if (node.isCluster) {
-            // Cluster node: dashed border, semi-transparent fill, hexagonal feel
             context.fillStyle = node.fill;
             context.globalAlpha *= 0.35;
             context.beginPath();
@@ -254,31 +268,32 @@ export function useGraphSimulation({
             context.fill();
             context.globalAlpha = getNodeOpacity(node.graphId);
 
-            // Dashed ring
             context.setLineDash([4, 3]);
             context.strokeStyle = node.fill;
             context.lineWidth = 2;
             context.stroke();
             context.setLineDash([]);
 
-            // Inner count badge
             context.fillStyle = '#f8fafc';
             context.font = 'bold 11px ui-sans-serif, system-ui, sans-serif';
             context.textAlign = 'center';
             context.textBaseline = 'middle';
             context.fillText(String(node.childCount), node.x, node.y);
 
-            // Directory label below
             const dirLabel = node.file_path.split('/').pop() || node.file_path;
             context.fillStyle = 'rgba(248, 250, 252, 0.7)';
             context.font = '10px ui-sans-serif, system-ui, sans-serif';
             context.fillText(dirLabel, node.x, node.y + node.radius + 14);
           } else {
-            // Standard file node
-            context.fillStyle = getNodeFill(node);
+            const nodeFill = getNodeFill(node);
+            const glowIntensity = 8 + (12 * (node.incoming_count || 0) / maxIncoming);
+            context.shadowColor = nodeFill;
+            context.shadowBlur = glowIntensity;
+            context.fillStyle = nodeFill;
             context.beginPath();
             context.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
             context.fill();
+            context.shadowBlur = 0;
 
             context.strokeStyle = getNodeStroke(node);
             context.lineWidth = getNodeStrokeWidth(node);
@@ -288,6 +303,12 @@ export function useGraphSimulation({
 
         context.globalAlpha = 1;
         context.restore();
+      };
+
+      const animateDraw = () => {
+        dashOffset = (dashOffset + 0.4) % 20;
+        draw();
+        animFrame = requestAnimationFrame(animateDraw);
       };
 
       const zoomBehavior = d3.zoom()
@@ -313,7 +334,28 @@ export function useGraphSimulation({
         canvasSelection.call(zoomBehavior.transform, d3.zoomIdentity);
       }
 
-      draw();
+      if (isSelectionActive || isImpactActive) {
+        animateDraw();
+      } else {
+        draw();
+      }
+
+      // Hover tracking
+      let lastHoveredId = null;
+      canvasSelection.on('mousemove', (event) => {
+        const [x, y] = d3.pointer(event, canvas);
+        const graphPoint = canvasTransformRef.current.invert([x, y]);
+        const hitNode = getNodeAtPoint(localNodes, graphPoint);
+        const hitId = hitNode?.graphId || null;
+        if (hitId !== lastHoveredId) {
+          lastHoveredId = hitId;
+          onNodeHover?.(hitNode && !hitNode.isCluster ? hitNode : null, hitNode ? event : null);
+        }
+      });
+      canvasSelection.on('mouseleave', () => {
+        lastHoveredId = null;
+        onNodeHover?.(null, null);
+      });
 
       const handlePointer = (event) => {
         const [x, y] = d3.pointer(event, canvas);
@@ -353,15 +395,16 @@ export function useGraphSimulation({
 
       return () => {
         simulation.stop();
-        // Explicitly release d3-force graph copies for GC
+        if (animFrame) cancelAnimationFrame(animFrame);
         localNodes.length = 0;
         localLinks.length = 0;
-        // Clear canvas GPU texture memory
         const ctx = canvas.getContext('2d');
         if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
         canvasSelection.on('.zoom', null);
         canvasSelection.on('click', null);
         canvasSelection.on('contextmenu', null);
+        canvasSelection.on('mousemove', null);
+        canvasSelection.on('mouseleave', null);
       };
     }
 
@@ -382,13 +425,16 @@ export function useGraphSimulation({
       .attr('d', 'M0,-5L10,0L0,5')
       .attr('fill', '#94a3b8');
 
-    // Drop shadow filter for nodes to look premium
-    const filter = defs.append('filter')
-      .attr('id', 'node-shadow')
-      .attr('x', '-20%').attr('y', '-20%').attr('width', '140%').attr('height', '140%');
-    filter.append('feDropShadow')
-      .attr('dx', '0').attr('dy', '4').attr('stdDeviation', '4')
-      .attr('flood-color', 'rgba(0, 0, 0, 0.5)');
+    // Glow filter — blurs the node's own color to create a bloom effect
+    const glowFilter = defs.append('filter')
+      .attr('id', 'node-glow')
+      .attr('x', '-60%').attr('y', '-60%').attr('width', '220%').attr('height', '220%');
+    glowFilter.append('feGaussianBlur')
+      .attr('stdDeviation', '5')
+      .attr('result', 'coloredBlur');
+    const feMerge = glowFilter.append('feMerge');
+    feMerge.append('feMergeNode').attr('in', 'coloredBlur');
+    feMerge.append('feMergeNode').attr('in', 'SourceGraphic');
 
     const viewport = svg.append('g').attr('class', 'graph-viewport');
     const edgeLayer = viewport.append('g').attr('class', 'graph-edge-layer');
@@ -398,7 +444,11 @@ export function useGraphSimulation({
       .selectAll('path')
       .data(localLinks, (edge) => edge.id)
       .join('path')
-      .attr('class', (edge) => `graph-edge${!isImpactActive && isSelectionActive && !highlightedEdgeIds.has(edge.id) ? ' is-dimmed' : ''}`)
+      .attr('class', (edge) => {
+        const isDimmed = !isImpactActive && isSelectionActive && !highlightedEdgeIds.has(edge.id);
+        const isFlow = (isImpactActive || highlightedEdgeIds.has(edge.id)) && !isDimmed;
+        return `graph-edge${isDimmed ? ' is-dimmed' : ''}${isFlow ? ' graph-edge-flow' : ''}`;
+      })
       .attr('d', (edge) => {
         const dx = edge.target.x - edge.source.x;
         const dy = edge.target.y - edge.source.y;
@@ -443,7 +493,7 @@ export function useGraphSimulation({
       })
       .attr('stroke-width', (node) => (node.isCluster ? 2 : getNodeStrokeWidth(node)))
       .attr('stroke-dasharray', (node) => (node.isCluster ? '5,3' : 'none'))
-      .attr('filter', (node) => (node.isCluster ? 'none' : 'url(#node-shadow)'));
+      .attr('filter', (node) => (node.isCluster ? 'none' : 'url(#node-glow)'));
 
     // Child count badge for cluster nodes
     nodeGroups.filter((node) => node.isCluster)
@@ -501,6 +551,13 @@ export function useGraphSimulation({
       onNodeContextMenu?.(node, event);
     });
 
+    nodeSelection.on('mouseenter', (event, node) => {
+      if (!node.isCluster) onNodeHover?.(node, event);
+    });
+    nodeSelection.on('mouseleave', () => {
+      onNodeHover?.(null, null);
+    });
+
     svg.on('click', (event) => {
       if (event.target === svg.node()) {
         onBackgroundClick?.();
@@ -552,11 +609,11 @@ export function useGraphSimulation({
 
     return () => {
       simulation.stop();
-      // Explicitly release d3-force graph copies for GC
       localNodes.length = 0;
       localLinks.length = 0;
       svg.on('.zoom', null);
       svg.on('click', null);
+      onNodeHover?.(null, null);
     };
   }, [
     canvasRef,
@@ -570,6 +627,7 @@ export function useGraphSimulation({
     onNodeClick,
     onNodeContextMenu,
     onNodeDoubleClick,
+    onNodeHover,
     renderMode,
     selection,
     svgRef,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Warm body override ───────────────────────────────────────────────────── */
+html, body, #root {
+  background-color: #0c0d14;
+}
+
+/* ── Graph node/edge transitions ─────────────────────────────────────────── */
 .graph-node,
 .graph-edge {
   transition: opacity 180ms ease;
@@ -10,4 +16,40 @@
 .graph-node.is-dimmed,
 .graph-edge.is-dimmed {
   opacity: 0.15;
+}
+
+/* ── Edge flow animation (1D) ─────────────────────────────────────────────── */
+@keyframes dashFlow {
+  to { stroke-dashoffset: -20; }
+}
+
+.graph-edge-flow {
+  stroke-dasharray: 6, 4;
+  animation: dashFlow 1.8s linear infinite;
+}
+
+/* ── Tab panel transitions (3C) ──────────────────────────────────────────── */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.tab-panel-active {
+  animation: fadeInUp 180ms ease forwards;
+  position: relative;
+}
+
+.tab-panel-hidden {
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,42 @@ import UploadRepoModal from '../components/UploadRepoModal';
 import CreateTeamModal from '../components/CreateTeamModal';
 import { useToast } from '../components/Toast';
 
+const LANGUAGE_COLORS = {
+  javascript: '#60a5fa',
+  typescript: '#60a5fa',
+  python: '#facc15',
+  c_sharp: '#a78bfa',
+  go: '#06b6d4',
+  java: '#f97316',
+  rust: '#ea580c',
+  ruby: '#ef4444',
+  unknown: '#94a3b8',
+};
+
+function getHealthDot(repo) {
+  // Red: failed. Amber: has issues / pending. Green: ready + no obvious problems.
+  if (repo.status === 'failed') return { color: 'bg-red-500', label: 'Failed' };
+  if (repo.status === 'indexing' || repo.status === 'pending') return { color: 'bg-amber-400 animate-pulse', label: 'Indexing' };
+  return { color: 'bg-emerald-400', label: 'Healthy' };
+}
+
+function LanguageMiniBar({ languages }) {
+  if (!languages || languages.length === 0) return null;
+  const total = languages.reduce((s, l) => s + l.count, 0);
+  if (total === 0) return null;
+  return (
+    <div className="flex h-1 w-full overflow-hidden rounded-full mb-4" title="Language distribution">
+      {languages.map((l) => (
+        <div
+          key={l.language}
+          style={{ width: `${(l.count / total) * 100}%`, backgroundColor: LANGUAGE_COLORS[l.language] || LANGUAGE_COLORS.unknown }}
+          title={l.language}
+        />
+      ))}
+    </div>
+  );
+}
+
 function StatusBadge({ status }) {
   switch (status) {
     case 'ready':
@@ -21,61 +57,75 @@ function StatusBadge({ status }) {
 }
 
 function RepoCard({ repo, onRetry, onDelete, isRetrying }) {
+  const health = getHealthDot(repo);
+  const languages = repo.languages || [];
+
   return (
     <Link
       key={repo.id}
       to={`/repo/${repo.id}`}
-      className="group relative flex flex-col justify-between rounded-xl border border-gray-800 bg-gray-900 p-6 transition hover:border-gray-700 hover:bg-gray-800/80 hover:shadow-lg"
+      className="group relative flex flex-col justify-between rounded-xl border border-gray-700 bg-gray-900 overflow-hidden transition-all duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:shadow-xl hover:shadow-indigo-500/5"
     >
-      <div className="mb-4 flex items-start justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-100 group-hover:text-indigo-400 transition-colors">
-            {repo.name}
-          </h2>
-          <p className="text-sm text-gray-500 mt-1">
-            {repo.source === 'github' ? 'GitHub' : 'Upload'} • {repo.file_count || 0} files
-            {repo.shared && repo.team_name && (
-              <span className="ml-2 inline-flex items-center rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-400 ring-1 ring-inset ring-violet-500/20">
-                {repo.team_name}
+      {/* Gradient top border */}
+      <div className="h-0.5 w-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500" />
+
+      <div className="p-6">
+        {/* Language mini-bar */}
+        <LanguageMiniBar languages={languages} />
+
+        <div className="mb-4 flex items-start justify-between">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className={`h-2 w-2 shrink-0 rounded-full ${health.color}`} title={health.label} />
+              <h2 className="text-xl font-semibold text-gray-100 group-hover:text-indigo-400 transition-colors truncate">
+                {repo.name}
+              </h2>
+            </div>
+            <p className="text-sm text-gray-500 mt-1">
+              {repo.source === 'github' ? 'GitHub' : 'Upload'} • {repo.file_count || 0} files
+              {repo.shared && repo.team_name && (
+                <span className="ml-2 inline-flex items-center rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-400 ring-1 ring-inset ring-violet-500/20">
+                  {repo.team_name}
+                </span>
+              )}
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-1.5 ml-3 shrink-0">
+            <StatusBadge status={repo.status} />
+            {repo.auto_sync_enabled && (
+              <span className="inline-flex items-center rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs font-medium text-indigo-400 ring-1 ring-inset ring-indigo-500/20">
+                Auto-sync
               </span>
             )}
-          </p>
+          </div>
         </div>
-        <div className="flex flex-col items-end gap-1.5">
-          <StatusBadge status={repo.status} />
-          {repo.auto_sync_enabled && (
-            <span className="inline-flex items-center rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs font-medium text-indigo-400 ring-1 ring-inset ring-indigo-500/20">
-              Auto-sync
-            </span>
-          )}
-        </div>
-      </div>
 
-      <div className="flex items-center justify-between border-t border-gray-800/50 pt-4 mt-2">
-        <span className="text-xs text-gray-500">
-          {repo.indexed_at
-            ? `Indexed on ${new Date(repo.indexed_at).toLocaleDateString()}`
-            : `Added on ${new Date(repo.created_at).toLocaleDateString()}`}
-        </span>
+        <div className="flex items-center justify-between border-t border-gray-800/50 pt-4 mt-2">
+          <span className="text-xs text-gray-500">
+            {repo.indexed_at
+              ? `Indexed ${new Date(repo.indexed_at).toLocaleDateString()}`
+              : `Added ${new Date(repo.created_at).toLocaleDateString()}`}
+          </span>
 
-        <div className="flex gap-2">
-          {repo.status !== 'ready' && !repo.shared && (
-            <button
-              onClick={(e) => onRetry(e, repo.id)}
-              disabled={isRetrying}
-              className="rounded bg-red-900/40 px-3 py-1 text-xs font-semibold text-red-300 hover:bg-red-800/60 transition disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isRetrying ? 'Starting…' : 'Retry'}
-            </button>
-          )}
-          {!repo.shared && (
-            <button
-              onClick={(e) => onDelete(e, repo.id)}
-              className="rounded bg-gray-800/40 px-3 py-1 text-xs font-semibold text-gray-400 hover:bg-red-900/40 hover:text-red-300 transition"
-            >
-              Delete
-            </button>
-          )}
+          <div className="flex gap-2">
+            {repo.status !== 'ready' && !repo.shared && (
+              <button
+                onClick={(e) => onRetry(e, repo.id)}
+                disabled={isRetrying}
+                className="rounded bg-red-900/40 px-3 py-1 text-xs font-semibold text-red-300 hover:bg-red-800/60 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isRetrying ? 'Starting…' : 'Retry'}
+              </button>
+            )}
+            {!repo.shared && (
+              <button
+                onClick={(e) => onDelete(e, repo.id)}
+                className="rounded bg-gray-800/40 px-3 py-1 text-xs font-semibold text-gray-400 hover:bg-red-900/40 hover:text-red-300 transition"
+              >
+                Delete
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </Link>
@@ -192,14 +242,42 @@ export default function Dashboard() {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center p-8">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+      <div className="min-h-screen bg-[#0c0d14] p-8 text-white">
+        <div className="mb-8 flex items-center justify-between">
+          <div className="h-8 w-48 animate-pulse rounded-lg bg-gray-800" />
+          <div className="flex gap-3">
+            <div className="h-9 w-28 animate-pulse rounded-md bg-gray-800" />
+            <div className="h-9 w-36 animate-pulse rounded-md bg-gray-800" />
+            <div className="h-9 w-36 animate-pulse rounded-md bg-gray-700" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="rounded-xl border border-gray-800 bg-gray-900 overflow-hidden">
+              <div className="h-0.5 w-full bg-gradient-to-r from-gray-700 via-gray-600 to-gray-700 animate-pulse" />
+              <div className="p-6 space-y-4">
+                <div className="h-1.5 w-full rounded-full bg-gray-800 animate-pulse" />
+                <div className="flex justify-between">
+                  <div className="space-y-2">
+                    <div className="h-5 w-40 rounded bg-gray-700 animate-pulse" />
+                    <div className="h-3 w-28 rounded bg-gray-800 animate-pulse" />
+                  </div>
+                  <div className="h-6 w-16 rounded-full bg-gray-800 animate-pulse" />
+                </div>
+                <div className="border-t border-gray-800/50 pt-4 flex justify-between">
+                  <div className="h-3 w-32 rounded bg-gray-800 animate-pulse" />
+                  <div className="h-6 w-16 rounded bg-gray-800 animate-pulse" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 p-8 text-white">
+    <div className="min-h-screen bg-[#0c0d14] p-8 text-white">
       <div className="mb-8 flex items-center justify-between">
         <h1 className="text-3xl font-bold tracking-tight">Your Repositories</h1>
         <div className="flex gap-3">

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -10,6 +10,8 @@ import VirtualTable from '../components/VirtualTable';
 import FileChatPanel from '../components/FileChatPanel';
 import FileBrowser from '../components/FileBrowser';
 import DependenciesPanel from '../components/DependenciesPanel';
+import MetricsPanel from '../components/MetricsPanel';
+import IssuesPanel from '../components/IssuesPanel';
 import { useToast } from '../components/Toast';
 
 function formatLanguage(str) {
@@ -95,301 +97,6 @@ function buildImpactAnalysis(sourcePath, nodes, edges) {
 }
 
 // --- Child Panels ---
-function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnalyseImpact }) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortConfig, setSortConfig] = useState({ key: 'complexity_score', direction: 'desc' });
-
-  const filteredNodes = nodes.filter(n => n.file_path.toLowerCase().includes(searchQuery.toLowerCase()));
-
-  const sortedNodes = [...filteredNodes].sort((a, b) => {
-    const valA = a[sortConfig.key] || 0;
-    const valB = b[sortConfig.key] || 0;
-
-    if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
-    if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
-    return 0;
-  });
-
-  const handleSort = (key) => {
-    setSortConfig(prev => {
-      if (prev.key === key) {
-        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
-      }
-      return { key, direction: 'desc' };
-    });
-  };
-
-  const calc90th = (arr, key) => {
-    if (!arr || arr.length === 0) return 0;
-    const sortedVals = arr.map(n => n[key] || 0).sort((a, b) => a - b);
-    const index = Math.floor(0.9 * sortedVals.length);
-    return sortedVals[Math.min(index, sortedVals.length - 1)] || 0;
-  };
-
-  const p90Complexity = calc90th(nodes, 'complexity_score');
-  const p90Incoming   = calc90th(nodes, 'incoming_count');
-
-  let criticalCount = 0;
-  let atRiskCount   = 0;
-
-  nodes.forEach(n => {
-    const isHighComplex  = n.complexity_score > p90Complexity;
-    const isHighIncoming = n.incoming_count > p90Incoming;
-    if (isHighComplex && isHighIncoming) criticalCount++;
-    else if (isHighComplex || isHighIncoming) atRiskCount++;
-  });
-
-  const SortIcon = ({ columnKey }) => {
-    if (sortConfig.key !== columnKey) return <span className="ml-2 text-gray-600 font-mono">↕</span>;
-    return <span className="ml-2 text-indigo-400 font-mono">{sortConfig.direction === 'asc' ? '↑' : '↓'}</span>;
-  };
-
-  return (
-    <div className="flex h-[40rem] gap-4">
-      <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-gray-800 bg-gray-900/30 relative">
-        <div className="flex items-center justify-between border-b border-gray-800 bg-gray-900/80 p-4">
-          <p className="text-sm text-gray-400 font-medium">
-            {nodes.length} files total &middot;
-            <span className="text-red-400 ml-2">{criticalCount} critical</span> &middot;
-            <span className="text-yellow-400 ml-2">{atRiskCount} at-risk</span>
-          </p>
-          <input
-            type="text"
-            placeholder="Search by file path..."
-            className="bg-gray-950 border border-gray-700 text-sm text-white rounded-md px-3 py-1.5 focus:outline-none focus:border-indigo-500 w-72 transition-colors placeholder:text-gray-600"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </div>
-
-        <div className="flex-1 overflow-hidden">
-          <VirtualTable
-            rows={sortedNodes}
-            rowHeight={44}
-            bufferRows={20}
-            containerHeight="100%"
-            tableClassName="w-full text-left text-sm whitespace-nowrap"
-            renderHeader={() => (
-              <thead className="bg-gray-800/95 backdrop-blur text-gray-300 z-10 shadow-sm border-b border-gray-700">
-                <tr>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('file_path')}>
-                    File Path <SortIcon columnKey="file_path" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('language')}>
-                    Language <SortIcon columnKey="language" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('line_count')}>
-                    Lines <SortIcon columnKey="line_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('outgoing_count')}>
-                    Imports (Outgoing) <SortIcon columnKey="outgoing_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('incoming_count')}>
-                    Dependents (Incoming) <SortIcon columnKey="incoming_count" />
-                  </th>
-                  <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none group" onClick={() => handleSort('complexity_score')}>
-                    Complexity Score <SortIcon columnKey="complexity_score" />
-                  </th>
-                </tr>
-              </thead>
-            )}
-            renderRow={(node) => {
-              const isHighComplex  = node.complexity_score > p90Complexity;
-              const isHighIncoming = node.incoming_count > p90Incoming;
-              const isSelected     = selectedNode && (selectedNode.id || selectedNode.file_path) === (node.id || node.file_path);
-
-              let rowClass  = 'hover:bg-gray-800/60 cursor-pointer transition-colors';
-              let textFade  = 'text-gray-300';
-              let metaFade  = 'text-gray-500';
-
-              if (isHighComplex && isHighIncoming) {
-                rowClass = 'bg-red-900/30 hover:bg-red-900/50 cursor-pointer transition-colors';
-                textFade = 'text-red-100 font-medium';
-                metaFade = 'text-red-300';
-              } else if (isHighComplex || isHighIncoming) {
-                rowClass = 'bg-yellow-900/20 hover:bg-yellow-900/40 cursor-pointer transition-colors';
-                textFade = 'text-yellow-100';
-                metaFade = 'text-yellow-300/80';
-              }
-
-              if (isSelected) {
-                rowClass = `${rowClass} ring-1 ring-inset ring-sky-400/70 bg-sky-500/10`;
-              }
-
-              return (
-                <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path, { openGraph: true })} className={rowClass} style={{ height: 44 }}>
-                  <td className={`px-6 py-3 font-mono text-xs ${textFade}`}>{node.file_path}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{formatLanguage(node.language)}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.line_count}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.outgoing_count}</td>
-                  <td className={`px-6 py-3 ${metaFade}`}>{node.incoming_count}</td>
-                  <td className={`px-6 py-3 font-medium ${textFade}`}>
-                    {Number(node.complexity_score).toFixed(2)}
-                  </td>
-                </tr>
-              );
-            }}
-          />
-          {sortedNodes.length === 0 && (
-            <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
-              No files found matching &quot;{searchQuery}&quot;
-            </div>
-          )}
-        </div>
-      </div>
-
-      <aside
-        className={`w-72 shrink-0 rounded-2xl border border-gray-800 bg-gray-900/80 p-5 shadow-2xl shadow-black/20 transition-all duration-300 ${
-          selectedNode ? 'translate-x-0 opacity-100' : 'pointer-events-none translate-x-8 opacity-0 -mr-72'
-        }`}
-      >
-        {selectedNode && (
-          <div className="flex h-full flex-col">
-            <div className="mb-5">
-              <p className="text-xs uppercase tracking-[0.2em] text-gray-500">File Details</p>
-              <h3 className="mt-2 break-all font-mono text-sm text-gray-100">{selectedNode.file_path}</h3>
-            </div>
-
-            <div className="space-y-3 text-sm">
-              <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Language</p>
-                <p className="mt-1 text-gray-100">{formatLanguage(selectedNode.language)}</p>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Lines</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.line_count || 0}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Complexity</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{Number(selectedNode.complexity_score || 0).toFixed(2)}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Imports</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.outgoing_count || 0}</p>
-                </div>
-                <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-gray-500">Dependents</p>
-                  <p className="mt-1 text-lg font-semibold text-white">{selectedNode.incoming_count || 0}</p>
-                </div>
-              </div>
-            </div>
-
-            <button
-              onClick={() => onAnalyseImpact(selectedNode)}
-              className="mt-5 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-gray-950 transition hover:bg-amber-400"
-            >
-              Analyse impact
-            </button>
-
-            <p className="mt-auto pt-5 text-xs text-gray-500">
-              Select a row to inspect a file, then launch blast radius analysis from here.
-            </p>
-          </div>
-        )}
-      </aside>
-    </div>
-  );
-}
-
-function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDependencies }) {
-  const nodeMap = useMemo(
-    () => new Map(nodes.map(n => [n.file_path, n.id || n.file_path])),
-    [nodes]
-  );
-
-  if (!issues || issues.length === 0) {
-    return (
-      <div className="flex h-[40rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
-        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-green-500/10 mb-4">
-          <svg className="w-8 h-8 text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
-        </div>
-        <h3 className="text-lg font-medium text-gray-200">No issues detected — your codebase looks healthy 🎉</h3>
-      </div>
-    );
-  }
-
-  const GROUP_ORDER = [
-    { type: 'vulnerable_dependency', label: 'Vulnerable Dependencies', icon: '📦' },
-    { type: 'hardcoded_secret',      label: 'Hardcoded Secrets',        icon: '🔒' },
-    { type: 'insecure_pattern',      label: 'Insecure Code Patterns',   icon: '🛡️' },
-    { type: 'circular_dependency',   label: 'Circular Dependencies',    icon: null },
-    { type: 'god_file',              label: 'God Files',                icon: null },
-    { type: 'high_coupling',         label: 'High Coupling',            icon: null },
-    { type: 'dead_code',             label: 'Dead Code',                icon: null },
-  ];
-
-  const getBadgeStyles = (severity) => {
-    switch (severity?.toLowerCase()) {
-      case 'high':   return 'bg-red-500/20 text-red-400 ring-1 ring-inset ring-red-500/30';
-      case 'medium': return 'bg-orange-500/20 text-orange-400 ring-1 ring-inset ring-orange-500/30';
-      case 'low':    return 'bg-yellow-500/20 text-yellow-400 ring-1 ring-inset ring-yellow-500/30';
-      default:       return 'bg-gray-500/20 text-gray-400 ring-1 ring-inset ring-gray-500/30';
-    }
-  };
-
-  const handleIssueClick = (issue) => {
-    if (issue.type === 'vulnerable_dependency') {
-      onOpenDependencies(issue);
-      return;
-    }
-
-    const resolvedIds = issue.file_paths
-      .map(p => nodeMap.get(p))
-      .filter(Boolean);
-
-    if (resolvedIds.length > 0) {
-      onNodeSelect(resolvedIds);
-    }
-  };
-
-  return (
-    <div className="flex flex-col h-[40rem] overflow-auto bg-gray-950 rounded-xl space-y-8 p-1 relative">
-      <div className="rounded-xl border border-gray-800 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
-        Issues is the triage view. It shows only actionable problems, including vulnerable dependencies. Click a dependency issue to jump into the `Dependencies` tab with that package pre-filtered.
-      </div>
-      {GROUP_ORDER.map(({ type, label, icon }) => {
-        const groupIssues = issues.filter(i => i.type === type);
-        if (groupIssues.length === 0) return null;
-
-        return (
-          <div key={type} className="mb-8 last:mb-0">
-            <h2 className="text-lg font-semibold text-gray-200 border-b border-gray-800 pb-2 mb-4 sticky top-0 bg-gray-950 z-10 flex items-center">
-              {icon && <span className="mr-2">{icon}</span>}
-              {label} <span className="text-gray-500 text-sm ml-2 font-normal">({groupIssues.length})</span>
-            </h2>
-            <div className="grid gap-4">
-              {groupIssues.map((issue, idx) => (
-                <div
-                  key={issue.id || `${type}-${idx}`}
-                  onClick={() => handleIssueClick(issue)}
-                  className="flex flex-col bg-gray-900/50 hover:bg-gray-800/80 border border-gray-800 hover:border-gray-700 rounded-lg p-5 cursor-pointer transition-all duration-200"
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium uppercase tracking-wider ${getBadgeStyles(issue.severity)}`}>
-                      {issue.severity || 'UNKNOWN'}
-                    </span>
-                  </div>
-                  <p className="text-gray-300 text-sm mb-4 leading-relaxed">
-                    {issue.description || 'No description available.'}
-                  </p>
-                  <div className="mt-auto bg-gray-950/50 rounded-md p-3 border border-gray-800 break-words">
-                    <span className="font-mono text-xs text-gray-400 leading-loose">
-                      {issue.file_paths.join(' → ')}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 
 function SettingsPanel({ repo, session, onRepoUpdated }) {
   const [autoSync, setAutoSync] = useState(repo?.auto_sync_enabled ?? false);
@@ -451,7 +158,7 @@ function SettingsPanel({ repo, session, onRepoUpdated }) {
 
   if (!isGitHub) {
     return (
-      <div className="flex h-[40rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
+      <div className="h-[calc(100vh-12rem)] min-h-[30rem] flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30">
         <p className="text-sm text-gray-500">Webhook auto-sync is only available for GitHub repositories.</p>
       </div>
     );
@@ -733,8 +440,28 @@ export default function RepoView() {
 
   if (isLoading && !repo) {
     return (
-      <div className="flex min-h-screen bg-gray-950 items-center justify-center p-8">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+      <div className="flex min-h-screen bg-[#0c0d14] p-8">
+        <div className="flex-1 space-y-6">
+          {/* Header skeleton */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-2">
+              <div className="h-7 w-48 rounded-lg bg-gray-800 animate-pulse" />
+              <div className="h-4 w-64 rounded bg-gray-800/60 animate-pulse" />
+            </div>
+            <div className="h-9 w-24 rounded-md bg-gray-800 animate-pulse" />
+          </div>
+          {/* Table skeleton */}
+          <div className="rounded-xl border border-gray-800 bg-gray-900/30 overflow-hidden">
+            <div className="border-b border-gray-800 bg-gray-800/95 px-6 py-4 flex gap-8">
+              {[120,80,60,100,120,110].map((w,i) => <div key={i} className={`h-3 rounded bg-gray-700 animate-pulse`} style={{width: w}} />)}
+            </div>
+            {[...Array(8)].map((_,i) => (
+              <div key={i} className="flex gap-8 px-6 py-3 border-b border-gray-800/40">
+                {[200,70,50,60,80,80].map((w,j) => <div key={j} className="h-3 rounded bg-gray-800 animate-pulse" style={{width: w}} />)}
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     );
   }
@@ -755,7 +482,7 @@ export default function RepoView() {
   const isWorking = repo.status === 'pending' || repo.status === 'indexing';
 
   return (
-    <div className="flex flex-col min-h-screen bg-gray-950 text-white">
+    <div className="flex flex-col min-h-screen bg-[#0c0d14] text-white">
 
       {/* Header Container */}
       <div className="border-b border-gray-800 bg-gray-900/50 px-8 py-6">
@@ -842,7 +569,7 @@ export default function RepoView() {
           </div>
         ) : (
           <div className="h-full relative">
-            <div className={activeTab === 'graph' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'graph' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <DependencyGraph
                 nodes={analysisData.nodes}
                 edges={analysisData.edges}
@@ -857,7 +584,7 @@ export default function RepoView() {
               />
             </div>
 
-            <div className={activeTab === 'metrics' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'metrics' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <MetricsPanel
                 nodes={analysisData.nodes}
                 selectedNode={selectedNode}
@@ -866,26 +593,27 @@ export default function RepoView() {
               />
             </div>
 
-            <div className={activeTab === 'issues' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'issues' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <IssuesPanel
                 nodes={analysisData.nodes}
                 issues={analysisData.issues}
                 onNodeSelect={(nodeIds) => handleNodeSelect(nodeIds, { openGraph: true })}
                 onOpenDependencies={handleOpenDependencies}
+                repoId={repoId}
               />
             </div>
 
-            <div className={activeTab === 'search' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'search' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <SearchPanel repoId={repoId} />
             </div>
 
             {/* Review tab — CodeReviewPanel */}
-            <div className={activeTab === 'review' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'review' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <CodeReviewPanel repoId={repoId} />
             </div>
 
             {/* Settings tab — webhook / auto-sync */}
-            <div className={activeTab === 'settings' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'settings' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <SettingsPanel
                 repo={repo}
                 session={session}
@@ -894,12 +622,12 @@ export default function RepoView() {
             </div>
 
             {/* Files tab — repository file browser */}
-            <div className={activeTab === 'files' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'files' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <FileBrowser repoId={repoId} nodes={analysisData.nodes} />
             </div>
 
             {/* Dependencies tab — package vulnerability scanning (US-045) */}
-            <div className={activeTab === 'dependencies' ? 'block h-full' : 'hidden'}>
+            <div className={activeTab === 'dependencies' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
               <DependenciesPanel repoId={repoId} refreshKey={depsRefreshKey} />
             </div>
           </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,13 @@ export default {
     './src/**/*.{js,jsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'app-bg': '#0c0d14',
+        'app-surface': '#111218',
+        'app-border': '#1e1f2e',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Graph (section 1):
- Add node glow effect — SVG uses feMerge bloom filter, Canvas uses
  shadowColor/shadowBlur scaled by incoming_count so hub files glow brighter
- Add hover tooltips with language, lines, complexity, dependents — colored
  left border matches node language; works in both SVG and Canvas modes
- Add in-graph search (Ctrl+F) — highlights matching nodes using existing
  dim infrastructure, cycles through results with ↑↓/Enter, Escape clears
- Add animated edge flow — highlighted and impact edges get flowing dashes
  via CSS keyframes (SVG) and rAF-driven lineDashOffset (Canvas)

Metrics (section 2):
- Add summary card row above table: D3 donut health-score ring, total LOC,
  avg complexity, language distribution pills
- Add spark bars — 2px proportional bars at each numeric cell's bottom edge,
  color-coded by column (sky/indigo/violet/health-adaptive)
- Add complexity distribution histogram (collapsible) — click any bar to
  filter the table to that complexity range; active filter shown as badge

General UI/UX (section 3):
- Warmer palette: custom app-bg (#0c0d14), app-surface (#111218) in Tailwind
  config; sidebar active tab gets indigo left-border indicator
- Dashboard repo cards: gradient top border, language mini-bar, health dot,
  hover indigo glow shadow, skeleton loading state
- Responsive panel heights: h-[40rem] → h-[calc(100vh-12rem)] min-h-[30rem]
  across all tab panels
- Tab switch animations: fadeInUp CSS keyframes via tab-panel-active class
- Deduplicate MetricsPanel: inline copy removed from RepoView, now imported
  from standalone component; IssuesPanel similarly extracted
- Backend: enrich listRepos with language distribution data for dashboard cards