### PR TITLE
feat: incremental reindex, tab improvements, and US-046 completion

### DIFF
--- a/backend/src/sast/rules/python.json
+++ b/backend/src/sast/rules/python.json
@@ -52,5 +52,14 @@
     "description": "yaml.load() without an explicit Loader can deserialize and execute arbitrary Python objects.",
     "fixHint": "Use yaml.safe_load() or pass Loader=yaml.SafeLoader explicitly.",
     "pattern": "yaml\\.load\\s*\\([^)]*\\)"
+  },
+  {
+    "id": "py_sql_fstring",
+    "name": "Raw SQL with f-string formatting",
+    "severity": "high",
+    "cwe": "CWE-89",
+    "description": "Building SQL queries with f-strings allows SQL injection — user-controlled values land directly in the query string.",
+    "fixHint": "Use parameterised queries: cursor.execute(sql, params) with a tuple of values.",
+    "pattern": "execute\\s*\\(\\s*f['\"]"
   }
 ]

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -11,6 +11,11 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'sk-dummy' });
 const pLimit = require('p-limit');
 const fs = require('fs/promises');
 const path = require('path');
+const crypto = require('crypto');
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
 
 const VALID_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.py', '.cs', '.go', '.java', '.rs', '.rb']);
 
@@ -82,13 +87,20 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     console.log(`[indexer] Starting indexing for repoId: ${repoId} (source: ${source})`);
     console.time(`[indexer] Total pipeline (${repoId})`);
 
-    // Clear all derived tables in a single DB round trip via RPC instead of 6
-    // separate PostgREST calls.  The function runs all DELETEs in one transaction,
-    // avoiding repeated FK lock acquisitions on the repositories parent row.
-    const { error: clearError } = await supabaseAdmin.rpc('clear_repo_derived_data', { p_repo_id: repoId });
-    if (clearError) {
-      console.warn(`[indexer] Failed clearing derived data before reindex: ${clearError.message}`);
-    }
+    // Fetch existing node hashes BEFORE clearing — used for incremental indexing.
+    // If the content_hash column doesn't exist yet (old schema), we get an empty result
+    // and fall back to a full index on this run.
+    const { data: existingNodeRows } = await supabaseAdmin
+      .from('graph_nodes')
+      .select('file_path, content_hash, language, line_count, complexity_score')
+      .eq('repo_id', repoId);
+    const existingNodeMap = new Map((existingNodeRows || []).map(n => [n.file_path, n]));
+
+    // Also pre-fetch existing edges for unchanged files (we'll reuse them to skip re-parsing imports)
+    const { data: existingEdgeRows } = await supabaseAdmin
+      .from('graph_edges')
+      .select('from_path, to_path')
+      .eq('repo_id', repoId);
 
     // Fetch repo owner for usage tracking (US-042)
     const { data: repoMeta } = await supabaseAdmin
@@ -157,8 +169,74 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
 
     console.log(`[indexer] Discovered ${manifestFiles.length} manifest file(s) for SCA.`);
 
