### PR TITLE
fix(tours,hotspots,arch-diff): bugs and perf cleanup for US-050/051/055/056

### DIFF
--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -954,6 +954,19 @@ const getDiff = async (req, res) => {
         if (error) console.warn('[getDiff] Cache write failed:', error.message);
       });
 
+    // Opportunistic TTL cleanup for this repo. us051_arch_diff.sql documents a
+    // 7-day expiry but relies on a scheduled job; pruning on cache miss keeps
+    // the table bounded without requiring pg_cron to be enabled.
+    const cutoffIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    supabaseAdmin
+      .from('diff_cache')
+      .delete()
+      .eq('repo_id', repoId)
+      .lt('created_at', cutoffIso)
+      .then(({ error }) => {
+        if (error) console.warn('[getDiff] Cache TTL cleanup failed:', error.message);
+      });
+
     res.json(diff);
   } catch (err) {
     console.error('[getDiff] Error:', err);

--- a/backend/src/controllers/toursController.js
+++ b/backend/src/controllers/toursController.js
@@ -175,13 +175,30 @@ const generateTour = async (req, res) => {
     }
   }
 
+  // Batch-fetch first chunk for non-relevant step files (avoid N+1 inside the Claude loop)
+  const fallbackByPath = new Map();
+  const nonRelevantStepPaths = result.filter((p) => !relevantSet.has(p));
+  if (nonRelevantStepPaths.length > 0) {
+    const { data: fallbackRows } = await supabaseAdmin
+      .from('code_chunks')
+      .select('file_path, content, start_line, end_line')
+      .eq('repo_id', repoId)
+      .in('file_path', nonRelevantStepPaths)
+      .order('start_line', { ascending: true });
+    for (const row of fallbackRows || []) {
+      if (!fallbackByPath.has(row.file_path)) fallbackByPath.set(row.file_path, row);
+    }
+  }
+
   // 7. Generate Claude explanation for each step
