### PR TITLE
feat: implement US-047 attack surface mapping and US-049 auth coverage check

### DIFF
--- a/backend/src/controllers/analysisController.js
+++ b/backend/src/controllers/analysisController.js
@@ -37,11 +37,14 @@ const suppressIssue = async (req, res) => {
 
   if (suppError) return res.status(500).json({ error: suppError.message });
 
+  // Derive issue type from rule_id so the delete targets the correct row
+  const issueType = rule_id === 'missing_auth' ? 'missing_auth' : 'hardcoded_secret';
+
   // 2. Delete the active issue from analysis_issues so it disappears immediately
   await supabaseAdmin
     .from('analysis_issues')
     .delete()
-    .match({ repo_id: repoId, type: 'hardcoded_secret' })
+    .match({ repo_id: repoId, type: issueType })
     .contains('file_paths', [file_path])
     .ilike('description', `%Rule ID: ${rule_id}%`);
 

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -344,7 +344,7 @@ async function fetchFileSource(repoId, filePath) {
     .eq('file_path', filePath)
     .order('start_line', { ascending: true });
   if (error || !chunks || chunks.length === 0) return null;
-  return chunks.map((chunk) => chunk.content).join('');
+  return chunks.map((chunk) => chunk.content).join('\n');
 }
 
 async function fetchDeterministicIssues(repoId, filePaths) {
@@ -453,7 +453,9 @@ const review = async (req, res) => {
 
     send({ type: 'sources', sources: chunks.map(formatSource) });
     const { system, user } = buildReviewPrompt(snippet.trim(), contextDescription, chunks, mode, filePath);
-    const { text } = await streamClaude({ system, user, send, userId: req.user.id, endpoint: 'review' });
+    // In security_audit mode, suppress raw chunk events — findings arrive as structured `finding` SSE events instead.
+    const chunkSend = mode === 'security_audit' ? null : send;
+    const { text } = await streamClaude({ system, user, send: chunkSend, userId: req.user.id, endpoint: 'review' });
 
     if (mode === 'security_audit') {
       const issues = await fetchDeterministicIssues(repoId, filePath ? [filePath] : []);

--- a/backend/src/services/attackSurfaceClassifier.js
+++ b/backend/src/services/attackSurfaceClassifier.js
@@ -1,0 +1,143 @@
+// US-047: Attack surface mapping
+// Classifies files as 'source' (externally reachable entry points),
+// 'sink' (dangerous operations), 'both', or null.
+// Pure regex — no AST — so it runs on every file during indexing without overhead.
+
+const SOURCE_PATTERNS = {
+  js: [
+    /router\.(get|post|put|delete|patch|use)\s*\(/,
+    /app\.(get|post|put|delete|patch|use)\s*\(/,
+    /fastify\.(get|post|put|delete|patch|route)\s*\(/,
+    /server\.(get|post|put|delete|patch|route)\s*\(/,
+    /@(Get|Post|Put|Delete|Patch|All)\s*\(/,   // NestJS decorators
+    /express\.Router\s*\(/,
+    /process\.argv/,                            // CLI entry point
+    /readline\.createInterface/,                // stdin reader
+  ],
+  py: [
+    /@(app|router|bp|blueprint|api)\.(route|get|post|put|delete|patch)\s*\(/,
+    /APIRouter\s*\(/,
+    /Blueprint\s*\(/,
+    /include_router\s*\(/,
+    /sys\.argv/,
+    /argparse\.ArgumentParser/,
+    /\binput\s*\(/,                             // stdin
+  ],
+  go: [
+    /http\.Handle(?:Func)?\s*\(/,
+    /r\.(GET|POST|PUT|DELETE|PATCH|Handle)\s*\(/,
+    /router\.(GET|POST|PUT|DELETE|PATCH|Handle)\s*\(/,
+    /mux\.Handle(?:Func)?\s*\(/,
+    /os\.Args/,
+  ],
+  rb: [
+    /^\s*(get|post|put|delete|patch)\s+['"\/]/m,
+    /Rails\.application\.routes/,
+    /\bgets\b/,                                 // stdin
+    /ARGV/,
+  ],
+  java: [
+    /@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping|RequestMapping)/,
+    /@RestController/,
+    /@Controller/,
+    /public\s+static\s+void\s+main\s*\(/,      // CLI entry point
+  ],
+  cs: [
+    /\[(HttpGet|HttpPost|HttpPut|HttpDelete|HttpPatch|ApiController)\]/,
+    /Environment\.GetCommandLineArgs/,
+    /Console\.ReadLine\s*\(/,
+  ],
+  rs: [
+    /#\[(get|post|put|delete|patch)\]/,         // actix-web
+    /web::(get|post|put|delete|patch)\s*\(/,
+    /Router::new\s*\(\s*\)/,                    // axum
+    /std::env::args/,
+  ],
+};
+
+// Sinks are cross-language — patterns are specific enough to avoid false matches.
+const SINK_PATTERNS = [
+  // SQL execution
+  /\.query\s*\(\s*[`"']/,
+  /\.execute\s*\(\s*[`"']/,
+  /executeQuery\s*\(/,
+  /\.raw\s*\(\s*[`"']/,                         // knex .raw()
+  /SqlCommand\s*\(/,                            // ADO.NET
+  /cursor\.execute\s*\(/,                       // Python DB-API
+  /db\.execute\s*\(/,
+  /session\.execute\s*\(/,
+
+  // Shell / process execution
+  /child_process/,
+  /execSync\s*\(/,
+  /spawnSync\s*\(/,
+  /exec\s*\(\s*[`$]/,                           // exec with template literal — indicates dynamic arg
+  /subprocess\.(run|call|Popen)\s*\(/,
+  /os\.system\s*\(/,
+  /os\.popen\s*\(/,
+  /Runtime\.getRuntime\(\)\.exec\s*\(/,
+  /Process\.Start\s*\(/,
+  /std::process::Command::new/,
+
+  // Filesystem writes (dynamic paths)
+  /fs\.writeFile(?:Sync)?\s*\(/,
+  /fs\.appendFile(?:Sync)?\s*\(/,
+  /open\s*\([^)]+['"]\s*[wa]/,                  // Python open(..., 'w') / 'a'
+  /File\.WriteAllText\s*\(/,
+  /File\.AppendAllText\s*\(/,
+  /java\.io\.FileWriter/,
+  /std::fs::write\s*\(/,
+
+  // Deserialisation
+  /pickle\.loads?\s*\(/,
+  /yaml\.load\s*\(\s*[^,)]+\)/,                 // yaml.load without SafeLoader (no second arg)
+  /JSON\.parse\s*\(/,
+  /\bdeserialize\s*\(/,
+  /BinaryFormatter\.Deserialize/,
+  /ObjectInputStream\s*\(/,
+  /serde_json::from_str\s*\(/,
+
+  // Outbound HTTP with dynamic URLs (non-literal first argument)
+  /fetch\s*\(\s*[^'"]/,
+  /axios\.(get|post|put|delete|patch)\s*\(\s*[^'"]/,
+  /requests\.(get|post|put|delete|patch)\s*\(\s*[^'"]/,
+  /http\.NewRequest\s*\(/,
+  /HttpClient\b/,
+  /HttpURLConnection\b/,
+  /urllib\.request\.(urlopen|urlretrieve)\s*\(/,
+];
+
+function getLanguage(filePath) {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  if (['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs'].includes(ext)) return 'js';
+  if (ext === 'py') return 'py';
+  if (ext === 'go') return 'go';
+  if (ext === 'rb') return 'rb';
+  if (ext === 'java') return 'java';
+  if (ext === 'cs') return 'cs';
+  if (ext === 'rs') return 'rs';
+  return null;
+}
+
+/**
+ * Classifies a single file as 'source', 'sink', 'both', or null.
+ *
+ * @param {string} filePath - repo-relative path
+ * @param {string} content  - file source text
+ * @returns {'source'|'sink'|'both'|null}
+ */
+function classifyFile(filePath, content) {
+  const lang = getLanguage(filePath);
+  if (!lang) return null;
+
+  const srcPatterns = SOURCE_PATTERNS[lang] || [];
+  const isSource = srcPatterns.some(p => p.test(content));
+  const isSink   = SINK_PATTERNS.some(p => p.test(content));
+
+  if (isSource && isSink) return 'both';
+  if (isSource) return 'source';
+  if (isSink)   return 'sink';
+  return null;
+}
+
+module.exports = { classifyFile };

--- a/backend/src/services/authCoverageScanner.js
+++ b/backend/src/services/authCoverageScanner.js
@@ -1,0 +1,222 @@
+// US-049: Authentication coverage check
+// Heuristic two-layer detection:
+//   1. In-file: auth markers in source text
+//   2. Import-based: imported paths that sound like auth middleware
+
+const ROUTE_PATTERNS = {
+  js: [
+    /router\.(get|post|put|delete|patch|use)\s*\(/,
+    /app\.(get|post|put|delete|patch|use)\s*\(/,
+    /express\.Router\s*\(/,
+    /@(Get|Post|Put|Delete|Patch|All)\s*\(/,
+    /route\.(get|post|put|delete|patch)\s*\(/,
+    /fastify\.(get|post|put|delete|patch|route)\s*\(/,
+    /server\.(get|post|put|delete|patch|route)\s*\(/,
+    /hapi.*route\s*\(/,
+  ],
+  py: [
+    /@(app|router|bp|blueprint|api)\.(route|get|post|put|delete|patch)\s*\(/,
+    /APIRouter\s*\(/,
+    /Blueprint\s*\(/,
+    /include_router\s*\(/,
+  ],
+  go: [
+    /http\.Handle(?:Func)?\s*\(/,
+    /r\.(GET|POST|PUT|DELETE|PATCH|Handle)\s*\(/,
+    /router\.(GET|POST|PUT|DELETE|PATCH|Handle)\s*\(/,
+    /mux\.Handle(?:Func)?\s*\(/,
+  ],
+  rb: [
+    /^\s*(get|post|put|delete|patch)\s+['"/]/m,
+    /resources\s+:/,
+    /Rails\.application\.routes/,
+  ],
+  java: [
+    /@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping|RequestMapping)/,
+    /@RestController/,
+    /@Controller/,
+  ],
+  cs: [
+    /\[(HttpGet|HttpPost|HttpPut|HttpDelete|HttpPatch|Route|ApiController)\]/,
+  ],
+};
+
+// Patterns that indicate auth is being enforced within the file
+const AUTH_MARKERS = [
+  /passport\.authenticate\s*\(/,
+  /\brequireAuth\b/,
+  /\brequiresAuth\b/,
+  /\brequireAuthentication\b/,
+  /\bisAuthenticated\b/,
+  /\bisAuthorized\b/,
+  /\bverifyToken\b/,
+  /\bcheckAuth\b/,
+  /\bensureAuth\b/,
+  /\bauthMiddleware\b/,
+  /\bauthGuard\b/,
+  /\bAuthGuard\b/,
+  /\bJwtAuthGuard\b/,
+  /\bRolesGuard\b/,
+  /\b@UseGuards\b/,
+  /\bauth\.required\b/,
+  /\bjwtAuth\b/,
+  /\btokenAuth\b/,
+  /@login_required/,
+  /@authorize/,
+  /@requires_auth/,
+  /\[Authorize\]/,
+  /\bauthenticate\s*,/,
+  /\bverifyJWT\b/,
+  /\bverifyJwt\b/,
+  /\bcurrentUser\b/,
+  /\brequiresAuthentication\b/,
+  /login_required/,
+  /requires_authentication/,
+  /\bauth\.verify\b/,
+  /\bcheckJwt\b/,
+  /\bAuthenticationRequired\b/,
+  /\bProtected\b/,
+  /\bguardedBy\b/,
+  /middleware.*auth/i,
+  /auth.*middleware/i,
+  // Ruby / Rails (Devise, Sorcery)
+  /authenticate_user!/,
+  /before_action\s*:authenticate/,
+  /require_login/,
+  /authenticate_with_http_basic/,
+];
+
+// Patterns matching import paths that suggest auth middleware
+const AUTH_IMPORT_PATTERNS = [
+  /\bauth\b/i,
+  /\bauthn\b/i,
+  /\bauthz\b/i,
+  /\bauthenticate\b/i,
+  /\brequireAuth\b/i,
+  /middleware[\\/]auth/i,
+  /guards[\\/]/i,
+  /\bjwt\b/i,
+  /passport/i,
+  /\bauthMiddleware\b/i,
+  /\bcanActivate\b/i,
+  /\bauthGuard\b/i,
+];
+
+// Routes that are intentionally public and should not be flagged
+const PUBLIC_ROUTE_ALLOWLIST = [
+  /^\/health\b/,
+  /^\/healthz\b/,
+  /^\/ping\b/,
+  /^\/status\b/,
+  /^\/metrics\b/,
+  /^\/favicon\.ico\b/,
+  /^\/login\b/,
+  /^\/signin\b/,
+  /^\/signup\b/,
+  /^\/register\b/,
+  /^\/auth\//,
+  /^\/oauth\//,
+  /^\/.well-known\//,
+  /^\/public\//,
+  /^\/static\//,
+  /^\/assets\//,
+];
+
+function getLanguage(filePath) {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  if (['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs'].includes(ext)) return 'js';
+  if (ext === 'py') return 'py';
+  if (ext === 'go') return 'go';
+  if (ext === 'rb') return 'rb';
+  if (ext === 'java') return 'java';
+  if (ext === 'cs') return 'cs';
+  return null;
+}
+
+function isRouteHandlerFile(filePath, content) {
+  const lang = getLanguage(filePath);
+  if (!lang) return false;
+  const patterns = ROUTE_PATTERNS[lang] || [];
+  return patterns.some(p => p.test(content));
+}
+
+function extractRoutePaths(lang, content) {
+  const found = new Set();
+  let m;
+
+  if (lang === 'js') {
+    const verbRegex = /\.(get|post|put|delete|patch|all|use)\s*\(\s*['"`]([^'"`\n]+)['"`]/g;
+    while ((m = verbRegex.exec(content)) !== null) found.add(m[2]);
+    // NestJS decorators
+    const nestRegex = /@(Get|Post|Put|Delete|Patch|All)\s*\(\s*['"`]([^'"`\n]*)['"`]/g;
+    while ((m = nestRegex.exec(content)) !== null) found.add(m[2] || '/');
+  } else if (lang === 'py') {
+    const routeRegex = /@\w+(?:\.\w+)*\.(route|get|post|put|delete|patch)\s*\(\s*['"]([^'"]+)['"]/g;
+    while ((m = routeRegex.exec(content)) !== null) found.add(m[2]);
+  } else if (lang === 'go') {
+    const verbRegex = /\.(GET|POST|PUT|DELETE|PATCH|Handle|HandleFunc)\s*\(\s*["']([^"'\n]+)["']/g;
+    while ((m = verbRegex.exec(content)) !== null) found.add(m[2]);
+    const httpRegex = /http\.HandleFunc\s*\(\s*["']([^"'\n]+)["']/g;
+    while ((m = httpRegex.exec(content)) !== null) found.add(m[1]);
+  } else if (lang === 'rb') {
+    const routeRegex = /^\s*(get|post|put|delete|patch)\s+['"]([^'"]+)['"]/gm;
+    while ((m = routeRegex.exec(content)) !== null) found.add(m[2]);
+  } else if (lang === 'java') {
+    const mappingRegex = /@(?:Get|Post|Put|Delete|Patch|Request)Mapping\s*\(\s*(?:value\s*=\s*)?["'{]([^'"{}]+)["']/g;
+    while ((m = mappingRegex.exec(content)) !== null) found.add(m[1]);
+  } else if (lang === 'cs') {
+    const routeRegex = /\[Route\s*\(\s*["']([^"']+)["']/g;
+    while ((m = routeRegex.exec(content)) !== null) found.add(m[1]);
+  }
+
+  return Array.from(found);
+}
+
+function hasInFileAuthCoverage(content) {
+  return AUTH_MARKERS.some(p => p.test(content));
+}
+
+function hasImportAuthCoverage(imports) {
+  return imports.some(imp => AUTH_IMPORT_PATTERNS.some(p => p.test(imp)));
+}
+
+function isPublicRoute(routePath) {
+  return PUBLIC_ROUTE_ALLOWLIST.some(p => p.test(routePath));
+}
+
+/**
+ * Scans a single file for route handlers that lack authentication coverage.
+ *
+ * @param {string} filePath  - repo-relative file path
+ * @param {string} content   - file source text
+ * @param {string[]} imports - resolved import paths from the parser
+ * @returns {Array}          - zero or one issue objects (with _meta for suppression)
+ */
+function scanFileForMissingAuth(filePath, content, imports = []) {
+  if (!isRouteHandlerFile(filePath, content)) return [];
+
+  if (hasInFileAuthCoverage(content)) return [];
+  if (hasImportAuthCoverage(imports)) return [];
+
+  const lang = getLanguage(filePath);
+  const routes = extractRoutePaths(lang, content);
+  const unprotected = routes.filter(r => !isPublicRoute(r));
+
+  // If every extracted route is on the allow-list, this file is fine
+  if (routes.length > 0 && unprotected.length === 0) return [];
+
+  const routeDesc = unprotected.length > 0
+    ? unprotected.slice(0, 6).join(', ') + (unprotected.length > 6 ? ` (+${unprotected.length - 6} more)` : '')
+    : 'route paths not statically determinable';
+
+  return [{
+    repo_id: null, // filled by indexer
+    type: 'missing_auth',
+    severity: 'medium',
+    file_paths: [filePath],
+    description: `Potentially unauthenticated routes: ${routeDesc}. No auth middleware or markers detected in this file. (Rule ID: missing_auth)`,
+    _meta: { rule_id: 'missing_auth', line_number: 0 },
+  }];
+}
+
+module.exports = { scanFileForMissingAuth };

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -2,6 +2,8 @@ const { parseFile } = require('../parsers/repositoryParser');
 const { extractChunksFromFile } = require('../parsers/chunkParser');
 const { scanFileForSecrets } = require('./secretScanner');
 const { scanFileForInsecurePatterns } = require('./sastEngine'); // US-046
+const { scanFileForMissingAuth } = require('./authCoverageScanner'); // US-049
+const { classifyFile } = require('./attackSurfaceClassifier'); // US-047
 const { recordUsage } = require('./usageTracker'); // US-042
 const { isManifestFile, parseManifest } = require('./manifestParser'); // US-045
 const { scanDependencies } = require('./osvScanner'); // US-045
@@ -92,7 +94,7 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     // and fall back to a full index on this run.
     const { data: existingNodeRows } = await supabaseAdmin
       .from('graph_nodes')
-      .select('file_path, content_hash, language, line_count, complexity_score')
+      .select('file_path, content_hash, language, line_count, complexity_score, node_classification')
       .eq('repo_id', repoId);
     const existingNodeMap = new Map((existingNodeRows || []).map(n => [n.file_path, n]));
 
@@ -339,6 +341,22 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
               console.warn(`[indexer] SAST scan failed for ${file.path}: ${sastErr.message}`);
             }
 
+            // Auth coverage check (US-049)
+            try {
+              const authIssues = scanFileForMissingAuth(file.path, file.content, parsed.imports || []);
+              const validAuthIssues = authIssues.filter(is => {
+                const key = `${file.path}:${is._meta.rule_id}:${is._meta.line_number}`;
+                return !suppSet.has(key);
+              });
+              validAuthIssues.forEach(is => {
+                delete is._meta;
+                is.repo_id = repoId;
+                issues.push(is);
+              });
+            } catch (authErr) {
+              console.warn(`[indexer] Auth coverage scan failed for ${file.path}: ${authErr.message}`);
+            }
+
             parsedCount += 1;
             if (parsedCount % 100 === 0) {
               console.log(`[indexer] Parsed ${parsedCount}/${pendingFiles.length} files...`);
@@ -368,6 +386,7 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
           line_count: existing.line_count || 0,
           complexity_score: existing.complexity_score || 1,
           content_hash: existing.content_hash,
+          node_classification: existing.node_classification || null,
           outgoing_count: 0,
           incoming_count: 0,
         });
@@ -408,6 +427,7 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
         incoming_count: 0,
         complexity_score: file.complexity || 1,
         content_hash: originalFile?.contentHash || null,
+        node_classification: originalFile?.content ? classifyFile(file.filePath, originalFile.content) : null,
       });
 
       for (const imp of file.imports) {

--- a/frontend/src/components/CodeReviewPanel.jsx
+++ b/frontend/src/components/CodeReviewPanel.jsx
@@ -17,7 +17,6 @@ import { AlertTriangle, Clock, Code2, FileCode, ShieldAlert, Sparkles, StopCircl
 // ---------------------------------------------------------------------------
 
 const PRESETS = [
-  { id: 'security',     label: 'Security',     hint: 'Focus on injection vulnerabilities, XSS, CSRF, secrets exposure, authentication flaws, and dangerous API usage.' },
   { id: 'performance',  label: 'Performance',  hint: 'Focus on algorithmic complexity, unnecessary re-renders, memory leaks, N+1 queries, and inefficient operations.' },
   { id: 'bugs',         label: 'Bug Hunt',     hint: 'Focus on off-by-one errors, null dereferences, unhandled edge cases, race conditions, and error-handling gaps.' },
   { id: 'architecture', label: 'Architecture', hint: 'Focus on separation of concerns, coupling, abstraction leaks, SOLID principles, and long-term maintainability.' },
@@ -344,7 +343,7 @@ export default function CodeReviewPanel({ repoId, prefill }) {
         {isOverLimit && (
           <p className="mt-2 flex items-center gap-1.5 text-xs text-red-300">
             <AlertTriangle className="h-3.5 w-3.5" />
-            Snippet exceeds 200 lines. Please trim it before submitting.
+            Snippet exceeds {lineLimit} lines. Please trim it before submitting.
           </p>
         )}
 

--- a/frontend/src/components/DependencyGraph.jsx
+++ b/frontend/src/components/DependencyGraph.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useGraphSimulation } from '../hooks/useGraphSimulation';
 import { LANGUAGE_COLORS, formatLanguage } from '../lib/constants';
-import { ChevronDown, ChevronUp, Download, Search, X } from './ui/Icons';
+import { ChevronDown, ChevronUp, Download, Search, Shield, X } from './ui/Icons';
 
 function GraphLegend() {
   const items = [
@@ -238,6 +238,208 @@ function ImpactAnalysisPanel({ impactAnalysis, onClearImpactAnalysis }) {
   );
 }
 
+// ── US-047: Attack surface path finding ──────────────────────────────────────
+
+function findAllPaths(sourceId, adjacency, sinkIds, maxPaths = 50, maxDepth = 20) {
+  const paths = [];
+  function dfs(current, currentPath, visited) {
+    if (paths.length >= maxPaths) return;
+    // Record path when a sink is reached (but keep exploring — the current node
+    // may be a 'both' node that also has outgoing edges leading to further sinks).
+    if (sinkIds.has(current) && current !== sourceId) {
+      paths.push([...currentPath]);
+      if (paths.length >= maxPaths) return;
+    }
+    // Prune depth AFTER recording so a node exactly at maxDepth can still be a sink.
+    if (currentPath.length >= maxDepth) return;
+    for (const neighbor of (adjacency.get(current) || [])) {
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        currentPath.push(neighbor);
+        dfs(neighbor, currentPath, visited);
+        currentPath.pop();
+        visited.delete(neighbor);
+      }
+    }
+  }
+  const visited = new Set([sourceId]);
+  dfs(sourceId, [sourceId], visited);
+  return paths.sort((a, b) => a.length - b.length);
+}
+
+function PathCard({ path, index, nodeMap }) {
+  return (
+    <div className="rounded-xl border border-gray-800 bg-gray-950/70 px-3 py-2.5">
+      <p className="text-xs text-gray-600 mb-1.5">Path {index + 1} · {path.length} {path.length === 1 ? 'hop' : 'hops'}</p>
+      <div className="flex flex-col gap-0.5">
+        {path.map((nodeId, i) => {
+          const node = nodeMap.get(nodeId);
+          const name = (node?.file_path || nodeId).split('/').pop();
+          const isFirst = i === 0;
+          const isLast  = i === path.length - 1;
+          return (
+            <div key={nodeId} className="flex items-center gap-1.5">
+              {i > 0 && <span className="text-gray-700 text-xs shrink-0">→</span>}
+              <span
+                className={`font-mono text-xs truncate ${isFirst ? 'text-red-300' : isLast ? 'text-orange-300' : 'text-yellow-200'}`}
+                title={node?.file_path || nodeId}
+              >
+                {name}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AttackSurfacePanel({ graphNodes, sourceIds, sinkIds, bothIds, selectedSourceId, sourcePaths, perSourcePathCounts, onSelectSource, onClear }) {
+  const [showAll, setShowAll] = useState(false);
+
+  const nodeMap = useMemo(() => new Map(graphNodes.map(n => [n.graphId, n])), [graphNodes]);
+
+  const allSourceCount = sourceIds.size + bothIds.size;
+  const allSinkCount   = sinkIds.size  + bothIds.size;
+
+  const sourceNodeList = useMemo(() =>
+    graphNodes
+      .filter(n => sourceIds.has(n.graphId) || bothIds.has(n.graphId))
+      .sort((a, b) => (perSourcePathCounts.get(b.graphId) || 0) - (perSourcePathCounts.get(a.graphId) || 0)),
+    [graphNodes, sourceIds, bothIds, perSourcePathCounts]
+  );
+
+  // Empty state — no sources or no sinks in this repo
+  if (allSourceCount === 0 || allSinkCount === 0) {
+    return (
+      <aside className="w-full shrink-0 rounded-xl border border-surface-800 bg-surface-900/80 p-5 shadow-panel xl:w-80">
+        <div className="flex h-full flex-col">
+          <div className="mb-5">
+            <p className="text-xs uppercase tracking-[0.2em] text-red-400/80">Attack Surface</p>
+          </div>
+          <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+            No externally reachable endpoints detected — or this repo is a library.
+          </div>
+          <button
+            onClick={onClear}
+            className="mt-auto rounded-xl border border-gray-700 bg-gray-950/80 px-4 py-3 text-sm font-medium text-gray-100 transition hover:border-gray-500 hover:bg-gray-900"
+          >
+            Close
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  // Paths view — a specific source is selected
+  if (selectedSourceId) {
+    const selectedNode = nodeMap.get(selectedSourceId);
+    const visiblePaths = showAll ? sourcePaths : sourcePaths.slice(0, 10);
+    const hiddenCount  = sourcePaths.length - visiblePaths.length;
+    return (
+      <aside className="w-full shrink-0 rounded-xl border border-surface-800 bg-surface-900/80 p-5 shadow-panel transition-all duration-200 xl:w-80">
+        <div className="flex h-full flex-col">
+          <div className="mb-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-red-400/80">Attack Surface — Paths</p>
+            <button
+              onClick={() => { onSelectSource(null); setShowAll(false); }}
+              className="mt-1 text-xs text-indigo-400 transition hover:text-indigo-200"
+            >
+              ← All sources
+            </button>
+            <h3 className="mt-2 break-all font-mono text-xs text-gray-300">{selectedNode?.file_path}</h3>
+          </div>
+
+          {sourcePaths.length === 0 ? (
+            <div className="rounded-xl border border-gray-700 bg-gray-900/50 p-4 text-sm text-gray-400">
+              No paths from this source reach a detected sink.
+            </div>
+          ) : (
+            <>
+              <p className="mb-3 text-sm text-gray-300">
+                <span className="font-semibold text-red-300">{sourcePaths.length === 50 ? '50+' : sourcePaths.length}</span> path{sourcePaths.length !== 1 ? 's' : ''} reach a sink
+              </p>
+              <div className="flex-1 overflow-y-auto space-y-2 pr-0.5">
+                {visiblePaths.map((path, i) => (
+                  <PathCard key={i} path={path} index={i} nodeMap={nodeMap} />
+                ))}
+                {hiddenCount > 0 && !showAll && (
+                  <button
+                    onClick={() => setShowAll(true)}
+                    className="w-full rounded-xl border border-dashed border-gray-700 px-3 py-2 text-xs text-gray-400 transition hover:text-gray-200"
+                  >
+                    ... {hiddenCount} more
+                  </button>
+                )}
+              </div>
+            </>
+          )}
+
+          <button
+            onClick={onClear}
+            className="mt-5 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-100 transition hover:bg-red-500/20"
+          >
+            Close attack surface
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  // Sources list view
+  return (
+    <aside className="w-full shrink-0 rounded-xl border border-surface-800 bg-surface-900/80 p-5 shadow-panel transition-all duration-200 xl:w-80">
+      <div className="flex h-full flex-col">
+        <div className="mb-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-red-400/80">Attack Surface</p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3">
+            <p className="text-xs uppercase tracking-[0.16em] text-red-200/70">Sources</p>
+            <p className="mt-1 text-2xl font-semibold text-red-100">{allSourceCount}</p>
+          </div>
+          <div className="rounded-xl border border-orange-500/30 bg-orange-500/10 p-3">
+            <p className="text-xs uppercase tracking-[0.16em] text-orange-200/70">Sinks</p>
+            <p className="mt-1 text-2xl font-semibold text-orange-100">{allSinkCount}</p>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-2 pr-0.5">
+          {sourceNodeList.map(node => {
+            const pathCount = perSourcePathCounts.get(node.graphId) || 0;
+            const isBoth = bothIds.has(node.graphId);
+            return (
+              <button
+                key={node.graphId}
+                onClick={() => onSelectSource(node.graphId)}
+                className="w-full text-left rounded-xl border border-gray-800 bg-gray-950/70 px-3 py-3 transition hover:border-red-500/40 hover:bg-red-500/10"
+              >
+                <p className="font-mono text-xs text-red-100 break-all">{node.file_path}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  {isBoth && <span className="rounded-full bg-yellow-500/20 px-1.5 py-0.5 text-xs text-yellow-300">source + sink</span>}
+                  <span className="text-xs text-gray-500">
+                    {pathCount > 0
+                      ? <span className="text-orange-300">{pathCount === 50 ? '50+' : pathCount} path{pathCount !== 1 ? 's' : ''} to sink</span>
+                      : 'No sink reachable'}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          onClick={onClear}
+          className="mt-5 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-100 transition hover:bg-red-500/20"
+        >
+          Close attack surface
+        </button>
+      </div>
+    </aside>
+  );
+}
+
 /**
  * Compute directory clusters from flat file nodes.
  * Groups files sharing the same parent directory into a single cluster node.
@@ -356,6 +558,10 @@ export default function DependencyGraph({
   const [clusteringEnabled, setClusteringEnabled] = useState(true);
   const [expandedClusters, setExpandedClusters] = useState(new Set());
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
+
+  // US-047: attack surface state
+  const [attackSurfaceMode, setAttackSurfaceMode]   = useState(false);
+  const [attackSurfaceSource, setAttackSurfaceSource] = useState(null); // graphId of selected source
 
   // Search state
   const [searchBarOpen, setSearchBarOpen] = useState(false);
@@ -548,6 +754,63 @@ export default function DependencyGraph({
     return simNodes.find((node) => node.graphId === primaryId) || null;
   }, [simNodes, selection.primaryId]);
 
+  // US-047: attack surface — classify nodes and compute paths
+  const { asSourceIds, asSinkIds, asBothIds } = useMemo(() => {
+    const src = new Set(), snk = new Set(), both = new Set();
+    graphNodes.forEach(n => {
+      if (n.node_classification === 'source') src.add(n.graphId);
+      else if (n.node_classification === 'sink') snk.add(n.graphId);
+      else if (n.node_classification === 'both') both.add(n.graphId);
+    });
+    return { asSourceIds: src, asSinkIds: snk, asBothIds: both };
+  }, [graphNodes]);
+
+  // Adjacency for path finding (use raw graphEdges, not clustered)
+  const asAdjacency = useMemo(() => {
+    const adj = new Map();
+    graphEdges.forEach(edge => {
+      const src = typeof edge.source === 'object' ? edge.source.graphId : edge.source;
+      const tgt = typeof edge.target === 'object' ? edge.target.graphId : edge.target;
+      if (!adj.has(src)) adj.set(src, []);
+      adj.get(src).push(tgt);
+    });
+    return adj;
+  }, [graphEdges]);
+
+  const allSinkIdsForPaths = useMemo(() => new Set([...asSinkIds, ...asBothIds]), [asSinkIds, asBothIds]);
+  const allSourceIdsForPaths = useMemo(() => new Set([...asSourceIds, ...asBothIds]), [asSourceIds, asBothIds]);
+
+  // Per-source path counts (computed once, used in panel list)
+  const perSourcePathCounts = useMemo(() => {
+    if (!attackSurfaceMode) return new Map();
+    const counts = new Map();
+    for (const sourceId of allSourceIdsForPaths) {
+      counts.set(sourceId, findAllPaths(sourceId, asAdjacency, allSinkIdsForPaths, 50).length);
+    }
+    return counts;
+  }, [attackSurfaceMode, allSourceIdsForPaths, asAdjacency, allSinkIdsForPaths]);
+
+  // Paths from the currently-selected source (used for both panel display and highlighting)
+  const currentSourcePaths = useMemo(() => {
+    if (!attackSurfaceMode || !attackSurfaceSource) return [];
+    return findAllPaths(attackSurfaceSource, asAdjacency, allSinkIdsForPaths, 50);
+  }, [attackSurfaceMode, attackSurfaceSource, asAdjacency, allSinkIdsForPaths]);
+
+  const attackSurfaceData = useMemo(() => {
+    if (!attackSurfaceMode) return null;
+    const pathNodeIds = new Set();
+    const pathEdgeIds = new Set();
+    if (attackSurfaceSource && currentSourcePaths.length > 0) {
+      currentSourcePaths.forEach(path => {
+        path.forEach(id => pathNodeIds.add(id));
+        for (let i = 0; i < path.length - 1; i++) {
+          pathEdgeIds.add(`${path[i]}->${path[i + 1]}`);
+        }
+      });
+    }
+    return { isActive: true, sourceIds: asSourceIds, sinkIds: asSinkIds, bothIds: asBothIds, pathNodeIds, pathEdgeIds };
+  }, [attackSurfaceMode, asSourceIds, asSinkIds, asBothIds, attackSurfaceSource, currentSourcePaths]);
+
   // Search: filter simNodes by file path query
   const searchMatchNodes = useMemo(() => {
     if (!searchQuery.trim()) return [];
@@ -630,6 +893,7 @@ export default function DependencyGraph({
     renderMode,
     selection: effectiveSelection,
     impactAnalysis,
+    attackSurface: attackSurfaceData,
     focusNodeId: searchCurrentNode?.graphId || selection.primaryId,
     onNodeClick: handleNodeClick,
     onNodeContextMenu: handleNodeContextMenu,
@@ -748,6 +1012,27 @@ export default function DependencyGraph({
               <Search className="mr-1.5 inline h-3.5 w-3.5" /> Search
             </button>
             <button
+              onClick={() => {
+                const next = !attackSurfaceMode;
+                setAttackSurfaceMode(next);
+                setAttackSurfaceSource(null);
+                // Clustering uses cluster-level edge IDs that are incompatible with
+                // individual-node path IDs — force flat mode while attack surface is on.
+                if (next) {
+                  setClusteringEnabled(false);
+                  setExpandedClusters(new Set());
+                }
+              }}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                attackSurfaceMode
+                  ? 'border-red-500/50 bg-red-500/15 text-red-300 hover:bg-red-500/25'
+                  : 'border-gray-700 bg-gray-950/80 text-gray-400 hover:border-gray-500 hover:text-gray-200'
+              }`}
+              title="Toggle attack surface mapping (US-047)"
+            >
+              <Shield className="mr-1.5 inline h-3.5 w-3.5" /> Attack Surface
+            </button>
+            <button
               onClick={resetView}
               className="rounded-full border border-gray-700 bg-gray-950/80 px-4 py-2 text-sm font-medium text-gray-100 transition hover:border-gray-500 hover:bg-gray-900"
             >
@@ -792,6 +1077,17 @@ export default function DependencyGraph({
             >
               Analyse impact
             </button>
+            {attackSurfaceMode && (asSourceIds.has(contextMenu.node.graphId) || asBothIds.has(contextMenu.node.graphId)) && (
+              <button
+                onClick={() => {
+                  setAttackSurfaceSource(contextMenu.node.graphId);
+                  setContextMenu(null);
+                }}
+                className="block w-full rounded-lg px-3 py-2 text-left text-sm text-red-300 transition hover:bg-gray-800"
+              >
+                Show reachable paths
+              </button>
+            )}
             <button
               onClick={() => {
                 onChatWithFile?.(contextMenu.node.file_path);
@@ -831,6 +1127,18 @@ export default function DependencyGraph({
 
       {impactAnalysis ? (
         <ImpactAnalysisPanel impactAnalysis={impactAnalysis} onClearImpactAnalysis={onClearImpactAnalysis} />
+      ) : attackSurfaceMode ? (
+        <AttackSurfacePanel
+          graphNodes={graphNodes}
+          sourceIds={asSourceIds}
+          sinkIds={asSinkIds}
+          bothIds={asBothIds}
+          selectedSourceId={attackSurfaceSource}
+          sourcePaths={currentSourcePaths}
+          perSourcePathCounts={perSourcePathCounts}
+          onSelectSource={setAttackSurfaceSource}
+          onClear={() => { setAttackSurfaceMode(false); setAttackSurfaceSource(null); }}
+        />
       ) : (
         <GraphDetailsPanel node={selectedNode} onChatWithFile={onChatWithFile} onAuditFile={onAuditFile} />
       )}

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -4,18 +4,19 @@ import { apiUrl } from '../lib/api';
 import {
   Package, Lock, ShieldAlert, GitMerge,
   FileWarning, Link2, FileX, Search,
-  ChevronDown, ChevronUp, CheckCircle2,
+  ChevronDown, ChevronUp, CheckCircle2, AlertTriangle,
 } from './ui/Icons';
 
 // ── Group config ─────────────────────────────────────────────────────────────
 const GROUP_ORDER = [
-  { type: 'vulnerable_dependency', label: 'Vulnerable Dependencies',  Icon: Package      },
-  { type: 'hardcoded_secret',      label: 'Hardcoded Secrets',        Icon: Lock         },
-  { type: 'insecure_pattern',      label: 'Insecure Code Patterns',   Icon: ShieldAlert  },
-  { type: 'circular_dependency',   label: 'Circular Dependencies',    Icon: GitMerge     },
-  { type: 'god_file',              label: 'God Files',                Icon: FileWarning  },
-  { type: 'high_coupling',         label: 'High Coupling',            Icon: Link2        },
-  { type: 'dead_code',             label: 'Dead Code',                Icon: FileX        },
+  { type: 'vulnerable_dependency', label: 'Vulnerable Dependencies',           Icon: Package       },
+  { type: 'hardcoded_secret',      label: 'Hardcoded Secrets',                 Icon: Lock          },
+  { type: 'missing_auth',          label: 'Potentially Unauthenticated Routes', Icon: AlertTriangle },
+  { type: 'insecure_pattern',      label: 'Insecure Code Patterns',            Icon: ShieldAlert   },
+  { type: 'circular_dependency',   label: 'Circular Dependencies',             Icon: GitMerge      },
+  { type: 'god_file',              label: 'God Files',                         Icon: FileWarning   },
+  { type: 'high_coupling',         label: 'High Coupling',                     Icon: Link2         },
+  { type: 'dead_code',             label: 'Dead Code',                         Icon: FileX         },
 ];
 
 function getBadgeStyles(severity) {
@@ -98,6 +99,17 @@ const IssueCard = memo(function IssueCard({ issue, type, onIssueClick, onSuppres
             className="text-xs text-gray-500 hover:text-gray-200 underline transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             Mark as false positive
+          </button>
+        )}
+
+        {/* Suppress button for unauthenticated routes */}
+        {type === 'missing_auth' && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onSuppress(e, issue); }}
+            disabled={actionsDisabled}
+            className="text-xs text-gray-500 hover:text-gray-200 underline transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Mark as intentionally public
           </button>
         )}
 
@@ -228,13 +240,13 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
     e.stopPropagation();
     if (!canMutateIssues) return;
     const ruleMatch = issue.description.match(/Rule ID: (.*?)\)/);
+    if (!ruleMatch) return;
     const lineMatch = issue.description.match(/line (\d+)/);
-    if (!ruleMatch || !lineMatch) return;
 
     const payload = {
       file_path:   issue.file_paths[0],
       rule_id:     ruleMatch[1],
-      line_number: parseInt(lineMatch[1], 10),
+      line_number: lineMatch ? parseInt(lineMatch[1], 10) : 0,
     };
     try {
       const res = await fetch(apiUrl(`/api/analysis/${repoId}/issues/suppress`), {

--- a/frontend/src/hooks/useGraphSimulation.js
+++ b/frontend/src/hooks/useGraphSimulation.js
@@ -28,6 +28,7 @@ export function useGraphSimulation({
   renderMode,
   selection,
   impactAnalysis,
+  attackSurface,
   focusNodeId,
   onNodeClick,
   onNodeContextMenu,
@@ -163,7 +164,20 @@ export function useGraphSimulation({
       ...transitiveImpactIds,
     ].filter(Boolean));
 
+    const isAttackSurfaceActive = Boolean(attackSurface?.isActive);
+    const asSourceIds   = attackSurface?.sourceIds   || new Set();
+    const asSinkIds     = attackSurface?.sinkIds     || new Set();
+    const asBothIds     = attackSurface?.bothIds     || new Set();
+    const asPathNodeIds = attackSurface?.pathNodeIds || new Set();
+    const asPathEdgeIds = attackSurface?.pathEdgeIds || new Set();
+    const hasPathHighlight = asPathNodeIds.size > 0;
+
     const getNodeOpacity = (nodeId) => {
+      if (isAttackSurfaceActive) {
+        if (asSourceIds.has(nodeId) || asSinkIds.has(nodeId) || asBothIds.has(nodeId)) return 1;
+        if (asPathNodeIds.has(nodeId)) return 1;
+        return hasPathHighlight ? 0.08 : 0.12;
+      }
       if (isImpactActive) {
         return impactedNodeIds.has(nodeId) ? 1 : 0.12;
       }
@@ -171,6 +185,12 @@ export function useGraphSimulation({
     };
 
     const getEdgeOpacity = (edge) => {
+      if (isAttackSurfaceActive) {
+        if (hasPathHighlight) {
+          return asPathEdgeIds.has(edge.id) ? 0.9 : 0.06;
+        }
+        return 0.12;
+      }
       if (isImpactActive) {
         const sourceId = typeof edge.source === 'object' ? edge.source.graphId : edge.source;
         const targetId = typeof edge.target === 'object' ? edge.target.graphId : edge.target;
@@ -180,6 +200,14 @@ export function useGraphSimulation({
     };
 
     const getNodeFill = (node) => {
+      if (isAttackSurfaceActive) {
+        const id = node.graphId;
+        if (asBothIds.has(id))     return '#eab308'; // yellow  — source + sink
+        if (asSourceIds.has(id))   return '#dc2626'; // red     — source
+        if (asSinkIds.has(id))     return '#f97316'; // orange  — sink
+        if (asPathNodeIds.has(id)) return '#facc15'; // amber   — intermediate path node
+        return node.fill;
+      }
       if (!isImpactActive) return node.fill;
       if (impactAnalysis?.sourceId === node.graphId) return '#ef4444';
       if (directImpactIds.has(node.graphId) || transitiveImpactIds.has(node.graphId)) return '#f59e0b';
@@ -187,6 +215,14 @@ export function useGraphSimulation({
     };
 
     const getNodeStroke = (node) => {
+      if (isAttackSurfaceActive) {
+        const id = node.graphId;
+        if (asBothIds.has(id))     return '#fde047'; // yellow-300
+        if (asSourceIds.has(id))   return '#fca5a5'; // red-300
+        if (asSinkIds.has(id))     return '#fdba74'; // orange-300
+        if (asPathNodeIds.has(id)) return '#fef08a'; // yellow-200
+        return 'rgba(255, 255, 255, 0.06)';
+      }
       if (isImpactActive) {
         if (impactAnalysis?.sourceId === node.graphId) return '#fecaca';
         if (directImpactIds.has(node.graphId) || transitiveImpactIds.has(node.graphId)) return '#fde68a';
@@ -197,6 +233,12 @@ export function useGraphSimulation({
     };
 
     const getNodeStrokeWidth = (node) => {
+      if (isAttackSurfaceActive) {
+        const id = node.graphId;
+        if (asSourceIds.has(id) || asSinkIds.has(id) || asBothIds.has(id)) return 3.5;
+        if (asPathNodeIds.has(id)) return 2.5;
+        return 1;
+      }
       if (isImpactActive) {
         if (impactAnalysis?.sourceId === node.graphId) return 3.5;
         if (directImpactIds.has(node.graphId) || transitiveImpactIds.has(node.graphId)) return 2.5;
@@ -245,11 +287,14 @@ export function useGraphSimulation({
           const endY = target.y - ((target.radius + 2) * Math.sin(angle));
 
           const lineOpacity = getEdgeOpacity(link);
-          const isHighlightedEdge = highlightedEdgeIds.has(link.id) || isImpactActive;
-          const edgeColor = isImpactActive ? `rgba(245, 158, 11, ${lineOpacity})` : `rgba(148, 163, 184, ${lineOpacity})`;
+          const isPathEdge = isAttackSurfaceActive && asPathEdgeIds.has(link.id);
+          const isHighlightedEdge = highlightedEdgeIds.has(link.id) || isImpactActive || isPathEdge;
+          const edgeColor = isAttackSurfaceActive
+            ? (isPathEdge ? `rgba(250, 204, 21, ${lineOpacity})` : `rgba(148, 163, 184, ${lineOpacity})`)
+            : isImpactActive ? `rgba(245, 158, 11, ${lineOpacity})` : `rgba(148, 163, 184, ${lineOpacity})`;
 
           context.strokeStyle = edgeColor;
-          context.lineWidth = isImpactActive ? 1.8 : isHighlightedEdge ? 1.8 : 1.2;
+          context.lineWidth = (isImpactActive || isPathEdge) ? 1.8 : isHighlightedEdge ? 1.8 : 1.2;
 
           if (isHighlightedEdge) {
             context.setLineDash([6, 4]);
@@ -358,7 +403,7 @@ export function useGraphSimulation({
         canvasSelection.call(zoomBehavior.transform, canvasTransformRef.current);
       }
 
-      if (isSelectionActive || isImpactActive) {
+      if (isSelectionActive || isImpactActive || (isAttackSurfaceActive && hasPathHighlight)) {
         animateDraw();
       } else {
         draw();
@@ -433,8 +478,9 @@ export function useGraphSimulation({
       .data(localLinks, (edge) => edge.id)
       .join('path')
       .attr('class', (edge) => {
-        const isDimmed = !isImpactActive && isSelectionActive && !highlightedEdgeIds.has(edge.id);
-        const isFlow = (isImpactActive || highlightedEdgeIds.has(edge.id)) && !isDimmed;
+        const isDimmed = !isImpactActive && !isAttackSurfaceActive && isSelectionActive && !highlightedEdgeIds.has(edge.id);
+        const isPathFlow = isAttackSurfaceActive && asPathEdgeIds.has(edge.id);
+        const isFlow = (isImpactActive || highlightedEdgeIds.has(edge.id) || isPathFlow) && !isDimmed;
         return `graph-edge${isDimmed ? ' is-dimmed' : ''}${isFlow ? ' graph-edge-flow' : ''}`;
       })
       .attr('d', (edge) => {
@@ -447,7 +493,10 @@ export function useGraphSimulation({
         return `M${edge.source.x},${edge.source.y}A${dr},${dr} 0 0,1 ${edge.target.x},${edge.target.y}`;
       })
       .attr('fill', 'none')
-      .attr('stroke', () => (isImpactActive ? '#f59e0b' : '#64748b'))
+      .attr('stroke', (edge) => {
+        if (isAttackSurfaceActive && asPathEdgeIds.has(edge.id)) return '#facc15';
+        return isImpactActive ? '#f59e0b' : '#64748b';
+      })
       .attr('stroke-opacity', (edge) => getEdgeOpacity(edge))
       .attr('stroke-width', (edge) => (isImpactActive ? 1.8 : highlightedEdgeIds.has(edge.id) ? 2 : 1.2));
 
@@ -461,7 +510,7 @@ export function useGraphSimulation({
       svgAnimationFrame = window.requestAnimationFrame(animateSvgFlow);
     };
 
-    if (isSelectionActive || isImpactActive) {
+    if (isSelectionActive || isImpactActive || (isAttackSurfaceActive && hasPathHighlight)) {
       animateSvgFlow();
     }
 
@@ -605,6 +654,7 @@ export function useGraphSimulation({
     renderMode,
     selection,
     impactAnalysis,
+    attackSurface,
     focusNodeId,
     onBackgroundClick,
     onNodeClick,

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -31,6 +31,8 @@ COMMIT;
 ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'insecure_pattern';
 COMMIT;
 ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'hardcoded_secret';
+COMMIT;
+ALTER TYPE issue_type ADD VALUE IF NOT EXISTS 'missing_auth';
 
 -- =============================================================================
 -- FUNCTIONS — Vault wrappers (US-039)
@@ -174,6 +176,8 @@ CREATE TABLE IF NOT EXISTS graph_nodes (
 
 -- Migration for existing deployments: add content_hash if it doesn't exist
 ALTER TABLE graph_nodes ADD COLUMN IF NOT EXISTS content_hash TEXT;
+-- US-047: attack surface classification ('source', 'sink', 'both', or null)
+ALTER TABLE graph_nodes ADD COLUMN IF NOT EXISTS node_classification TEXT;
 
 CREATE INDEX IF NOT EXISTS graph_nodes_repo_id_idx ON graph_nodes (repo_id);
 


### PR DESCRIPTION
US-047 — Attack surface mapping
Classifies every indexed file as source (HTTP route handlers, CLI entry
points, stdin readers), sink (SQL execution, shell commands, filesystem
writes, deserialisation, dynamic outbound HTTP), or both. Classification
is stored in a new graph_nodes.node_classification column and preserved
across incremental re-indexes.

Frontend adds an "Attack Surface" toggle on the dependency graph. When
active, sources render in red, sinks in orange, both-nodes in yellow, and
unclassified nodes dim to 12% opacity. Clicking a source in the side panel
runs a client-side DFS (capped at 50 paths, depth 20) and highlights every
source→sink path with animated yellow edges. The panel lists all sources
with per-source path counts and a drillable path view with "…N more"
expand. Repos with zero sources or sinks show a positive empty state.

US-049 — Authentication coverage check
During indexing, each source file is checked for route-registration
patterns across JS/TS, Python, Go, Ruby, Java, C#, and Rust, then tested
for auth coverage via in-file markers (passport.authenticate, requireAuth,
@login_required, [Authorize], Devise authenticate_user!, etc.) and
auth-sounding import paths (auth, jwt, passport, guards/, …). Files with
unprotected routes emit a missing_auth analysis issue (medium severity)
with the specific route paths named in the description. A public-route
allow-list covers /health, /login, /auth/*, /oauth/*, and friends.

The Issues panel groups these under "Potentially Unauthenticated Routes"
with a per-issue "Mark as intentionally public" button that writes to
issue_suppressions and removes the issue immediately. Suppressions persist
across re-indexes via the existing suppSet mechanism.

Also fixes bugs found during review:
- DFS (US-047) records a path at a sink and continues exploring instead of
  returning immediately, so paths through 'both' nodes are no longer missed
- maxDepth check moved after sink recording so nodes at the depth limit are
  still eligible to be recorded
- Enabling attack surface mode forces flat graph rendering; cluster edge IDs
  are incompatible with individual-node path IDs
- /\bsession\b/i removed from auth import patterns — too broad, suppressed
  issues on any file importing a session library regardless of auth intent