+    // ── Incremental delta: read all content + compute hashes ──────────────────
+    console.time(`[indexer] Phase 1c: Hash computation (${repoId})`);
+    const readLimit = pLimit(20);
+    await Promise.all(pendingFiles.map(file => readLimit(async () => {
+      try {
+        if (!file.content) file.content = await fs.readFile(file.fsPath, 'utf-8');
+        file.contentHash = sha256(file.content);
+      } catch (readErr) {
+        console.warn(`[indexer] Failed to read ${file.path}: ${readErr.message}`);
+      }
+    })));
+    console.timeEnd(`[indexer] Phase 1c: Hash computation (${repoId})`);
+
+    const currentFilePaths = new Set(pendingFiles.map(f => f.path));
+    const deletedFilePaths = [...existingNodeMap.keys()].filter(p => !currentFilePaths.has(p));
+
+    const unchangedFilePaths = new Set();
+    const changedFilePaths = new Set();
+    for (const file of pendingFiles) {
+      const existing = existingNodeMap.get(file.path);
+      if (existing && existing.content_hash && existing.content_hash === file.contentHash) {
+        unchangedFilePaths.add(file.path);
+      } else {
+        changedFilePaths.add(file.path);
+      }
+    }
+
+    console.log(`[indexer] Incremental: ${unchangedFilePaths.size} unchanged, ${changedFilePaths.size} changed/new, ${deletedFilePaths.length} deleted`);
+
+    const changedOrDeletedPaths = [...changedFilePaths, ...deletedFilePaths];
+
+    // ── Targeted clearing instead of blanket wipe ─────────────────────────────
+    // Pre-fetch per-file issues (secrets + SAST) for unchanged files before clearing.
+    // We skip scanning unchanged files so we need to re-inject their existing issues.
+    const PER_FILE_ISSUE_TYPES = ['hardcoded_secret', 'insecure_pattern'];
+    let preservedPerFileIssues = [];
+    if (unchangedFilePaths.size > 0) {
+      const unchangedArr = [...unchangedFilePaths];
+      const batches = chunkArray(unchangedArr, 150);
+      for (const batch of batches) {
+        const { data: existing } = await supabaseAdmin
+          .from('analysis_issues')
+          .select('*')
+          .eq('repo_id', repoId)
+          .in('type', PER_FILE_ISSUE_TYPES)
+          .overlaps('file_paths', batch);
+        if (existing) preservedPerFileIssues.push(...existing);
+      }
+    }
+
+    // Always clear: issues, dependency_manifests, all edges (coupling counts change)
+    // Partial clear: nodes/chunks/file_contents only for changed or deleted files
+    await supabaseAdmin.from('analysis_issues').delete().eq('repo_id', repoId);
+    await supabaseAdmin.from('dependency_manifests').delete().eq('repo_id', repoId);
+    await supabaseAdmin.from('graph_edges').delete().eq('repo_id', repoId);
+
+    if (changedOrDeletedPaths.length > 0) {
+      const pathBatches = chunkArray(changedOrDeletedPaths, 150);
+      for (const batch of pathBatches) {
+        await supabaseAdmin.from('graph_nodes').delete().eq('repo_id', repoId).in('file_path', batch);
+        await supabaseAdmin.from('code_chunks').delete().eq('repo_id', repoId).in('file_path', batch);
+        await supabaseAdmin.from('file_contents').delete().eq('repo_id', repoId).in('file_path', batch);
+      }
+    }
+
     const limit = pLimit(10);
-    const issues = [];
+    // Seed with pre-fetched per-file issues from unchanged files (secrets + SAST)
+    const issues = [...preservedPerFileIssues];
 
     // Fetch existing suppressions for this repo BEFORE scanning
     const { data: suppressions } = await supabaseAdmin
@@ -177,12 +255,15 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
 
     // 2.5 Optional Pre-pass for C# Namespaces (US-011)
     const namespaceMap = new Map();