+  // Track budget in-memory: snapshot once, then decrement from each Claude usage report.
+  // Avoids an api_usage range scan per step.
+  let budgetRemaining = MAX_DAILY_TOKENS - (await dailyTokensUsed(userId));
   const steps = [];
   for (let i = 0; i < result.length; i++) {
     const filePath = result[i];
 
-    // Per-step budget check
-    if ((await dailyTokensUsed(userId)) >= MAX_DAILY_TOKENS) {
+    if (budgetRemaining <= 0) {
       console.warn(`[tour] daily token budget exhausted at step ${i + 1}/${result.length}`);
       break;
     }
@@ -198,18 +215,11 @@ const generateTour = async (req, res) => {
       startLine = best.start_line;
       endLine   = best.end_line;
     } else {
-      // File reached via graph traversal but not in relevant set — fetch first chunk
-      const { data: fallbackChunks } = await supabaseAdmin
-        .from('code_chunks')
-        .select('content, start_line, end_line')
-        .eq('repo_id', repoId)
-        .eq('file_path', filePath)
-        .order('start_line', { ascending: true })
-        .limit(1);
-      if (fallbackChunks && fallbackChunks.length > 0) {
-        excerpt   = fallbackChunks[0].content;
-        startLine = fallbackChunks[0].start_line;
-        endLine   = fallbackChunks[0].end_line;
+      const fallback = fallbackByPath.get(filePath);
+      if (fallback) {
+        excerpt   = fallback.content;
+        startLine = fallback.start_line;
+        endLine   = fallback.end_line;
       }
     }
 
@@ -233,12 +243,15 @@ const generateTour = async (req, res) => {
         messages:  [{ role: 'user', content: userPrompt }],
       });
       explanation = response.content[0]?.type === 'text' ? response.content[0].text : '';
+      const inputTokens  = response.usage?.input_tokens  || 0;
+      const outputTokens = response.usage?.output_tokens || 0;
+      budgetRemaining -= inputTokens + outputTokens;
       await recordUsage({
         userId,
         endpoint:         'tour-generate',
         provider:         'anthropic',
-        promptTokens:     response.usage?.input_tokens  || 0,
-        completionTokens: response.usage?.output_tokens || 0,
+        promptTokens:     inputTokens,
+        completionTokens: outputTokens,
       });
     } catch (err) {
       console.error(`[tour] Claude call failed at step ${i + 1}:`, err.message);
@@ -249,6 +262,10 @@ const generateTour = async (req, res) => {
   }
 
   // 8. Optionally persist
+  if (steps.length === 0) {
+    return res.status(429).json({ error: 'Daily token budget exhausted' });
+  }
+
   if (save) {
     const title = query.length > 80 ? query.slice(0, 77) + '…' : query;
 
@@ -280,7 +297,11 @@ const generateTour = async (req, res) => {
 
     const { error: stepsErr } = await supabaseAdmin.from('tour_steps').insert(stepRows);
     if (stepsErr) {
+      // Compensating delete: the tour row is already committed, so undo it rather
+      // than leaving an empty tour visible in the library.
       console.error('[tour] Failed to insert tour steps:', stepsErr.message);
+      await supabaseAdmin.from('tours').delete().eq('id', tour.id);
+      return res.status(500).json({ error: 'Failed to save tour steps' });
     }
 
     return res.json({ tour, steps });
@@ -342,7 +363,7 @@ const listTours = async (req, res) => {
 
   const { data: tourRows, error: toursErr } = await supabaseAdmin
     .from('tours')
-    .select('id, repo_id, created_by, title, description, original_query, is_auto_generated, is_team_shared, created_at, updated_at')
+    .select('id, repo_id, created_by, title, description, original_query, is_auto_generated, is_team_shared, forked_from, created_at, updated_at')
     .eq('repo_id', repoId)
     .order('updated_at', { ascending: false });
 

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -123,11 +123,18 @@ const handleGitHubPush = async (req, res) => {
     return res.status(200).json({ ok: true, skipped: 'push not to default branch' });
   }
 
-  // Fire-and-forget re-index (US-028)
-  console.log(`[webhook] Triggering re-index for repo ${repo.id} (${fullName}) on push to ${ref}`);
-  
+  // Fire-and-forget re-index (US-028). For US-050, hand the payload's commit
+  // SHAs to the indexer so the churn phase updates only changed files instead
+  // of re-fetching the full 12-month history.
+  const incrementalChurnCommits = Array.isArray(payload.commits)
+    ? payload.commits.map((c) => c?.id).filter(Boolean)
+    : [];
+
+  console.log(`[webhook] Triggering re-index for repo ${repo.id} (${fullName}) on push to ${ref}` +
+    (incrementalChurnCommits.length ? ` (incremental churn over ${incrementalChurnCommits.length} commits)` : ''));
+
   queue.add(async () => {
-    await indexer.startGitHubIndexing(repo.id, githubToken, repo.name);
+    await indexer.startGitHubIndexing(repo.id, githubToken, repo.name, { incrementalChurnCommits });
   });
 
   return res.status(200).send("OK");

--- a/backend/src/services/churnService.js
+++ b/backend/src/services/churnService.js
@@ -157,4 +157,127 @@ async function fetchRepoChurn(owner, repoName, token, repoId) {
   return churnMap;
 }
 
-module.exports = { fetchRepoChurn };
+/**
+ * Incremental update of file_churn for a small set of new commit SHAs
+ * (typically from a GitHub push webhook payload). Avoids the full 12-month
+ * recompute when only a handful of commits have landed since last index.
+ *
+ * Approximation: `unique_authors` is NOT updated incrementally because the
+ * existing row stores only the count, not the underlying author set, so a
+ * union cannot be computed without a schema change. The count converges on
+ * the next full re-index. `commit_count`, `lines_changed`, and `last_modified`
+ * are updated accurately.
+ */
+async function applyIncrementalChurn(owner, repoName, token, repoId, commitShas) {
+  if (!Array.isArray(commitShas) || commitShas.length === 0) return;
+  console.time(`[churn] Incremental (${repoId})`);
+
+  const limit = pLimit(DETAIL_CONCURRENCY);
+  const details = await Promise.allSettled(
+    commitShas.map(sha => limit(async () => {
+      const url = `${GITHUB_API}/repos/${owner}/${repoName}/commits/${sha}`;
+      return githubGet(url, token);
+    }))
+  );
+
+  // Build per-file delta from fetched commit details
+  const deltaMap = new Map(); // filePath → { countDelta, linesDelta, lastModified }
+  for (const result of details) {
+    if (result.status !== 'fulfilled') continue;
+    const commit = result.value;
+    const dateStr = commit.commit?.author?.date || commit.commit?.committer?.date;
+    const ts = dateStr ? new Date(dateStr) : null;
+    for (const file of commit.files || []) {
+      const fp = file.filename;
+      if (!fp) continue;
+      if (!deltaMap.has(fp)) {
+        deltaMap.set(fp, { countDelta: 0, linesDelta: 0, lastModified: null });
+      }
+      const entry = deltaMap.get(fp);
+      entry.countDelta += 1;
+      entry.linesDelta += (file.additions || 0) + (file.deletions || 0);
+      if (ts && (!entry.lastModified || ts > entry.lastModified)) {
+        entry.lastModified = ts;
+      }
+    }
+  }
+
+  if (deltaMap.size === 0) {
+    console.timeEnd(`[churn] Incremental (${repoId})`);
+    return;
+  }
+
+  // Read existing churn rows for just the touched files
+  const touchedPaths = [...deltaMap.keys()];
+  const { data: existingRows, error: readErr } = await supabaseAdmin
+    .from('file_churn')
+    .select('file_path, commit_count, unique_authors, lines_changed, last_modified')
+    .eq('repo_id', repoId)
+    .in('file_path', touchedPaths);
+  if (readErr) {
+    console.warn(`[churn] Incremental read failed: ${readErr.message}`);
+    console.timeEnd(`[churn] Incremental (${repoId})`);
+    return;
+  }
+  const existingByPath = new Map((existingRows || []).map(r => [r.file_path, r]));
+
+  // Compose upsert rows
+  const rows = [];
+  for (const [filePath, delta] of deltaMap.entries()) {
+    const existing = existingByPath.get(filePath);
+    const existingTs = existing?.last_modified ? new Date(existing.last_modified) : null;
+    const nextTs = delta.lastModified && (!existingTs || delta.lastModified > existingTs)
+      ? delta.lastModified
+      : existingTs;
+    rows.push({
+      repo_id: repoId,
+      file_path: filePath,
+      commit_count:  (existing?.commit_count  || 0) + delta.countDelta,
+      lines_changed: (existing?.lines_changed || 0) + delta.linesDelta,
+      unique_authors: existing?.unique_authors || 0,
+      last_modified: nextTs ? nextTs.toISOString() : null,
+    });
+  }
+
+  const { error: upErr } = await supabaseAdmin
+    .from('file_churn')
+    .upsert(rows, { onConflict: 'repo_id,file_path', ignoreDuplicates: false });
+  if (upErr) console.warn(`[churn] Incremental upsert failed: ${upErr.message}`);
+  else console.log(`[churn] Incremental update touched ${rows.length} files for repo ${repoId}`);
+
+  console.timeEnd(`[churn] Incremental (${repoId})`);
+}
+
+/**
+ * Hydrate file_churn into the same Map<filePath, entry> shape that
+ * fetchRepoChurn returns, so the indexer's refactoring_candidate scoring can
+ * run identically after either a full or an incremental update.
+ *
+ * `authors` is reconstructed as a placeholder Set sized to match the stored
+ * unique_authors count — only `.size` is read downstream.
+ */
+async function readChurnFromDb(repoId) {
+  const { data, error } = await supabaseAdmin
+    .from('file_churn')
+    .select('file_path, commit_count, unique_authors, lines_changed, last_modified')
+    .eq('repo_id', repoId);
+  if (error) {
+    console.warn(`[churn] readChurnFromDb failed: ${error.message}`);
+    return new Map();
+  }
+  const map = new Map();
+  for (const row of data || []) {
+    const authorCount = row.unique_authors || 0;
+    const authors = new Set();
+    for (let i = 0; i < authorCount; i++) authors.add(`__author_${i}__`);
+    map.set(row.file_path, {
+      count: row.commit_count || 0,
+      authors,
+      lines: row.lines_changed || 0,
+      lastModified: row.last_modified ? new Date(row.last_modified) : null,
+    });
+  }
+  return map;
+}
+
+module.exports = { fetchRepoChurn, applyIncrementalChurn, readChurnFromDb };

--- a/backend/src/services/indexer.js
+++ b/backend/src/services/indexer.js
@@ -16,12 +16,19 @@ const VALID_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.py', '.cs']);
  */
 const { indexRepository } = require('./indexerService');
 
-const startGitHubIndexing = async (repoId, githubToken, repoFullName) => {
+const startGitHubIndexing = async (repoId, githubToken, repoFullName, options = {}) => {
   const [owner, name] = repoFullName.split('/');
   // The service handles marking it ready or failed, and the full try/catch pipeline.
   // We wrap it again here to ensure unhandled rejections never reach the main process.
   try {
-    await indexRepository({ repoId, owner, name, token: githubToken, source: 'github' });
+    await indexRepository({
+      repoId,
+      owner,
+      name,
+      token: githubToken,
+      source: 'github',
+      incrementalChurnCommits: options.incrementalChurnCommits,
+    });
   } catch (err) {
     console.error(`[Indexer] Top-level fallback error for ${repoFullName}:`, err.message);
   }

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -5,7 +5,7 @@ const { scanFileForSecrets } = require('./secretScanner');
 const { scanFileForInsecurePatterns } = require('./sastEngine'); // US-046
 const { scanFileForMissingAuth } = require('./authCoverageScanner'); // US-049
 const { classifyFile } = require('./attackSurfaceClassifier'); // US-047
-const { fetchRepoChurn } = require('./churnService'); // US-050
+const { fetchRepoChurn, applyIncrementalChurn, readChurnFromDb } = require('./churnService'); // US-050
 const { detectDuplicateCandidates } = require('./duplicationScanner'); // US-052
 const { isTestFilePath, parseCoverageOverrides } = require('./testCoverageService'); // US-053
 const { recordUsage } = require('./usageTracker'); // US-042
@@ -121,7 +121,7 @@ async function fetchLocalFiles(dir, baseDir = dir, results = []) {
  * @param {string} [params.extractPath] - Path to extracted local zip
  * @param {string} params.source - 'github' or 'upload'
  */
-const indexRepository = async ({ repoId, owner, name, token, extractPath, source }) => {
+const indexRepository = async ({ repoId, owner, name, token, extractPath, source, incrementalChurnCommits }) => {
   let zipTempDir = null;
   try {
     console.log(`[indexer] Starting indexing for repoId: ${repoId} (source: ${source})`);
@@ -264,7 +264,11 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     await supabaseAdmin.from('analysis_issues').delete().eq('repo_id', repoId);
     await supabaseAdmin.from('dependency_manifests').delete().eq('repo_id', repoId);
     await supabaseAdmin.from('graph_edges').delete().eq('repo_id', repoId);
-    await supabaseAdmin.from('file_churn').delete().eq('repo_id', repoId); // US-050
+    // US-050: full-recompute path wipes churn; incremental webhook path preserves
+    // existing rows so applyIncrementalChurn can add deltas onto them.
+    if (!Array.isArray(incrementalChurnCommits) || incrementalChurnCommits.length === 0) {
+      await supabaseAdmin.from('file_churn').delete().eq('repo_id', repoId);
+    }
     await supabaseAdmin.from('duplication_candidates').delete().eq('repo_id', repoId); // US-052
     await supabaseAdmin
       .from('graph_nodes')
@@ -829,7 +833,18 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     if (source === 'github' && token) {
       try {
         console.time(`[indexer] Phase Churn (${repoId})`);
-        const churnMap = await fetchRepoChurn(owner, name, token, repoId);
+
+        const isIncremental = Array.isArray(incrementalChurnCommits) && incrementalChurnCommits.length > 0;
+        if (isIncremental) {
+          await applyIncrementalChurn(owner, name, token, repoId, incrementalChurnCommits);
+        } else {
+          await fetchRepoChurn(owner, name, token, repoId);
+        }
+
+        // Read persisted churn back so refactoring_candidate issues are recomputed
+        // from the canonical rows on both the full-recompute and the incremental
+        // path. analysis_issues is wiped earlier in the pipeline.
+        const churnMap = await readChurnFromDb(repoId);
 
         if (churnMap.size > 0) {
           const complexityMap = new Map(finalNodes.map(n => [n.file_path, n.complexity_score || 0]));

--- a/frontend/src/components/TourViewer.jsx
+++ b/frontend/src/components/TourViewer.jsx
@@ -135,11 +135,12 @@ export default function TourViewer({
       return;
     }
 
-    let cancelled = false;
+    const controller = new AbortController();
     setFileState({ status: 'loading', content: '', language: null, error: null });
 
     fetch(apiUrl(`/api/repos/${repoId}/file?path=${encodeURIComponent(step.file_path)}`), {
       headers: { Authorization: `Bearer ${session.access_token}` },
+      signal: controller.signal,
     })
       .then(async (res) => {
         if (res.status === 404) {
@@ -152,7 +153,6 @@ export default function TourViewer({
         return res.json();
       })
       .then((data) => {
-        if (cancelled) return;
         if (data.missing) {
           setFileState({ status: 'missing', content: '', language: null, error: MISSING_FILE_MESSAGE });
           return;
@@ -162,13 +162,11 @@ export default function TourViewer({
         setFileState({ status: 'ready', content: next.content, language: next.language, error: null });
       })
       .catch((err) => {
-        if (cancelled) return;
+        if (err?.name === 'AbortError') return;
         setFileState({ status: 'error', content: '', language: null, error: err.message || 'Failed to fetch file content' });
       });
 
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [open, repoId, session?.access_token, step?.file_path]);
 
   useEffect(() => {

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -815,8 +815,10 @@ CREATE INDEX IF NOT EXISTS tour_steps_tour_id_order_idx ON tour_steps (tour_id, 
 
 ALTER TABLE tour_steps ENABLE ROW LEVEL SECURITY;
 
+-- Read steps of any tour the user can see (own + team-shared)
 DROP POLICY IF EXISTS "Users can access steps of accessible tours" ON tour_steps;
-CREATE POLICY "Users can access steps of accessible tours" ON tour_steps FOR ALL
+DROP POLICY IF EXISTS "Users can read steps of accessible tours" ON tour_steps;
+CREATE POLICY "Users can read steps of accessible tours" ON tour_steps FOR SELECT
   USING (
     tour_id IN (
       SELECT id FROM tours
@@ -830,6 +832,13 @@ CREATE POLICY "Users can access steps of accessible tours" ON tour_steps FOR ALL
         )
     )
   );
+
+-- Write (INSERT / UPDATE / DELETE) steps only for tours the user owns
+DROP POLICY IF EXISTS "Users can write steps of own tours" ON tour_steps;
+CREATE POLICY "Users can write steps of own tours" ON tour_steps
+  FOR ALL
+  USING  (tour_id IN (SELECT id FROM tours WHERE created_by = auth.uid()))
+  WITH CHECK (tour_id IN (SELECT id FROM tours WHERE created_by = auth.uid()));
 
 -- updated_at trigger for tours
 


### PR DESCRIPTION
- US-055: roll back orphaned tours row when tour_steps insert fails
- US-055: track token budget in-memory instead of scanning api_usage per step
- US-055: batch fallback code_chunks fetch instead of N+1 per step
- US-056: use AbortController for in-flight file fetches in TourViewer
- US-051: prune diff_cache rows older than 7 days on cache miss
- US-050: incremental churn update on webhook push (skip the full
  12-month recompute when only a handful of commits have landed)