### PR TITLE
implement US-051: architectural diff between branches or commits

### DIFF
--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -823,4 +823,107 @@ const getDuplication = async (req, res) => {
   }
 };
 
-module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData, updateRepo, generateWebhook, getFileContent, getDependencies, getChurn, getDuplication };
+/**
+ * GET /api/repos/:repoId/diff?base=<ref>&head=<ref>
+ * Computes or returns a cached architectural diff between two git refs (US-051).
+ * Only supported for GitHub-sourced repositories.
+ */
+const getDiff = async (req, res) => {
+  const { repoId } = req.params;
+  const { base, head } = req.query;
+
+  if (!base || !head) {
+    return res.status(400).json({ error: 'base and head query params are required' });
+  }
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  const { data: repo, error: repoError } = await supabaseAdmin
+    .from('repositories')
+    .select('id, name, full_name, source, default_branch')
+    .eq('id', repoId)
+    .single();
+
+  if (repoError || !repo) return res.status(404).json({ error: 'Repository not found' });
+  if (repo.source !== 'github') {
+    return res.status(400).json({ error: 'Architectural diff is only supported for GitHub repositories' });
+  }
+
+  const fullName = repo.full_name || repo.name || '';
+  const [owner, repoName] = fullName.split('/');
+  if (!owner || !repoName) {
+    return res.status(400).json({ error: 'Repository full_name is missing or invalid' });
+  }
+
+  const githubToken = await _getGithubTokenForUser(req.user.id);
+  if (!githubToken) return res.status(400).json({ error: 'GitHub token not found' });
+
+  try {
+    const octokit = new Octokit({ auth: githubToken });
+
+    // Resolve refs to commit SHAs so we can key the cache on stable SHAs
+    const [baseResult, headResult] = await Promise.allSettled([
+      octokit.rest.repos.getCommit({ owner, repo: repoName, ref: base }),
+      octokit.rest.repos.getCommit({ owner, repo: repoName, ref: head }),
+    ]);
+
+    if (baseResult.status === 'rejected') {
+      return res.status(400).json({ error: `Could not resolve base ref "${base}": ${baseResult.reason?.message}` });
+    }
+    if (headResult.status === 'rejected') {
+      return res.status(400).json({ error: `Could not resolve head ref "${head}": ${headResult.reason?.message}` });
+    }
+
+    const baseSha = baseResult.value.data.sha;
+    const headSha = headResult.value.data.sha;
+    const baseTreeSha = baseResult.value.data.commit.tree.sha;
+    const headTreeSha = headResult.value.data.commit.tree.sha;
+
+    // Cache lookup by stable SHAs
+    const { data: cached } = await supabaseAdmin
+      .from('diff_cache')
+      .select('result_json')
+      .eq('repo_id', repoId)
+      .eq('base_sha', baseSha)
+      .eq('head_sha', headSha)
+      .maybeSingle();
+
+    if (cached?.result_json) {
+      return res.json(cached.result_json);
+    }
+
+    const { computeArchDiff } = require('../services/diffService');
+    const diff = await computeArchDiff({
+      owner,
+      name: repoName,
+      token: githubToken,
+      baseRef: base,
+      headRef: head,
+      baseCommit: { sha: baseSha, treeSha: baseTreeSha },
+      headCommit: { sha: headSha, treeSha: headTreeSha },
+    });
+
+    // Persist to cache (best-effort; failure must not break the response)
+    supabaseAdmin
+      .from('diff_cache')
+      .upsert({
+        repo_id: repoId,
+        base_sha: baseSha,
+        head_sha: headSha,
+        base_ref: base,
+        head_ref: head,
+        result_json: diff,
+      }, { onConflict: 'repo_id,base_sha,head_sha' })
+      .then(({ error }) => {
+        if (error) console.warn('[getDiff] Cache write failed:', error.message);
+      });
+
+    res.json(diff);
+  } catch (err) {
+    console.error('[getDiff] Error:', err);
+    res.status(500).json({ error: err.message || 'Failed to compute architectural diff' });
+  }
+};
+
+module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData, updateRepo, generateWebhook, getFileContent, getDependencies, getChurn, getDuplication, getDiff };

--- a/backend/src/routes/repo.js
+++ b/backend/src/routes/repo.js
@@ -50,4 +50,7 @@ router.get('/:repoId/churn', requireAuth, repoController.getChurn);
 // Fetch duplicate code clusters (US-052)
 router.get('/:repoId/duplication', requireAuth, repoController.getDuplication);
 
+// Compute or retrieve cached architectural diff between two refs (US-051)
+router.get('/:repoId/diff', requireAuth, repoController.getDiff);
+
 module.exports = router;