+    // Files that need to be parsed (changed or new) — defined here for use by pre-pass and parsing phase
+    const filesToProcess = pendingFiles.filter(f => changedFilePaths.has(f.path));
+
     const isCSharpRepo = pendingFiles.some(f => f.path.toLowerCase().endsWith('.cs'));
 
     if (isCSharpRepo) {
-      console.log(`[indexer] C# files detected. Running namespace pre-pass...`);
+      console.log(`[indexer] C# files detected. Running namespace pre-pass on changed files...`);
       await Promise.all(
-        pendingFiles.map(file =>
+        filesToProcess.map(file =>
           limit(async () => {
             if (!file.path.toLowerCase().endsWith('.cs')) return;
             try {
@@ -210,9 +291,11 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     let parsedCount = 0;
 
     // 3. parse (with concurrency) and 4. resolve imports
+    // Only process files that changed or are new — unchanged files reuse their DB state.
     console.time(`[indexer] Phase 2: Parsing (${repoId})`);
+    console.log(`[indexer] Parsing ${filesToProcess.length} changed/new files (skipping ${unchangedFilePaths.size} unchanged)`);
     await Promise.all(
-      pendingFiles.map(file =>
+      filesToProcess.map(file =>
         limit(async () => {
           try {
             // Content might already be loaded from pre-pass
@@ -269,14 +352,38 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     console.timeEnd(`[indexer] Phase 2: Parsing (${repoId})`);
 
     // 5. dedupe nodes (in memory)
+    // Seed with unchanged nodes from DB so they still appear in the final graph.
     const nodeMap = new Map();
     const allEdges = [];
-    let fileCount = pendingFiles.length; // From acceptance criteria or just matched valid files
+    let fileCount = pendingFiles.length;
+
+    // Reconstruct unchanged nodes from DB snapshot
+    for (const filePath of unchangedFilePaths) {
+      const existing = existingNodeMap.get(filePath);
+      if (existing) {
+        nodeMap.set(filePath, {
+          repo_id: repoId,
+          file_path: filePath,
+          language: existing.language || 'unknown',
+          line_count: existing.line_count || 0,
+          complexity_score: existing.complexity_score || 1,
+          content_hash: existing.content_hash,
+          outgoing_count: 0,
+          incoming_count: 0,
+        });
+      }
+    }
+
+    // Reconstruct edges originating from unchanged files
+    for (const edge of (existingEdgeRows || [])) {
+      if (unchangedFilePaths.has(edge.from_path)) {
+        allEdges.push({ repo_id: repoId, from_path: edge.from_path, to_path: edge.to_path });
+      }
+    }
 
     for (const file of parsedFiles) {
-      if (!file) continue; // In case of skipped parse
+      if (!file) continue;
 
-      // Find original file body to count lines
       const originalFile = pendingFiles.find(f => f.path === file.filePath);
       const lineCount = (originalFile && originalFile.content) ? originalFile.content.split('\n').length : 0;
 
@@ -299,7 +406,8 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
         line_count: lineCount,
         outgoing_count: 0,
         incoming_count: 0,
-        complexity_score: file.complexity || 1
+        complexity_score: file.complexity || 1,
+        content_hash: originalFile?.contentHash || null,
       });
 
       for (const imp of file.imports) {
@@ -550,10 +658,12 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       }
     }
 
-    // 10. Store full file contents (US-043) — independent of OpenAI key
+    // 10. Store full file contents (US-043) — only for changed/new files
+    // Unchanged files already have their content rows in the DB.
     const FILE_SIZE_CAP = 1024 * 1024; // 1 MB
     const fileContentRows = [];
     for (const file of pendingFiles) {
+      if (!changedFilePaths.has(file.path)) continue; // skip unchanged
       if (!file.content) continue;
       const raw = file.content;
       const truncated = raw.length > FILE_SIZE_CAP;
@@ -582,17 +692,16 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       try {
         console.log(`[indexer] Starting semantic chunking and embedding for ${repoId}`);
 
-        // Wipe obsolete chunks before re-embedding (Handled by clear_repo_derived_data RPC earlier)
-        
-        // Extract local raw chunks
+        // Only embed changed/new files — unchanged files keep their existing code_chunks rows.
         const allExtractedChunks = [];
         for (const file of pendingFiles) {
+          if (!changedFilePaths.has(file.path)) continue;
           if (!file.content) continue;
           const fileChunks = extractChunksFromFile(file.path, file.content, repoId);
           allExtractedChunks.push(...fileChunks);
         }
 
-        console.log(`[indexer] Generated ${allExtractedChunks.length} raw chunks. Proceeding to OpenAI.`);
+        console.log(`[indexer] Generated ${allExtractedChunks.length} raw chunks for ${changedFilePaths.size} changed files. Proceeding to OpenAI.`);
 
         // 10c. Batch API vectors — batch size of 100 (OpenAI supports up to 2048 inputs)
         console.time(`[indexer] Phase 5: Embedding (${repoId})`);

--- a/frontend/src/components/CodeReviewPanel.jsx
+++ b/frontend/src/components/CodeReviewPanel.jsx
@@ -14,12 +14,20 @@ import { AnswerBlock, SourceCard } from './SharedAnswerComponents';
 // Main CodeReviewPanel
 // ---------------------------------------------------------------------------
 
+const PRESETS = [
+  { id: 'security',     label: 'Security',     hint: 'Focus on injection vulnerabilities, XSS, CSRF, secrets exposure, authentication flaws, and dangerous API usage.' },
+  { id: 'performance',  label: 'Performance',  hint: 'Focus on algorithmic complexity, unnecessary re-renders, memory leaks, N+1 queries, and inefficient operations.' },
+  { id: 'bugs',         label: 'Bug Hunt',     hint: 'Focus on off-by-one errors, null dereferences, unhandled edge cases, race conditions, and error-handling gaps.' },
+  { id: 'architecture', label: 'Architecture', hint: 'Focus on separation of concerns, coupling, abstraction leaks, SOLID principles, and long-term maintainability.' },
+];
+
 export default function CodeReviewPanel({ repoId }) {
   const { session } = useAuth();
 
   // State — same pattern as SearchPanel
   const [snippet,            setSnippet]            = useState('');
   const [contextDescription, setContextDescription] = useState('');
+  const [activePreset,       setActivePreset]       = useState(null);
   const [isStreaming,        setIsStreaming]         = useState(false);
   const [answer,             setAnswer]             = useState('');
   const [sources,            setSources]            = useState([]);
@@ -76,7 +84,10 @@ export default function CodeReviewPanel({ repoId }) {
         },
         body: JSON.stringify({
           snippet:  snippet.trim(),
-          context:  contextDescription.trim() || undefined,
+          context:  [
+            activePreset ? PRESETS.find(p => p.id === activePreset)?.hint : '',
+            contextDescription.trim(),
+          ].filter(Boolean).join('\n\n') || undefined,
           mode,
         }),
         signal: controller.signal,
@@ -171,6 +182,27 @@ export default function CodeReviewPanel({ repoId }) {
             Snippet exceeds 200 lines. Please trim it before submitting.
           </p>
         )}
+
+        {/* Review focus presets */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-gray-500 shrink-0">Focus:</span>
+          {PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              disabled={isStreaming}
+              onClick={() => setActivePreset(p => p === preset.id ? null : preset.id)}
+              title={preset.hint}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition disabled:opacity-50 ${
+                activePreset === preset.id
+                  ? 'border-indigo-500/50 bg-indigo-500/15 text-indigo-300'
+                  : 'border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-200'
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
 
         {/* Context field */}
         <input

--- a/frontend/src/components/DependenciesPanel.jsx
+++ b/frontend/src/components/DependenciesPanel.jsx
@@ -118,6 +118,13 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
   const totalVulnerable = useMemo(() => deps.filter(d => d.vuln_count > 0).length, [deps]);
   const totalClean      = useMemo(() => deps.filter(d => d.vuln_count === 0).length, [deps]);
 
+  const SEVERITY_RANK = { high: 3, medium: 2, low: 1, none: 0 };
+  const getMaxSeverity = (dep) => {
+    const vulns = dep.vulns_json || [];
+    if (!vulns.length) return 0;
+    return Math.max(...vulns.map(v => SEVERITY_RANK[v.severity] || 0));
+  };
+
   const filteredDeps = useMemo(() => {
     let result = [...deps];
     if (searchQuery) {
@@ -131,15 +138,22 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
       result = result.filter(d => d.vuln_count > 0);
     }
     result.sort((a, b) => {
-      let valA = a[sortConfig.key];
-      let valB = b[sortConfig.key];
-      if (typeof valA === 'string') valA = valA.toLowerCase();
-      if (typeof valB === 'string') valB = valB.toLowerCase();
+      let valA, valB;
+      if (sortConfig.key === 'max_severity') {
+        valA = getMaxSeverity(a);
+        valB = getMaxSeverity(b);
+      } else {
+        valA = a[sortConfig.key];
+        valB = b[sortConfig.key];
+        if (typeof valA === 'string') valA = valA.toLowerCase();
+        if (typeof valB === 'string') valB = valB.toLowerCase();
+      }
       if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
       if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
       return 0;
     });
     return result;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deps, searchQuery, filterEcosystem, showOnlyVulnerable, sortConfig]);
 
   const handleSort = useCallback((key) => {
@@ -337,6 +351,13 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
               </th>
               <th className="px-5 py-3 font-semibold text-gray-400">Manifest</th>
               <th
+                id="dep-col-severity"
+                className="px-5 py-3 font-semibold cursor-pointer hover:text-white transition-colors select-none"
+                onClick={() => handleSort('max_severity')}
+              >
+                Severity <SortIcon columnKey="max_severity" sortConfig={sortConfig} />
+              </th>
+              <th
                 id="dep-col-status"
                 className="px-5 py-3 font-semibold cursor-pointer hover:text-white transition-colors select-none"
                 onClick={() => handleSort('vuln_count')}
@@ -348,7 +369,7 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
           <tbody className="divide-y divide-gray-800/60">
             {filteredDeps.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-5 py-10 text-center text-sm text-gray-500">
+                <td colSpan={6} className="px-5 py-10 text-center text-sm text-gray-500">
                   No packages match your search.
                 </td>
               </tr>
@@ -489,6 +510,17 @@ function Dependency({ id, dep, vulns, hasVulns, isExpanded, onToggle }) {
           </span>
         </td>
 
+        {/* Max severity */}
+        <td className="px-5 py-3">
+          {hasVulns ? (() => {
+            const top = vulns.reduce((best, v) => {
+              const rank = { high: 3, medium: 2, low: 1 };
+              return (rank[v.severity] || 0) > (rank[best?.severity] || 0) ? v : best;
+            }, vulns[0]);
+            return <SeverityBadge severity={top?.severity} />;
+          })() : <span className="text-gray-700 text-xs">—</span>}
+        </td>
+
         {/* Status */}
         <td className="px-5 py-3">
           {hasVulns ? (
@@ -508,7 +540,7 @@ function Dependency({ id, dep, vulns, hasVulns, isExpanded, onToggle }) {
       {/* Expanded vulnerability details */}
       {isExpanded && hasVulns && (
         <tr id={`dep-detail-${id}`} className="bg-gray-950/60">
-          <td colSpan={5} className="px-5 pb-4 pt-2">
+          <td colSpan={6} className="px-5 pb-4 pt-2">
             <div className="ml-5 space-y-3">
               {vulns.map((vuln, idx) => (
                 <div

--- a/frontend/src/components/FileBrowser.jsx
+++ b/frontend/src/components/FileBrowser.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useAuth } from '../context/AuthContext';
@@ -147,6 +148,7 @@ function RootFiles({ files, selectedPath, onSelect, depth = 0 }) {
 export default function FileBrowser({ repoId, nodes }) {
   const { session } = useAuth();
   const toast = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedPath, setSelectedPath] = useState(null);
   const [content, setContent]           = useState(null);
@@ -173,6 +175,31 @@ export default function FileBrowser({ repoId, nodes }) {
       return next;
     });
   }, []);
+
+  // Auto-open file from ?file= URL param (set by Issues tab "Open in Files")
+  const fileParam = searchParams.get('file');
+  useEffect(() => {
+    if (!fileParam || !nodes.length || !session?.access_token) return;
+    const matchingNode = nodes.find((n) => n.file_path === fileParam);
+    if (!matchingNode) return;
+
+    // Expand all ancestor directories of the target file
+    const parts = fileParam.replace(/\\/g, '/').split('/');
+    const ancestorPaths = [];
+    for (let i = 1; i < parts.length; i++) {
+      ancestorPaths.push(parts.slice(0, i).join('/'));
+    }
+    setExpandedDirs((prev) => new Set([...prev, ...ancestorPaths]));
+    setSelectedPath(fileParam);
+
+    // Clear the param so navigating away and back doesn't re-trigger
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      next.delete('file');
+      return next;
+    }, { replace: true });
+  // fetchFile is defined after this effect; call it imperatively via ref below
+  }, [fileParam, nodes, session?.access_token, setSearchParams]);
 
   const fetchFile = useCallback(async (filePath) => {
     if (!session?.access_token) return;
@@ -206,10 +233,16 @@ export default function FileBrowser({ repoId, nodes }) {
     }
   }, [repoId, session?.access_token]);
 
+  // Fetch content whenever selectedPath changes (handles both manual clicks and URL-param auto-open)
+  useEffect(() => {
+    if (selectedPath) fetchFile(selectedPath);
+  // fetchFile identity is stable (useCallback with stable deps)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPath]);
+
   const handleSelect = useCallback((filePath) => {
     setSelectedPath(filePath);
-    fetchFile(filePath);
-  }, [fetchFile]);
+  }, []);
 
   const handleLineCopy = useCallback(async (lineNum) => {
     if (!selectedPath) return;

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { apiUrl } from '../lib/api';
 
-export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDependencies, repoId }) {
+export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDependencies, onOpenFile, repoId }) {
   const { session } = useAuth();
   // Local state to hide suppressed issues instantly without full page reload
   const [localIssues, setLocalIssues] = useState(issues || []);
@@ -202,10 +202,26 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
                     {issue.description || 'No description available.'}
                   </p>
 
-                  <div className="mt-auto bg-gray-950/50 rounded-md p-3 border border-gray-800 break-words">
-                    <span className="font-mono text-xs text-gray-400 leading-loose">
-                      {issue.file_paths.join(' → ')}
-                    </span>
+                  <div className="mt-auto bg-gray-950/50 rounded-md p-3 border border-gray-800 flex flex-wrap gap-y-1 gap-x-2">
+                    {issue.file_paths.map((fp, i) => (
+                      <span key={fp} className="flex items-center gap-1.5">
+                        {i > 0 && <span className="text-gray-600 text-xs">→</span>}
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (type !== 'vulnerable_dependency') onOpenFile?.(fp);
+                          }}
+                          title={type !== 'vulnerable_dependency' ? `Open ${fp} in Files tab` : fp}
+                          className={`font-mono text-xs text-gray-400 leading-loose break-all text-left ${
+                            type !== 'vulnerable_dependency'
+                              ? 'hover:text-indigo-300 transition-colors cursor-pointer'
+                              : 'cursor-default'
+                          }`}
+                        >
+                          {fp}
+                        </button>
+                      </span>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/frontend/src/components/MetricsPanel.jsx
+++ b/frontend/src/components/MetricsPanel.jsx
@@ -319,7 +319,17 @@ export default function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnal
               rowHeight={44}
               bufferRows={20}
               containerHeight="100%"
-              tableClassName="w-full text-left text-sm whitespace-nowrap"
+              tableClassName="w-full text-left text-sm table-fixed"
+              colGroup={
+                <colgroup>
+                  <col style={{ width: '36%' }} />
+                  <col style={{ width: '11%' }} />
+                  <col style={{ width: '10%' }} />
+                  <col style={{ width: '10%' }} />
+                  <col style={{ width: '11%' }} />
+                  <col style={{ width: '12%' }} />
+                </colgroup>
+              }
               renderHeader={() => (
                 <thead className="bg-gray-800/95 backdrop-blur text-gray-300 z-10 shadow-sm border-b border-gray-700">
                   <tr>
@@ -329,16 +339,16 @@ export default function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnal
                     <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('language')}>
                       Language <SortIcon columnKey="language" />
                     </th>
-                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('line_count')}>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none text-center" onClick={() => handleSort('line_count')}>
                       Lines <SortIcon columnKey="line_count" />
                     </th>
-                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('outgoing_count')}>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none text-center" onClick={() => handleSort('outgoing_count')}>
                       Imports <SortIcon columnKey="outgoing_count" />
                     </th>
-                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('incoming_count')}>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none text-center" onClick={() => handleSort('incoming_count')}>
                       Dependents <SortIcon columnKey="incoming_count" />
                     </th>
-                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none" onClick={() => handleSort('complexity_score')}>
+                    <th className="px-6 py-4 font-semibold cursor-pointer hover:text-white transition-colors select-none text-center" onClick={() => handleSort('complexity_score')}>
                       Complexity <SortIcon columnKey="complexity_score" />
                     </th>
                   </tr>
@@ -370,21 +380,23 @@ export default function MetricsPanel({ nodes, selectedNode, onNodeSelect, onAnal
 
                 return (
                   <tr key={node.id || node.file_path} onClick={() => onNodeSelect(node.id || node.file_path, { openGraph: true })} className={rowClass} style={{ height: 44 }}>
-                    <td className={`px-6 py-3 font-mono text-xs ${textFade}`}>{node.file_path}</td>
+                    <td className={`px-6 py-3 font-mono text-xs ${textFade} max-w-0`}>
+                    <span className="block truncate" title={node.file_path}>{node.file_path}</span>
+                  </td>
                     <td className={`px-6 py-3 ${metaFade}`}>{formatLanguage(node.language)}</td>
-                    <td className="px-6 py-3 relative" style={{ minWidth: 80 }}>
+                    <td className="px-6 py-3 relative text-center">
                       <span className={metaFade}>{node.line_count}</span>
                       <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-sky-400" style={{ width: `${((node.line_count || 0) / maxLineCount) * 100}%` }} />
                     </td>
-                    <td className="px-6 py-3 relative" style={{ minWidth: 70 }}>
+                    <td className="px-6 py-3 relative text-center">
                       <span className={metaFade}>{node.outgoing_count}</span>
                       <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-indigo-400" style={{ width: `${((node.outgoing_count || 0) / maxOutgoing) * 100}%` }} />
                     </td>
-                    <td className="px-6 py-3 relative" style={{ minWidth: 80 }}>
+                    <td className="px-6 py-3 relative text-center">
                       <span className={metaFade}>{node.incoming_count}</span>
                       <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-35 bg-violet-400" style={{ width: `${((node.incoming_count || 0) / maxIncoming) * 100}%` }} />
                     </td>
-                    <td className="px-6 py-3 relative" style={{ minWidth: 90 }}>
+                    <td className="px-6 py-3 relative text-center">
                       <span className={`font-medium ${textFade}`}>{Number(node.complexity_score).toFixed(2)}</span>
                       <div className="absolute bottom-0 left-0 h-0.5 rounded-full opacity-40" style={{ width: `${complexityRatio * 100}%`, backgroundColor: complexityBarColor }} />
                     </td>

--- a/frontend/src/components/VirtualTable.jsx
+++ b/frontend/src/components/VirtualTable.jsx
@@ -24,6 +24,7 @@ export default function VirtualTable({
   renderHeader,
   renderRow,
   tableClassName = '',
+  colGroup,
 }) {
   const scrollRef = useRef(null);
   const rafRef = useRef(null);
@@ -78,6 +79,7 @@ export default function VirtualTable({
       {/* Sticky header outside scroll area */}
       {renderHeader && (
         <table className={tableClassName}>
+          {colGroup}
           {renderHeader()}
         </table>
       )}
@@ -89,6 +91,7 @@ export default function VirtualTable({
         className="flex-1 overflow-y-auto overflow-x-auto"
       >
         <table className={tableClassName}>
+          {colGroup}
           <tbody>
             {/* Top spacer */}
             {topPadding > 0 && (

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -420,6 +420,15 @@ export default function RepoView() {
     }
   };
 
+  const handleOpenFile = useCallback((filePath) => {
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      next.set('tab', 'files');
+      next.set('file', filePath);
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   const handleOpenDependencies = useCallback((issue) => {
     const packageName = issue?.description?.match(/:\s(@?[^@\s:]+(?:\/[^@\s:]+)?)@/)?.[1] || '';
     setSearchParams((current) => {
@@ -599,6 +608,7 @@ export default function RepoView() {
                 issues={analysisData.issues}
                 onNodeSelect={(nodeIds) => handleNodeSelect(nodeIds, { openGraph: true })}
                 onOpenDependencies={handleOpenDependencies}
+                onOpenFile={handleOpenFile}
                 repoId={repoId}
               />
             </div>

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -168,8 +168,12 @@ CREATE TABLE IF NOT EXISTS graph_nodes (
   outgoing_count   INT   DEFAULT 0,
   incoming_count   INT   DEFAULT 0,
   complexity_score FLOAT DEFAULT 0,
+  content_hash     TEXT,
   UNIQUE (repo_id, file_path)
 );
+
+-- Migration for existing deployments: add content_hash if it doesn't exist
+ALTER TABLE graph_nodes ADD COLUMN IF NOT EXISTS content_hash TEXT;
 
 CREATE INDEX IF NOT EXISTS graph_nodes_repo_id_idx ON graph_nodes (repo_id);
 

--- a/user-stories-CodeLens.md
+++ b/user-stories-CodeLens.md
@@ -1506,6 +1506,14 @@ US-026: AI Code Review Panel
 **Note**
 > Reuse the SSE streaming from `searchController.js`. The confidence field is critical — users should know when Claude is certain vs. guessing. Suggested system prompt: "You are a security engineer reviewing code for vulnerabilities. Analyse the snippet in the context of the provided codebase excerpts. For each potential issue, identify the vulnerability type, cite the specific line, rate severity (low/medium/high), estimate confidence (low/medium/high), and suggest a concrete fix. If the code looks secure, say so explicitly — do not invent issues." The whole-repo audit is capped at 20 files to keep cost bounded; file selection surfaces the highest-leverage files rather than a random sample.
 
+**⚠️ Implementation note — overlap with existing "Security" preset**
+> `CodeReviewPanel.jsx` already ships a lightweight "Security" focus preset (one of four preset buttons: Security, Performance, Bug Hunt, Architecture) that prepends a security-focused instruction to the review context. This is intentionally shallow — it does not change retrieval ranking, structured output format, or support whole-repo auditing.
+>
+> When implementing US-048, **do not add a separate toggle** alongside the existing presets. Instead:
+> 1. Remove the "Security" preset button from the four-preset row.
+> 2. Replace it with the full "Security Audit" mode toggle described in this story (with its own system prompt, re-ranked retrieval, structured findings output, and "Audit this file" / "Run full audit" actions).
+> 3. Keep the remaining three presets (Performance, Bug Hunt, Architecture) as-is — they are lightweight focus hints and do not conflict.
+
 ---
 
 ### US-049: Authentication coverage check
@@ -1651,6 +1659,14 @@ US-026: AI Code Review Panel
 
 **Note**
 > This is "is this file referenced by any test" coverage, not line-level — but the heuristic version is genuinely useful because it scales to any language without running a test runner. The LCOV upgrade path is an easy bolt-on: `lcov-parse` on npm handles it in a few lines. The combination with hotspots from US-050 is especially powerful — untested + high-churn + high-complexity = exactly where production incidents come from. Consider a later "Risk Matrix" story that visualises all three dimensions together.
+
+**⚠️ Implementation note — schema and incremental indexing**
+> `graph_nodes` already has a `content_hash TEXT` column added by the incremental re-indexing work (see `scripts/schema.sql`). Adding `has_test_coverage BOOLEAN DEFAULT FALSE` is a straightforward additional column — apply via:
+> ```sql
+> ALTER TABLE graph_nodes ADD COLUMN IF NOT EXISTS has_test_coverage BOOLEAN DEFAULT FALSE;
+> ```
+>
+> **Incremental indexing interaction:** Coverage must be recomputed from the complete edge graph on every re-index, not just for changed files. A test file changing its imports can affect the coverage status of source files that themselves haven't changed. The implementation should compute `has_test_coverage` from the full `allEdges` set (which is always rebuilt from scratch) and update it on all nodes during the final bulk upsert — not only on files in `changedFilePaths`. This is already how coupling metrics (`incoming_count`, `outgoing_count`) work, so the pattern is established.
 
 ---
 


### PR DESCRIPTION
Incremental re-indexing (backend):
- Replace blanket clear_repo_derived_data with targeted deletes: issues,
  dep_manifests, and edges always cleared; nodes/chunks/file_contents only
  deleted for changed or deleted files
- SHA-256 content_hash computed for every file; unchanged files skip
  parsing, SAST, secret scanning, and OpenAI embedding entirely
- Unchanged nodes and edges reconstructed from DB snapshot so coupling
  metrics still update across the full graph
- Per-file SAST/secrets issues for unchanged files pre-fetched before
  clear and re-injected to prevent silent data loss on incremental runs
- content_hash TEXT column added to graph_nodes (schema.sql includes
  ALTER TABLE ADD COLUMN IF NOT EXISTS for existing deployments)

Code Review — review presets:
- Four focus preset buttons: Security, Performance, Bug Hunt, Architecture
- Active preset prepends its focus instruction to the context payload;
  no backend changes required

Issues panel — click-to-open in FileBrowser:
- File paths in issue cards are now clickable; navigates to ?tab=files&file=<path>
- FileBrowser reads ?file= param on mount, auto-expands ancestor dirs,
  selects and fetches the file, then clears the param

Dependencies panel — severity sort:
- New Severity column showing the highest-severity badge per package
- Sortable by max CVSS severity (high → medium → low) via max_severity key

Metrics panel — column alignment fix:
- VirtualTable gains a colGroup prop rendered in both header and body tables
  so column widths are enforced identically across the two separate <table>
  elements; fixes the one-column-right misalignment on long file paths
- Numeric columns (Lines, Imports, Dependents, Complexity) centered in
  both headers and cells

US-046 completion:
- Add py_sql_fstring rule (CWE-89, high) to detect f-string SQL injection:
  pattern execute\s*\(\s*f['"] — the last gap in the Python ruleset

User stories:
- US-048: document overlap with existing Security preset and exact
  migration path (remove preset, replace with full audit mode toggle)
- US-053: document content_hash schema coexistence and incremental
  indexing constraint (coverage must use full allEdges, not changedFilePaths)