--- a/backend/src/services/diffService.js
+++ b/backend/src/services/diffService.js
@@ -1,0 +1,361 @@
+/**
+ * diffService.js — US-051: Architectural diff between branches or commits.
+ *
+ * Computes a structural diff (nodes, edges, new issues) between two git refs
+ * without touching the primary index tables.
+ */
+
+const path = require('path');
+const { Octokit } = require('octokit');
+const { parseFile } = require('../parsers/repositoryParser');
+const pLimit = require('p-limit');
+
+const VALID_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.py', '.cs', '.go', '.java', '.rs', '.rb']);
+const SKIP_DIRS = new Set(['node_modules', '.git', 'vendor', '__pycache__', 'dist', 'build', '.next', 'coverage', '.cache']);
+
+function getLanguage(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (['.js', '.jsx'].includes(ext)) return 'javascript';
+  if (['.ts', '.tsx'].includes(ext)) return 'typescript';
+  if (ext === '.py') return 'python';
+  if (ext === '.cs') return 'c_sharp';
+  if (ext === '.go') return 'go';
+  if (ext === '.java') return 'java';
+  if (ext === '.rs') return 'rust';
+  if (ext === '.rb') return 'ruby';
+  return 'unknown';
+}
+
+function shouldSkipPath(filePath) {
+  return filePath.split('/').some((part) => SKIP_DIRS.has(part));
+}
+
+async function resolveRefToCommit(octokit, owner, repo, ref) {
+  try {
+    const { data } = await octokit.rest.repos.getCommit({ owner, repo, ref });
+    return { sha: data.sha, treeSha: data.commit.tree.sha };
+  } catch (err) {
+    throw new Error(`Could not resolve ref "${ref}": ${err.message}`);
+  }
+}
+
+async function fetchCodeTree(octokit, owner, repo, treeSha) {
+  const { data } = await octokit.rest.git.getTree({
+    owner,
+    repo,
+    tree_sha: treeSha,
+    recursive: '1',
+  });
+
+  const files = new Map();
+  for (const item of data.tree || []) {
+    if (item.type !== 'blob') continue;
+    const ext = path.extname(item.path).toLowerCase();
+    if (!VALID_EXTENSIONS.has(ext)) continue;
+    if (shouldSkipPath(item.path)) continue;
+    files.set(item.path, { sha: item.sha, size: item.size || 0 });
+  }
+  return files;
+}
+
+async function fetchBlob(octokit, owner, repo, sha) {
+  const { data } = await octokit.rest.git.getBlob({ owner, repo, file_sha: sha });
+  return Buffer.from(data.content, data.encoding).toString('utf-8');
+}
+
+/**
+ * Compute a structural architectural diff between two git refs.
+ *
+ * @param {Object} params
+ * @param {string} params.owner   - GitHub owner (login)
+ * @param {string} params.name    - GitHub repo name
+ * @param {string} params.token   - GitHub access token
+ * @param {string} params.baseRef - Base ref (branch name, tag, or SHA)
+ * @param {string} params.headRef - Head ref (branch name, tag, or SHA)
+ * @param {{ sha: string, treeSha: string }} [params.baseCommit] - Pre-resolved base commit (skip resolution)
+ * @param {{ sha: string, treeSha: string }} [params.headCommit] - Pre-resolved head commit
+ * @returns {Promise<Object>} Structured diff payload
+ */
+async function computeArchDiff({ owner, name, token, baseRef, headRef, baseCommit: preBase, headCommit: preHead }) {
+  const octokit = new Octokit({ auth: token });
+
+  const [baseCommit, headCommit] = preBase && preHead
+    ? [preBase, preHead]
+    : await Promise.all([
+        resolveRefToCommit(octokit, owner, name, baseRef),
+        resolveRefToCommit(octokit, owner, name, headRef),
+      ]);
+
+  if (baseCommit.sha === headCommit.sha) {
+    return {
+      base_ref: baseRef,
+      head_ref: headRef,
+      base_sha: baseCommit.sha,
+      head_sha: headCommit.sha,
+      identical: true,
+      summary: {
+        added_files: 0,
+        removed_files: 0,
+        modified_files: 0,
+        unchanged_files: 0,
+        added_edges: 0,
+        removed_edges: 0,
+        new_issues: [],
+        complexity_deltas: [],
+      },
+      nodes: [],
+      edges: { added: [], removed: [] },
+    };
+  }
+
+  const [baseFiles, headFiles] = await Promise.all([
+    fetchCodeTree(octokit, owner, name, baseCommit.treeSha),
+    fetchCodeTree(octokit, owner, name, headCommit.treeSha),
+  ]);
+
+  // Classify each file by diff status
+  const addedPaths = [];
+  const removedPaths = [];
+  const modifiedPaths = [];
+  const unchangedPaths = [];
+
+  const allPaths = new Set([...baseFiles.keys(), ...headFiles.keys()]);
+  for (const p of allPaths) {
+    const inBase = baseFiles.has(p);
+    const inHead = headFiles.has(p);
+    if (inBase && !inHead) {
+      removedPaths.push(p);
+    } else if (!inBase && inHead) {
+      addedPaths.push(p);
+    } else if (baseFiles.get(p).sha !== headFiles.get(p).sha) {
+      modifiedPaths.push(p);
+    } else {
+      unchangedPaths.push(p);
+    }
+  }
+
+  // Fetch content only for changed files, capped to avoid timeout on huge diffs.
+  // modifiedPaths must appear in both lists — apply a shared budget so removed files
+  // are not crowded out when there are many modified ones.
+  const MAX_BLOBS = 300;
+  const changedInHead = [...addedPaths, ...modifiedPaths].slice(0, MAX_BLOBS);
+  // Prioritise removedPaths first so they always get their base content; modified
+  // entries that exceed the cap will be missing base data but still appear in headNodes.
+  const changedInBase = [...removedPaths, ...modifiedPaths].slice(0, MAX_BLOBS);
+
+  const limit = pLimit(8);
+  const headContents = new Map();
+  const baseContents = new Map();
+
+  await Promise.all([
+    ...changedInHead.map((p) => limit(async () => {
+      try {
+        headContents.set(p, await fetchBlob(octokit, owner, name, headFiles.get(p).sha));
+      } catch (e) {
+        console.warn(`[diffService] Failed to fetch ${p}@head: ${e.message}`);
+      }
+    })),
+    ...changedInBase.map((p) => limit(async () => {
+      try {
+        baseContents.set(p, await fetchBlob(octokit, owner, name, baseFiles.get(p).sha));
+      } catch (e) {
+        console.warn(`[diffService] Failed to fetch ${p}@base: ${e.message}`);
+      }
+    })),
+  ]);
+
+  // Parse all fetched file contents
+  const headNodes = new Map();
+  const baseNodes = new Map();
+  const allHeadPaths = new Set(headFiles.keys());
+  const allBasePaths = new Set(baseFiles.keys());
+
+  for (const [p, content] of headContents) {
+    try {
+      const parsed = parseFile(p, content, allHeadPaths);
+      headNodes.set(p, {
+        file_path: p,
+        language: getLanguage(p),
+        line_count: content.split('\n').length,
+        complexity_score: parsed.complexity || 1,
+        imports: parsed.imports || [],
+      });
+    } catch (e) {
+      console.warn(`[diffService] Failed to parse ${p}@head: ${e.message}`);
+    }
+  }
+
+  for (const [p, content] of baseContents) {
+    try {
+      const parsed = parseFile(p, content, allBasePaths);
+      baseNodes.set(p, {
+        file_path: p,
+        language: getLanguage(p),
+        line_count: content.split('\n').length,
+        complexity_score: parsed.complexity || 1,
+        imports: parsed.imports || [],
+      });
+    } catch (e) {
+      console.warn(`[diffService] Failed to parse ${p}@base: ${e.message}`);
+    }
+  }
+
+  // Build edge sets from changed-file imports
+  const headEdgeSet = new Set();
+  const baseEdgeSet = new Set();
+
+  for (const [p, node] of headNodes) {
+    for (const imp of node.imports) {
+      headEdgeSet.add(`${p}\x00${imp}`);
+    }
+  }
+
+  for (const [p, node] of baseNodes) {
+    for (const imp of node.imports) {
+      baseEdgeSet.add(`${p}\x00${imp}`);
+    }
+  }
+
+  const addedEdges = [];
+  const removedEdges = [];
+
+  for (const e of headEdgeSet) {
+    if (!baseEdgeSet.has(e)) {
+      const sep = e.indexOf('\x00');
+      addedEdges.push({ from_path: e.slice(0, sep), to_path: e.slice(sep + 1) });
+    }
+  }
+
+  for (const e of baseEdgeSet) {
+    if (!headEdgeSet.has(e)) {
+      const sep = e.indexOf('\x00');
+      removedEdges.push({ from_path: e.slice(0, sep), to_path: e.slice(sep + 1) });
+    }
+  }
+
+  // Complexity deltas for modified files
+  const complexityDeltas = [];
+  for (const p of modifiedPaths) {
+    const headNode = headNodes.get(p);
+    const baseNode = baseNodes.get(p);
+    if (headNode && baseNode) {
+      complexityDeltas.push({
+        file_path: p,
+        base_complexity: baseNode.complexity_score,
+        head_complexity: headNode.complexity_score,
+        delta: headNode.complexity_score - baseNode.complexity_score,
+        base_lines: baseNode.line_count,
+        head_lines: headNode.line_count,
+      });
+    }
+  }
+  complexityDeltas.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+
+  // Detect new architectural issues in head that weren't present in base.
+  // The canonical god-file definition also checks incoming_count (coupling), but that
+  // requires the full repo graph which isn't available in a diff-only parse.
+  // We apply the two complexity/size conditions that ARE computable here:
+  //   • complexity_score > 30
+  //   • line_count > 500  (the full rule is line_count > 500 AND high coupling, but we
+  //     flag it conservatively; users can verify incoming_count in the main Issues panel)
+  const newIssues = [];
+
+  for (const p of [...addedPaths, ...modifiedPaths]) {
+    const headNode = headNodes.get(p);
+    if (!headNode) continue;
+
+    const isGodFileNow = headNode.complexity_score > 30 || headNode.line_count > 500;
+    if (isGodFileNow) {
+      const baseNode = baseNodes.get(p);
+      const wasGodFile = baseNode && (baseNode.complexity_score > 30 || baseNode.line_count > 500);
+      if (!wasGodFile) {
+        newIssues.push({
+          type: 'god_file',
+          severity: 'medium',
+          file_path: p,
+          description: `${p} newly exceeds god-file thresholds (complexity: ${headNode.complexity_score}, lines: ${headNode.line_count})`,
+        });
+      }
+    }
+
+    const outgoingCount = headNode.imports.length;
+    if (outgoingCount > 15) {
+      const baseNode = baseNodes.get(p);
+      const wasHighCoupling = baseNode && baseNode.imports.length > 15;
+      if (!wasHighCoupling) {
+        const sev = outgoingCount >= 30 ? 'high' : outgoingCount >= 20 ? 'medium' : 'low';
+        newIssues.push({
+          type: 'high_coupling',
+          severity: sev,
+          file_path: p,
+          description: `${p} newly has ${outgoingCount} outgoing dependencies`,
+        });
+      }
+    }
+  }
+
+  // Build the diff node list
+  const diffNodes = [];
+
+  for (const p of addedPaths) {
+    const node = headNodes.get(p);
+    diffNodes.push({
+      file_path: p,
+      language: getLanguage(p),
+      status: 'added',
+      complexity_score: node?.complexity_score ?? 0,
+      line_count: node?.line_count ?? 0,
+    });
+  }
+
+  for (const p of removedPaths) {
+    const node = baseNodes.get(p);
+    diffNodes.push({
+      file_path: p,
+      language: getLanguage(p),
+      status: 'removed',
+      complexity_score: node?.complexity_score ?? 0,
+      line_count: node?.line_count ?? 0,
+    });
+  }
+
+  for (const p of modifiedPaths) {
+    const headNode = headNodes.get(p);
+    const baseNode = baseNodes.get(p);
+    diffNodes.push({
+      file_path: p,
+      language: getLanguage(p),
+      status: 'modified',
+      complexity_score: headNode?.complexity_score ?? 0,
+      line_count: headNode?.line_count ?? 0,
+      base_complexity: baseNode?.complexity_score ?? 0,
+      base_line_count: baseNode?.line_count ?? 0,
+    });
+  }
+
+  for (const p of unchangedPaths) {
+    diffNodes.push({ file_path: p, language: getLanguage(p), status: 'unchanged' });
+  }
+
+  return {
+    base_ref: baseRef,
+    head_ref: headRef,
+    base_sha: baseCommit.sha,
+    head_sha: headCommit.sha,
+    identical: false,
+    summary: {
+      added_files: addedPaths.length,
+      removed_files: removedPaths.length,
+      modified_files: modifiedPaths.length,
+      unchanged_files: unchangedPaths.length,
+      added_edges: addedEdges.length,
+      removed_edges: removedEdges.length,
+      new_issues: newIssues,
+      complexity_deltas: complexityDeltas,
+    },
+    nodes: diffNodes,
+    edges: { added: addedEdges, removed: removedEdges },
+  };
+}
+
+module.exports = { computeArchDiff };

--- a/frontend/src/components/ArchDiffModal.jsx
+++ b/frontend/src/components/ArchDiffModal.jsx
@@ -1,0 +1,721 @@
+/**
+ * ArchDiffModal — US-051: Architectural diff between branches or commits.
+ *
+ * A full-screen overlay that lets the user compare two git refs and see
+ * the structural changes: added / removed / modified files, edge changes,
+ * new issues introduced, and a per-file complexity delta table.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { apiUrl } from '../lib/api';
+import {
+  Button, Badge, EmptyState, Panel,
+} from './ui/Primitives';
+import {
+  X, GitCompare, GitBranch, Plus, Minus, AlertTriangle,
+  FileCode, ArrowRight, TrendingUp, TrendingDown,
+  GitMerge, FileWarning, Link2, RefreshCw, Info,
+} from './ui/Icons';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function basename(filePath) {
+  const parts = (filePath || '').replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] || filePath;
+}
+
+function statusColor(status) {
+  switch (status) {
+    case 'added':    return 'text-emerald-400';
+    case 'removed':  return 'text-red-400';
+    case 'modified': return 'text-amber-400';
+    default:         return 'text-gray-500';
+  }
+}
+
+function statusBg(status) {
+  switch (status) {
+    case 'added':    return 'bg-emerald-500/10 border-emerald-500/20 text-emerald-300';
+    case 'removed':  return 'bg-red-500/10 border-red-500/20 text-red-300';
+    case 'modified': return 'bg-amber-500/10 border-amber-500/20 text-amber-300';
+    default:         return 'bg-gray-800/50 border-gray-700/50 text-gray-400';
+  }
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case 'added':    return '+added';
+    case 'removed':  return '−removed';
+    case 'modified': return '~modified';
+    default:         return 'unchanged';
+  }
+}
+
+function issueIcon(type) {
+  switch (type) {
+    case 'god_file':      return FileWarning;
+    case 'high_coupling': return Link2;
+    case 'circular_dependency': return GitMerge;
+    default:              return AlertTriangle;
+  }
+}
+
+function severityBadge(severity) {
+  switch (severity) {
+    case 'high':   return 'bg-red-500/15 text-red-300 border border-red-500/25';
+    case 'medium': return 'bg-amber-500/15 text-amber-300 border border-amber-500/25';
+    default:       return 'bg-blue-500/15 text-blue-300 border border-blue-500/25';
+  }
+}
+
+// ── Stat card ─────────────────────────────────────────────────────────────
+
+function StatCard({ label, value, icon: Icon, tone = 'neutral' }) {
+  const toneMap = {
+    neutral: 'text-gray-300',
+    green:   'text-emerald-400',
+    red:     'text-red-400',
+    amber:   'text-amber-400',
+    blue:    'text-blue-400',
+    purple:  'text-purple-400',
+  };
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-3 min-w-0">
+      <div className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wider">
+        {Icon && <Icon className="h-3 w-3" />}
+        {label}
+      </div>
+      <span className={`text-2xl font-bold tabular-nums ${toneMap[tone]}`}>{value}</span>
+    </div>
+  );
+}
+
+// ── File row ──────────────────────────────────────────────────────────────
+
+function FileRow({ node }) {
+  if (node.status === 'unchanged') return null;
+  return (
+    <div className="flex items-center gap-3 py-2 border-b border-gray-800/50 last:border-0 text-sm">
+      <span className={`font-mono text-xs px-1.5 py-0.5 rounded border ${statusBg(node.status)}`}>
+        {statusLabel(node.status)}
+      </span>
+      <span className="flex-1 min-w-0 truncate text-gray-300 font-mono text-xs" title={node.file_path}>
+        {node.file_path}
+      </span>
+      {node.status !== 'removed' && typeof node.complexity_score === 'number' && (
+        <span className="text-xs text-gray-500 tabular-nums shrink-0">
+          cx {node.complexity_score}
+          {node.status === 'modified' && typeof node.base_complexity === 'number' && node.base_complexity !== node.complexity_score && (
+            <span className={node.complexity_score > node.base_complexity ? 'text-amber-400 ml-1' : 'text-emerald-400 ml-1'}>
+              ({node.complexity_score > node.base_complexity ? '+' : ''}{node.complexity_score - node.base_complexity})
+            </span>
+          )}
+        </span>
+      )}
+      {typeof node.line_count === 'number' && node.line_count > 0 && (
+        <span className="text-xs text-gray-600 tabular-nums shrink-0">{node.line_count} lines</span>
+      )}
+    </div>
+  );
+}
+
+// ── Edge row ──────────────────────────────────────────────────────────────
+
+function EdgeRow({ edge, kind }) {
+  return (
+    <div className="flex items-center gap-2 py-1.5 border-b border-gray-800/40 last:border-0 text-xs font-mono">
+      <span className={kind === 'added' ? 'text-emerald-400 shrink-0' : 'text-red-400 shrink-0'}>
+        {kind === 'added' ? '+' : '−'}
+      </span>
+      <span className="truncate text-gray-400 min-w-0" title={edge.from_path}>{basename(edge.from_path)}</span>
+      <ArrowRight className="h-3 w-3 text-gray-600 shrink-0" />
+      <span className="truncate text-gray-400 min-w-0" title={edge.to_path}>{basename(edge.to_path)}</span>
+    </div>
+  );
+}
+
+// ── Issue row ──────────────────────────────────────────────────────────────
+
+function IssueRow({ issue }) {
+  const Icon = issueIcon(issue.type);
+  return (
+    <div className="flex items-start gap-3 py-2 border-b border-gray-800/40 last:border-0">
+      <Icon className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-center gap-2 mb-0.5">
+          <span className={`text-xs px-1.5 py-0.5 rounded ${severityBadge(issue.severity)}`}>
+            {issue.severity}
+          </span>
+          <span className="text-xs text-gray-500 font-mono">{issue.type.replace(/_/g, ' ')}</span>
+        </div>
+        <p className="text-xs text-gray-400 font-mono truncate" title={issue.description}>{issue.description}</p>
+      </div>
+    </div>
+  );
+}
+
+// ── Diff graph (simple SVG force layout) ─────────────────────────────────
+
+function DiffGraph({ nodes, edges }) {
+  const svgRef = useRef(null);
+  const animRef = useRef(null);
+
+  const changedNodes = nodes.filter((n) => n.status !== 'unchanged');
+  const changedPaths = new Set(changedNodes.map((n) => n.file_path));
+
+  // Include edges that connect to/from changed nodes
+  const relevantEdges = [
+    ...edges.added.map((e) => ({ ...e, kind: 'added' })),
+    ...edges.removed.map((e) => ({ ...e, kind: 'removed' })),
+  ].filter((e) => changedPaths.has(e.from_path) || changedPaths.has(e.to_path));
+
+  // Build a display node set: changed nodes + direct neighbours referenced by edges
+  const displayPaths = new Set(changedPaths);
+  for (const e of relevantEdges) {
+    displayPaths.add(e.from_path);
+    displayPaths.add(e.to_path);
+  }
+
+  const nodeList = [...displayPaths].slice(0, 80).map((p, i) => {
+    const info = nodes.find((n) => n.file_path === p);
+    return {
+      id: p,
+      label: basename(p),
+      status: info?.status || 'unchanged',
+      index: i,
+    };
+  });
+
+  const nodeIndex = new Map(nodeList.map((n) => [n.id, n]));
+
+  const edgeList = relevantEdges
+    .filter((e) => nodeIndex.has(e.from_path) && nodeIndex.has(e.to_path))
+    .slice(0, 150)
+    .map((e) => ({ source: nodeIndex.get(e.from_path), target: nodeIndex.get(e.to_path), kind: e.kind }));
+
+  // Simple spring simulation
+  useEffect(() => {
+    if (!svgRef.current || nodeList.length === 0) return;
+
+    const W = svgRef.current.clientWidth || 600;
+    const H = svgRef.current.clientHeight || 400;
+    const cx = W / 2;
+    const cy = H / 2;
+
+    // Initialise positions in a circle
+    nodeList.forEach((n, i) => {
+      const angle = (2 * Math.PI * i) / nodeList.length;
+      const r = Math.min(W, H) * 0.35;
+      n.x = cx + r * Math.cos(angle);
+      n.y = cy + r * Math.sin(angle);
+      n.vx = 0;
+      n.vy = 0;
+    });
+
+    const repulsion = 600;
+    const spring   = 0.04;
+    const restLen  = 80;
+    const damping  = 0.85;
+    let tick = 0;
+
+    function step() {
+      if (tick++ > 120) return; // run 120 frames then stop
+
+      // Repulsion
+      for (let i = 0; i < nodeList.length; i++) {
+        for (let j = i + 1; j < nodeList.length; j++) {
+          const a = nodeList[i];
+          const b = nodeList[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const dist = Math.sqrt(dx * dx + dy * dy) || 0.1;
+          const force = repulsion / (dist * dist);
+          a.vx -= (dx / dist) * force;
+          a.vy -= (dy / dist) * force;
+          b.vx += (dx / dist) * force;
+          b.vy += (dy / dist) * force;
+        }
+      }
+
+      // Spring attraction along edges
+      for (const e of edgeList) {
+        const dx = e.target.x - e.source.x;
+        const dy = e.target.y - e.source.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.1;
+        const force = (dist - restLen) * spring;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        e.source.vx += fx;
+        e.source.vy += fy;
+        e.target.vx -= fx;
+        e.target.vy -= fy;
+      }
+
+      // Gravity toward centre
+      for (const n of nodeList) {
+        n.vx += (cx - n.x) * 0.008;
+        n.vy += (cy - n.y) * 0.008;
+        n.vx *= damping;
+        n.vy *= damping;
+        n.x += n.vx;
+        n.y += n.vy;
+        n.x = Math.max(20, Math.min(W - 20, n.x));
+        n.y = Math.max(20, Math.min(H - 20, n.y));
+      }
+
+      render();
+      animRef.current = requestAnimationFrame(step);
+    }
+
+    const svg = svgRef.current;
+
+    function render() {
+      // Clear
+      while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+      const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+      const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+      marker.setAttribute('id', 'arrow');
+      marker.setAttribute('markerWidth', '6');
+      marker.setAttribute('markerHeight', '6');
+      marker.setAttribute('refX', '5');
+      marker.setAttribute('refY', '3');
+      marker.setAttribute('orient', 'auto');
+      const poly = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+      poly.setAttribute('points', '0 0, 6 3, 0 6');
+      poly.setAttribute('fill', '#6b7280');
+      marker.appendChild(poly);
+      defs.appendChild(marker);
+      svg.appendChild(defs);
+
+      // Draw edges
+      for (const e of edgeList) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', e.source.x);
+        line.setAttribute('y1', e.source.y);
+        line.setAttribute('x2', e.target.x);
+        line.setAttribute('y2', e.target.y);
+        line.setAttribute('stroke', e.kind === 'added' ? '#34d399' : '#f87171');
+        line.setAttribute('stroke-width', '1.5');
+        line.setAttribute('stroke-opacity', '0.6');
+        if (e.kind === 'removed') line.setAttribute('stroke-dasharray', '4 2');
+        line.setAttribute('marker-end', 'url(#arrow)');
+        svg.appendChild(line);
+      }
+
+      // Draw nodes
+      for (const n of nodeList) {
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.setAttribute('cx', n.x);
+        circle.setAttribute('cy', n.y);
+        circle.setAttribute('r', '8');
+
+        const fillMap = { added: '#34d399', removed: '#f87171', modified: '#fbbf24', unchanged: '#374151' };
+        const opacityMap = { added: '1', removed: '1', modified: '1', unchanged: '0.35' };
+        circle.setAttribute('fill', fillMap[n.status] || '#374151');
+        circle.setAttribute('fill-opacity', opacityMap[n.status] || '1');
+        circle.setAttribute('stroke', fillMap[n.status] || '#374151');
+        circle.setAttribute('stroke-width', '1.5');
+        circle.setAttribute('stroke-opacity', '0.8');
+        g.appendChild(circle);
+
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', n.x);
+        text.setAttribute('y', n.y + 20);
+        text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('fill', '#9ca3af');
+        text.setAttribute('font-size', '8');
+        text.setAttribute('font-family', 'ui-monospace, monospace');
+        text.textContent = n.label.length > 14 ? n.label.slice(0, 12) + '…' : n.label;
+        g.appendChild(text);
+
+        svg.appendChild(g);
+      }
+    }
+
+    animRef.current = requestAnimationFrame(step);
+    return () => {
+      if (animRef.current) cancelAnimationFrame(animRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeList.length, edgeList.length]);
+
+  if (nodeList.length === 0) {
+    return (
+      <EmptyState
+        icon={GitCompare}
+        title="No changed files to visualize"
+        description="All files are identical between the selected refs."
+        className="py-20"
+      />
+    );
+  }
+
+  return (
+    <div className="relative rounded-xl border border-gray-800 bg-gray-950 overflow-hidden" style={{ height: 420 }}>
+      <div className="absolute top-2 right-2 z-10 flex flex-wrap gap-3 text-xs text-gray-500">
+        <span className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full bg-emerald-400" /> added</span>
+        <span className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full bg-red-400" /> removed</span>
+        <span className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full bg-amber-400" /> modified</span>
+        <span className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-full bg-gray-700 opacity-35" /> unchanged</span>
+      </div>
+      <svg ref={svgRef} className="w-full h-full" />
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export default function ArchDiffModal({ repoId, defaultBranch = 'main', onClose }) {
+  const { session } = useAuth();
+  const [baseRef, setBaseRef] = useState(defaultBranch);
+  const [headRef, setHeadRef] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [diff, setDiff]   = useState(null);
+  const [error, setError] = useState(null);
+  const [view, setView]   = useState('summary'); // 'summary' | 'graph' | 'files' | 'edges' | 'issues' | 'complexity'
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const runDiff = useCallback(async () => {
+    if (!baseRef.trim() || !headRef.trim()) return;
+    setLoading(true);
+    setError(null);
+    setDiff(null);
+    setView('summary');
+    try {
+      const res = await fetch(
+        apiUrl(`/api/repos/${repoId}/diff?base=${encodeURIComponent(baseRef.trim())}&head=${encodeURIComponent(headRef.trim())}`),
+        { headers: { Authorization: `Bearer ${session.access_token}` } },
+      );
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to compute diff');
+      setDiff(data);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [repoId, baseRef, headRef, session?.access_token]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') runDiff();
+  }, [runDiff]);
+
+  const s = diff?.summary;
+  const changedNodes = diff ? diff.nodes.filter((n) => n.status !== 'unchanged') : [];
+
+  const VIEWS = [
+    { id: 'summary',    label: 'Summary' },
+    { id: 'graph',      label: 'Graph' },
+    { id: 'files',      label: `Files (${s ? s.added_files + s.removed_files + s.modified_files : 0})` },
+    { id: 'edges',      label: `Edges (${s ? s.added_edges + s.removed_edges : 0})` },
+    { id: 'issues',     label: `New Issues (${s?.new_issues?.length ?? 0})` },
+    { id: 'complexity', label: `Complexity (${s?.complexity_deltas?.length ?? 0})` },
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="relative flex flex-col w-full max-w-5xl max-h-[90vh] rounded-2xl border border-gray-800 bg-surface-900 shadow-2xl overflow-hidden">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-800 shrink-0">
+          <div className="flex items-center gap-2">
+            <GitCompare className="h-5 w-5 text-indigo-400" />
+            <h2 className="text-base font-semibold text-white">Architectural Diff</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-gray-400 hover:text-white hover:bg-gray-800 transition-colors"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Ref selector */}
+        <div className="flex items-end gap-3 px-6 py-4 border-b border-gray-800 bg-gray-900/40 shrink-0 flex-wrap">
+          <div className="flex flex-col gap-1 min-w-0">
+            <label className="text-xs text-gray-500 font-medium">Base ref</label>
+            <div className="relative">
+              <GitBranch className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-500" />
+              <input
+                className="h-9 rounded-lg border border-gray-700 bg-gray-800 pl-8 pr-3 text-sm text-white placeholder-gray-600 focus:border-indigo-500 focus:outline-none w-44"
+                value={baseRef}
+                onChange={(e) => setBaseRef(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="main"
+              />
+            </div>
+          </div>
+
+          <ArrowRight className="h-4 w-4 text-gray-600 mb-2 shrink-0" />
+
+          <div className="flex flex-col gap-1 min-w-0">
+            <label className="text-xs text-gray-500 font-medium">Head ref</label>
+            <div className="relative">
+              <GitBranch className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-500" />
+              <input
+                className="h-9 rounded-lg border border-gray-700 bg-gray-800 pl-8 pr-3 text-sm text-white placeholder-gray-600 focus:border-indigo-500 focus:outline-none w-52"
+                value={headRef}
+                onChange={(e) => setHeadRef(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="feature/my-branch or SHA"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <Button
+            onClick={runDiff}
+            disabled={loading || !baseRef.trim() || !headRef.trim()}
+            loading={loading}
+            icon={loading ? RefreshCw : GitCompare}
+            className="shrink-0"
+          >
+            {loading ? 'Comparing…' : 'Compare'}
+          </Button>
+
+          {diff && (
+            <span className="text-xs text-gray-500 font-mono self-end mb-2 truncate">
+              {diff.base_sha.slice(0, 7)}…{diff.head_sha.slice(0, 7)}
+            </span>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">
+          {error && (
+            <div className="mx-6 mt-4 rounded-lg bg-red-950/30 border border-red-800/40 px-4 py-3 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          {!diff && !loading && !error && (
+            <EmptyState
+              icon={GitCompare}
+              title="Compare two refs"
+              description="Enter a base and head branch name (or commit SHA) and click Compare to see architectural changes."
+              className="py-24"
+            />
+          )}
+
+          {loading && (
+            <div className="flex flex-col items-center justify-center py-24 gap-3">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+              <p className="text-sm text-gray-400">Fetching file trees and parsing changes…</p>
+            </div>
+          )}
+
+          {diff && diff.identical && (
+            <EmptyState
+              icon={GitCompare}
+              title="Refs are identical"
+              description={`Both refs resolve to the same commit (${diff.base_sha.slice(0, 7)}).`}
+              className="py-24"
+            />
+          )}
+
+          {diff && !diff.identical && (
+            <div className="flex flex-col gap-0">
+              {/* Summary stats row */}
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 px-6 pt-5 pb-4">
+                <StatCard label="Files added"   value={`+${s.added_files}`}   icon={Plus}        tone="green"  />
+                <StatCard label="Files removed" value={`−${s.removed_files}`} icon={Minus}       tone="red"    />
+                <StatCard label="Files changed" value={s.modified_files}       icon={FileCode}    tone="amber"  />
+                <StatCard label="Edges added"   value={`+${s.added_edges}`}   icon={Plus}        tone="green"  />
+                <StatCard label="Edges removed" value={`−${s.removed_edges}`} icon={Minus}       tone="red"    />
+                <StatCard label="New issues"    value={s.new_issues.length}    icon={AlertTriangle} tone={s.new_issues.length ? 'amber' : 'neutral'} />
+              </div>
+
+              {/* Prose summary */}
+              <div className="mx-6 mb-4 rounded-xl border border-indigo-500/20 bg-indigo-500/5 px-4 py-3 text-sm text-indigo-200 flex items-start gap-2">
+                <Info className="h-4 w-4 shrink-0 mt-0.5 text-indigo-400" />
+                <span>
+                  <strong>{baseRef}</strong> → <strong>{headRef}</strong>:{' '}
+                  {s.added_files > 0 && `+${s.added_files} file${s.added_files > 1 ? 's' : ''}, `}
+                  {s.removed_files > 0 && `−${s.removed_files} file${s.removed_files > 1 ? 's' : ''}, `}
+                  {s.modified_files > 0 && `~${s.modified_files} modified, `}
+                  {s.added_edges > 0 && `+${s.added_edges} edge${s.added_edges > 1 ? 's' : ''}, `}
+                  {s.removed_edges > 0 && `−${s.removed_edges} edge${s.removed_edges > 1 ? 's' : ''}, `}
+                  {s.new_issues.length > 0
+                    ? `${s.new_issues.length} new issue${s.new_issues.length > 1 ? 's' : ''} introduced`
+                    : 'no new issues introduced'}
+                  {s.unchanged_files > 0 && `, ${s.unchanged_files} files unchanged`}.
+                </span>
+              </div>
+
+              {/* View tabs */}
+              <div className="flex gap-1 px-6 pb-3 overflow-x-auto shrink-0">
+                {VIEWS.map((v) => (
+                  <button
+                    key={v.id}
+                    onClick={() => setView(v.id)}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-colors ${
+                      view === v.id
+                        ? 'bg-indigo-600/25 text-indigo-300 border border-indigo-500/30'
+                        : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
+                    }`}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="px-6 pb-6">
+                {/* Summary view */}
+                {view === 'summary' && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {/* Changed files preview */}
+                    <Panel padded={false}>
+                      <div className="px-4 py-3 border-b border-gray-800 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                        Changed Files ({changedNodes.length})
+                      </div>
+                      <div className="px-4 py-2 max-h-52 overflow-y-auto">
+                        {changedNodes.length === 0
+                          ? <p className="text-xs text-gray-600 py-2">No file changes</p>
+                          : changedNodes.slice(0, 20).map((n) => <FileRow key={n.file_path} node={n} />)}
+                        {changedNodes.length > 20 && (
+                          <p className="text-xs text-gray-600 pt-2">…and {changedNodes.length - 20} more. See the Files tab.</p>
+                        )}
+                      </div>
+                    </Panel>
+
+                    {/* New issues preview */}
+                    <Panel padded={false}>
+                      <div className="px-4 py-3 border-b border-gray-800 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                        New Issues ({s.new_issues.length})
+                      </div>
+                      <div className="px-4 py-2 max-h-52 overflow-y-auto">
+                        {s.new_issues.length === 0
+                          ? <p className="text-xs text-gray-600 py-2">No new architectural issues introduced</p>
+                          : s.new_issues.map((issue, i) => <IssueRow key={i} issue={issue} />)}
+                      </div>
+                    </Panel>
+
+                    {/* Complexity deltas preview */}
+                    {s.complexity_deltas.length > 0 && (
+                      <Panel padded={false} className="md:col-span-2">
+                        <div className="px-4 py-3 border-b border-gray-800 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                          Top Complexity Changes
+                        </div>
+                        <div className="px-4 py-2">
+                          {s.complexity_deltas.slice(0, 6).map((d) => (
+                            <div key={d.file_path} className="flex items-center gap-3 py-1.5 border-b border-gray-800/40 last:border-0 text-xs">
+                              {d.delta > 0
+                                ? <TrendingUp className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+                                : <TrendingDown className="h-3.5 w-3.5 text-emerald-400 shrink-0" />}
+                              <span className="flex-1 truncate font-mono text-gray-400" title={d.file_path}>{d.file_path}</span>
+                              <span className="tabular-nums text-gray-500">{d.base_complexity} → {d.head_complexity}</span>
+                              <span className={`tabular-nums font-semibold ${d.delta > 0 ? 'text-amber-400' : 'text-emerald-400'}`}>
+                                {d.delta > 0 ? '+' : ''}{d.delta}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </Panel>
+                    )}
+                  </div>
+                )}
+
+                {/* Graph view — key on SHAs so a new diff always creates a fresh simulation */}
+                {view === 'graph' && (
+                  <DiffGraph
+                    key={`${diff.base_sha}-${diff.head_sha}`}
+                    nodes={diff.nodes}
+                    edges={diff.edges}
+                  />
+                )}
+
+                {/* Files view */}
+                {view === 'files' && (
+                  <Panel padded={false}>
+                    <div className="px-4 py-2 max-h-[calc(90vh-22rem)] overflow-y-auto">
+                      {changedNodes.length === 0
+                        ? <p className="text-xs text-gray-600 py-4 text-center">No changed files</p>
+                        : changedNodes.map((n) => <FileRow key={n.file_path} node={n} />)}
+                    </div>
+                  </Panel>
+                )}
+
+                {/* Edges view */}
+                {view === 'edges' && (
+                  <Panel padded={false}>
+                    <div className="px-4 py-2 max-h-[calc(90vh-22rem)] overflow-y-auto">
+                      {diff.edges.added.length === 0 && diff.edges.removed.length === 0 ? (
+                        <p className="text-xs text-gray-600 py-4 text-center">No edge changes</p>
+                      ) : (
+                        <>
+                          {diff.edges.added.map((e, i) => <EdgeRow key={`a-${i}`} edge={e} kind="added" />)}
+                          {diff.edges.removed.map((e, i) => <EdgeRow key={`r-${i}`} edge={e} kind="removed" />)}
+                        </>
+                      )}
+                    </div>
+                  </Panel>
+                )}
+
+                {/* Issues view */}
+                {view === 'issues' && (
+                  <Panel padded={false}>
+                    <div className="px-4 py-2 max-h-[calc(90vh-22rem)] overflow-y-auto">
+                      {s.new_issues.length === 0
+                        ? <p className="text-xs text-gray-600 py-4 text-center">No new architectural issues introduced</p>
+                        : s.new_issues.map((issue, i) => <IssueRow key={i} issue={issue} />)}
+                    </div>
+                  </Panel>
+                )}
+
+                {/* Complexity view */}
+                {view === 'complexity' && (
+                  <Panel padded={false}>
+                    <div className="max-h-[calc(90vh-22rem)] overflow-y-auto">
+                      <table className="w-full text-xs">
+                        <thead className="sticky top-0 bg-gray-900 border-b border-gray-800">
+                          <tr>
+                            <th className="text-left px-4 py-2 text-gray-500 font-medium">File</th>
+                            <th className="text-right px-4 py-2 text-gray-500 font-medium">Base cx</th>
+                            <th className="text-right px-4 py-2 text-gray-500 font-medium">Head cx</th>
+                            <th className="text-right px-4 py-2 text-gray-500 font-medium">Δ</th>
+                            <th className="text-right px-4 py-2 text-gray-500 font-medium">Lines Δ</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {s.complexity_deltas.length === 0 ? (
+                            <tr><td colSpan={5} className="text-center text-gray-600 py-4">No complexity changes</td></tr>
+                          ) : s.complexity_deltas.map((d) => (
+                            <tr key={d.file_path} className="border-b border-gray-800/40 hover:bg-gray-800/30">
+                              <td className="px-4 py-2 font-mono truncate max-w-xs text-gray-400" title={d.file_path}>{d.file_path}</td>
+                              <td className="px-4 py-2 text-right tabular-nums text-gray-500">{d.base_complexity}</td>
+                              <td className="px-4 py-2 text-right tabular-nums text-gray-400">{d.head_complexity}</td>
+                              <td className={`px-4 py-2 text-right tabular-nums font-semibold ${d.delta > 0 ? 'text-amber-400' : 'text-emerald-400'}`}>
+                                {d.delta > 0 ? '+' : ''}{d.delta}
+                              </td>
+                              <td className={`px-4 py-2 text-right tabular-nums ${d.head_lines - d.base_lines > 0 ? 'text-amber-400/70' : 'text-emerald-400/70'}`}>
+                                {d.head_lines - d.base_lines > 0 ? '+' : ''}{d.head_lines - d.base_lines}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </Panel>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Icons.jsx
+++ b/frontend/src/components/ui/Icons.jsx
@@ -19,6 +19,7 @@ export {
   // Repo / Graph
   GitGraph,
   GitBranch,
+  GitCompare,
   GitMerge,
   GitFork,
   Network,

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -6,7 +6,8 @@ import { apiUrl }           from '../lib/api';
 import { formatDate }       from '../lib/constants';
 import { useToast }         from '../components/Toast';
 import { Badge, Banner, Button, EmptyState, Panel, Skeleton } from '../components/ui/Primitives';
-import { RefreshCw, ArrowLeft, Home } from '../components/ui/Icons';
+import { RefreshCw, ArrowLeft, Home, GitCompare } from '../components/ui/Icons';
+import ArchDiffModal        from '../components/ArchDiffModal';
 
 const DependencyGraph      = lazy(() => import('../components/DependencyGraph'));
 const SearchPanel          = lazy(() => import('../components/SearchPanel'));
@@ -114,6 +115,7 @@ export default function RepoView() {
   const [error, setError]             = useState(null);
   const [isReindexing, setIsReindexing] = useState(false);
   const [depsRefreshKey, setDepsRefreshKey] = useState(0);
+  const [isDiffModalOpen, setIsDiffModalOpen] = useState(false);
 
   const handleNodeSelect = useCallback((nodeIdOrIds, options = {}) => {
     setSelectedNodeId(nodeIdOrIds);
@@ -440,14 +442,26 @@ export default function RepoView() {
             </p>
           </div>
 
-          <Button
-            onClick={handleReindex}
-            disabled={isWorking || isReindexing}
-            icon={RefreshCw}
-            loading={isReindexing}
-          >
-            {isReindexing ? 'Starting...' : 'Re-index'}
-          </Button>
+          <div className="flex items-center gap-2">
+            {repo?.source === 'github' && (
+              <Button
+                onClick={() => setIsDiffModalOpen(true)}
+                disabled={isWorking}
+                icon={GitCompare}
+                variant="outline"
+              >
+                Compare
+              </Button>
+            )}
+            <Button
+              onClick={handleReindex}
+              disabled={isWorking || isReindexing}
+              icon={RefreshCw}
+              loading={isReindexing}
+            >
+              {isReindexing ? 'Starting...' : 'Re-index'}
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -595,6 +609,15 @@ export default function RepoView() {
           onClose={() => setChatFilePath(null)}
         />
       </Suspense>
+
+      {/* Architectural diff modal (US-051) */}
+      {isDiffModalOpen && (
+        <ArchDiffModal
+          repoId={repoId}
+          defaultBranch={repo?.default_branch || 'main'}
+          onClose={() => setIsDiffModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/scripts/us051_arch_diff.sql
+++ b/scripts/us051_arch_diff.sql
@@ -1,0 +1,44 @@
+-- US-051: Architectural diff cache
+-- Apply via Supabase SQL Editor
+
+CREATE TABLE IF NOT EXISTS diff_cache (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id     UUID        NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  base_sha    TEXT        NOT NULL,
+  head_sha    TEXT        NOT NULL,
+  base_ref    TEXT        NOT NULL,
+  head_ref    TEXT        NOT NULL,
+  result_json JSONB       NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (repo_id, base_sha, head_sha)
+);
+
+-- Auto-expire entries older than 7 days to prevent unbounded growth.
+-- A cron job or pg_cron extension can run this; for now it is left as a
+-- reference for ops to schedule manually.
+-- DELETE FROM diff_cache WHERE created_at < NOW() - INTERVAL '7 days';
+
+ALTER TABLE diff_cache ENABLE ROW LEVEL SECURITY;
+
+-- Repo owners can read their own diff cache.
+-- Writes go through supabaseAdmin (service role) which bypasses RLS, so
+-- we restrict the client-facing policy to SELECT only to prevent cache poisoning.
+CREATE POLICY "owner can read diff_cache"
+  ON diff_cache FOR SELECT
+  USING (
+    repo_id IN (
+      SELECT id FROM repositories WHERE user_id = auth.uid()
+    )
+  );
+
+-- Team members can read diff cache for repos shared with their teams
+CREATE POLICY "team member can read diff_cache"
+  ON diff_cache FOR SELECT
+  USING (
+    repo_id IN (
+      SELECT tr.repo_id
+      FROM team_repositories tr
+      INNER JOIN team_members tm ON tm.team_id = tr.team_id
+      WHERE tm.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
- New diffService.js: fetches git trees for two refs via Octokit,
  classifies files as added/removed/modified/unchanged by SHA comparison,
  fetches blobs only for changed files (capped at 300), parses with
  parseFile(), computes added/removed edges, complexity deltas, and newly-
  introduced god-file / high-coupling issues without touching the primary index

- GET /api/repos/:repoId/diff?base=<ref>&head=<ref>: resolves refs to SHAs
  for stable cache keys, checks diff_cache before computing, writes result
  back asynchronously; GitHub repos only

- diff_cache table (scripts/us051_arch_diff.sql): keyed on
  (repo_id, base_sha, head_sha), RLS SELECT-only for clients (writes go
  through service role), team-member read policy mirrors other cache tables

- ArchDiffModal.jsx: full-screen overlay with ref selector, six tabbed
  views (Summary / Graph / Files / Edges / New Issues / Complexity),
  force-directed SVG diff graph (green=added, red dashed=removed,
  amber=modified, dimmed=unchanged), prose summary line matching AC spec

- Compare button added to repo header (GitHub repos only); modal keyed on
  base+head SHA pair so each new diff triggers a fresh graph simulation