### PR TITLE
feat(perf,proposals): performance roadmap + AI proposals + symbol-aware edges (US-063, 064)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,3 +427,6 @@ FodyWeavers.xsd
 
 # Personal / local notes
 DEMO_GUIDE.md
+
+# Claude Code workspace (per-user agent state, plans, transcripts)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,20 @@ CodeLens-hub/
 │   │   ├── secret-rules.json         # Regex rules for secret scanning
 │   │   └── rules/                    # Per-language SAST rules (US-046)
 │   ├── parsers/            # Tree-sitter AST parsing per language
+│   │   ├── parserPool.js             # Piscina worker pool singleton (Phase 5.1)
+│   │   └── parser-worker.js          # Worker entry — JSON-safe parsed result
+│   ├── lib/                # Shared helpers — dbHelpers, sseAbort
+│   ├── observability/      # AsyncLocalStorage request ledger (Phase 0)
 │   ├── ai/                 # ragService.js (RAG pipeline)
-│   ├── db/                 # Supabase admin client
+│   ├── db/                 # Supabase admin client (instrumented fetch)
 │   └── middleware/         # Auth, error handling, AI rate limiting
 │
 ├── scripts/
-│   ├── setup.sh                      # Idempotent bootstrap
-│   ├── schema.sql                    # Full DB schema — apply via Supabase SQL Editor
-│   └── us048_security_audits.sql     # security_audits table + RLS
+│   ├── setup.sh                              # Idempotent bootstrap
+│   ├── schema.sql                            # Full DB schema — apply via Supabase SQL Editor
+│   ├── us048_security_audits.sql             # security_audits table + RLS
+│   ├── maintenance_truncate_api_usage.sql    # Monthly — prune raw api_usage > 30 days
+│   └── maintenance_evict_embedding_cache.sql # Quarterly — evict embedding_cache idle > 90 days
 │
 └── docker-compose.yml      # postgres + backend + frontend
 ```
@@ -130,6 +136,8 @@ CodeLens-hub/
 | `POST` | `/api/review/:id/security-audit` | Whole-repo security audit (US-048) |
 | `GET` | `/api/review/:id/security-audits` | Audit history |
 | `GET` | `/api/review/:id/security-audits/:auditId` | Single audit |
+| `POST` | `/api/review/:id/duplication-refactor` | SSE: AI shared-utility refactor for a duplicate cluster |
+| `POST` | `/api/issues/:issueId/proposal` | SSE: AI fix proposal for an `analysis_issues` row (US-063) |
 
 ---
 
@@ -146,9 +154,17 @@ Tables (all with RLS):
 - `vulnerability_cache` — OSV.dev results per `(ecosystem, name, version)` with 24 h TTL (US-045)
 - `dependency_manifests` — per-package SCA results for the Dependencies tab; cleared on re-index (US-045)
 - `security_audits` — whole-repo AI audit reports: `{ id, user_id, repo_id, findings_json, created_at }` (US-048)
-- `api_usage` — per-user token usage tracking for daily budget enforcement (US-042)
+- `api_usage` — per-user token usage log (audit/debug; truncated monthly — see Maintenance)
+- `api_usage_daily` — `(user_id, usage_date)` rollup maintained by an `AFTER INSERT` trigger on `api_usage`; read by every budget check so the rolling-24 h scan never grows
+- `issue_proposals` — AI fix proposals for `analysis_issues` (US-063); status `pending | accepted | dismissed | stale`. Re-index sets `stale` on any proposal whose underlying issue is being deleted
+- `embedding_cache` — global, content-hash-keyed OpenAI embedding cache; rows shared across repos and accessed only via `service_role`. `last_used_at` drives quarterly eviction
+- `graph_edges.symbols TEXT[]` — per-importer symbol list (US-064); empty array on edges written before the column existed
 
 **Schema migration:** `scripts/schema.sql` is idempotent and safe to re-run. Apply via Supabase SQL Editor. The `scripts/us048_security_audits.sql` file creates the `security_audits` table separately.
+
+**Indexer-side RPCs** (also in `scripts/schema.sql`):
+- `prepare_repo_reindex(repo_id, unchanged_paths, changed_or_deleted_paths, preserve_churn)` — single PL/pgSQL call that stale-marks pending proposals, deletes non-preservable issues (preserves `hardcoded_secret` / `insecure_pattern` / `missing_auth` whose `file_paths` are entirely in `unchanged_paths`), wipes derived tables, and partial-purges nodes/chunks/file_contents for changed-or-deleted files
+- `bulk_insert_analysis_issues(repo_id, issues jsonb)` — single insert with server-side shape validation (`type` non-null, `file_paths` non-empty)
 
 ---
 
@@ -165,18 +181,25 @@ GROQ_API_KEY          # for RAG LLM responses
 ANTHROPIC_API_KEY     # for AI code review + security audit (US-048)
 NODE_ENV, PORT
 MAX_DAILY_TOKENS_PER_USER   # optional, default 500000 (US-042)
+
+# Performance / observability knobs (all optional)
+SLOW_REQUEST_MS             # WARN threshold for the request-timing middleware, default 500
+LOG_REQUEST_TIMING          # 'true' → log every request, not only slow ones
+SUPABASE_FETCH_CEILING      # row limit on bulk SELECTs, default 50000 (Phase 1.2)
+PARSER_WORKER_COUNT         # piscina pool size; default = min(os.cpus().length, 8)
+PARSER_WORKERS_DISABLED     # 'true' → skip the worker pool, parse in-process
 ```
 
 ---
 
 ## Indexing Pipeline (Core Flow)
 
-Per-file scanning runs inside a `p-limit` concurrency pool. All scanners are wrapped in try/catch — failures are logged and never block the pipeline.
+Per-file scanning runs inside a `p-limit` concurrency pool. Tree-sitter parsing for non-`.cs` files is offloaded to a **Piscina worker pool** (`backend/src/parsers/parserPool.js`) so multi-core hosts actually use multiple cores; `.cs` files stay in-process because the pre-pass tree is cached and reused by the main pass to avoid a double parse. All scanners are wrapped in try/catch — failures are logged and never block the pipeline.
 
 1. Repo tree fetched (GitHub Octokit or uploaded ZIP)
 2. Files filtered by supported extension; manifest files separated
-3. Incremental hash check — unchanged files reuse their DB state
-4. Tree-sitter parses each changed file → imports, exports, cyclomatic complexity
+3. Incremental hash check — unchanged files reuse their DB state. A single `prepare_repo_reindex` RPC then stale-marks pending proposals, deletes non-preservable issues, wipes derived tables, and partial-purges changed/deleted nodes/chunks/file_contents in one transactional call
+4. Tree-sitter parses each changed file → imports, exports, cyclomatic complexity. JS/TS parsers also emit per-import symbol lists used by the proposal-context builder (US-064)
 5. Per-file scanners run in the same loop:
    - **Secret scanner** (`secretScanner.js`) — regex rules + high-entropy catch-all; suppressions filtered via `suppSet` (US-044)
    - **SAST engine** (`sastEngine.js`) — AST-query rules per language; per-repo disabled rules respected (US-046)
@@ -185,8 +208,9 @@ Per-file scanning runs inside a `p-limit` concurrency pool. All scanners are wra
 7. Dependency graph upserted (`graph_nodes` + `graph_edges`); metrics (incoming/outgoing counts) computed in-memory then persisted
 8. Architectural issue detection: circular dependencies (DFS), god files, high coupling, dead code
 9. SCA: manifest files parsed → OSV.dev batch query → `vulnerability_cache` + `dependency_manifests` + `analysis_issues` (US-045)
-10. All collected issues bulk-inserted into `analysis_issues`
+10. All collected issues bulk-inserted via `bulk_insert_analysis_issues` (single RPC instead of chunked inserts)
 11. File contents stored in `file_contents` table for AI review retrieval (US-043)
+12. Semantic chunks: each chunk's `sha256(content)` is looked up in `embedding_cache` first; only cache misses go to OpenAI. New embeddings are upserted into the cache and `last_used_at` is bumped on hits
 
 ---
 
@@ -355,7 +379,11 @@ ESLint in both `frontend/` and `backend/`. No Prettier, no commit hooks. Run `np
 - **Error handling:** `express-async-errors` patches async routes; centralized error middleware
 - **Concurrency:** `p-limit` controls concurrent file fetches; OSV enrichment limited to 5 concurrent requests
 - **Incremental indexing:** Files with unchanged `content_hash` skip parsing and scanning; their DB state (including `node_classification`) is preserved as-is
-- **SSE streaming:** AI review and security audit use Server-Sent Events; frontend reads with `ReadableStream` + `TextDecoder`; abort via `AbortController`
+- **SSE streaming:** AI review and security audit use Server-Sent Events; frontend reads with `ReadableStream` + `TextDecoder`; abort via `AbortController`. Server-side, every Claude stream binds `req.on('close')` to an `AbortController` via `backend/src/lib/sseAbort.js` (`bindRequestAbort` / `isAbortError`) so a closed tab stops generating tokens mid-stream
+- **Shared backend helpers** (`backend/src/lib/`):
+  - `dbHelpers.js` — `SAFE_FETCH_CEILING` + `warnIfCeilingHit` for bulk `.range(0, SAFE_FETCH_CEILING - 1)` selects; `withSupabaseRetry(fn, { tries, baseMs, label })` for critical writes (retries on 5xx / 429 / network errors only)
+  - `sseAbort.js` — `bindRequestAbort(req)` returns `{ signal, cleanup, isAborted }`; pass `signal` to any upstream SDK call and call `cleanup()` in `finally`
+- **Observability (Phase 0):** every request runs inside an `AsyncLocalStorage` ledger (`backend/src/observability/requestStore.js`); the Supabase client's custom fetch records `(method, table, durationMs, status)` per round-trip. Requests slower than `SLOW_REQUEST_MS` log a one-line summary with the top 3 DB calls. Set `LOG_REQUEST_TIMING=true` to log every request
 
 ---
 
@@ -367,3 +395,12 @@ ESLint in both `frontend/` and `backend/`. No Prettier, no commit hooks. Run `np
 - Frontend Vite proxy (`/api/*` → port 3001) configured in `frontend/vite.config.js`
 - Attack surface toggle forces `clusteringEnabled = false` — clustering uses cluster-level edge IDs incompatible with individual-node path IDs
 - `issue_suppressions` is rule-agnostic: `rule_id` is a free-text string, `line_number: 0` is the convention for file-level suppressions (used by `missing_auth`)
+
+---
+
+## Maintenance
+
+Periodic SQL snippets in [scripts/](scripts/) — apply via Supabase SQL Editor. No pg_cron required.
+
+- `maintenance_truncate_api_usage.sql` — monthly. Deletes `api_usage` rows older than 30 days. The rolling budget is served by `api_usage_daily` (trigger-maintained rollup), so raw `api_usage` is only needed for audit/debugging.
+- `maintenance_evict_embedding_cache.sql` — quarterly. Removes `embedding_cache` rows whose `last_used_at` is older than 90 days. The cache is keyed by chunk content hash and shared across repos.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "octokit": "^3.2.2",
         "openai": "^4.52.0",
         "p-limit": "^3.1.0",
+        "piscina": "^4.7.0",
         "tree-sitter": "^0.21.0",
         "tree-sitter-c-sharp": "^0.21.0",
         "tree-sitter-go": "^0.21.0",
@@ -589,6 +590,311 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
+    },
+    "node_modules/@napi-rs/nice": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
+      "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/nice-android-arm-eabi": "1.1.1",
+        "@napi-rs/nice-android-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-x64": "1.1.1",
+        "@napi-rs/nice-freebsd-x64": "1.1.1",
+        "@napi-rs/nice-linux-arm-gnueabihf": "1.1.1",
+        "@napi-rs/nice-linux-arm64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-arm64-musl": "1.1.1",
+        "@napi-rs/nice-linux-ppc64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-riscv64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-s390x-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-musl": "1.1.1",
+        "@napi-rs/nice-openharmony-arm64": "1.1.1",
+        "@napi-rs/nice-win32-arm64-msvc": "1.1.1",
+        "@napi-rs/nice-win32-ia32-msvc": "1.1.1",
+        "@napi-rs/nice-win32-x64-msvc": "1.1.1"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm-eabi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
+      "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
+      "integrity": "sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-freebsd-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
+      "integrity": "sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
+      "integrity": "sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
+      "integrity": "sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
+      "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
+      "integrity": "sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
+      "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-s390x-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
+      "integrity": "sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
+      "integrity": "sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
+      "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-openharmony-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
+      "integrity": "sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-arm64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
+      "integrity": "sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-ia32-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
+      "integrity": "sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-x64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
+      "integrity": "sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -4071,6 +4377,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.2.tgz",
+      "integrity": "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@napi-rs/nice": "^1.0.1"
       }
     },
     "node_modules/postcss": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "octokit": "^3.2.2",
     "openai": "^4.52.0",
     "p-limit": "^3.1.0",
+    "piscina": "^4.7.0",
     "tree-sitter": "^0.21.0",
     "tree-sitter-c-sharp": "^0.21.0",
     "tree-sitter-go": "^0.21.0",

--- a/backend/src/controllers/analysisController.js
+++ b/backend/src/controllers/analysisController.js
@@ -1,4 +1,5 @@
 const { supabase, supabaseAdmin } = require('../db/supabase');
+const { SAFE_FETCH_CEILING, warnIfCeilingHit } = require('../lib/dbHelpers');
 
 /** GET /api/analysis/:repoId/graph — dependency graph nodes + edges */
 const getDependencyGraph = async (req, res) => {
@@ -18,9 +19,11 @@ const getIssues = async (req, res) => {
   const { data, error } = await supabaseAdmin
     .from('analysis_issues')
     .select('*')
-    .eq('repo_id', repoId);
-    
+    .eq('repo_id', repoId)
+    .range(0, SAFE_FETCH_CEILING - 1);
+
   if (error) return res.status(500).json({ error: error.message });
+  warnIfCeilingHit('analysisController.getIssues', data);
   res.json(data);
 };
 

--- a/backend/src/controllers/fileChatController.js
+++ b/backend/src/controllers/fileChatController.js
@@ -13,6 +13,7 @@
 
 const Anthropic = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
+const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
 
 const anthropic = globalThis.__CODELENS_ANTHROPIC__ || new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY || 'sk-ant-dummy' });
 
@@ -179,21 +180,34 @@ const chatWithFile = async (req, res) => {
       'When you reference code, cite file paths and (approximate) line numbers when possible.',
     ].join(' ');
 
-    const stream = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 1500,
-      system: `${system}\n\n${systemContext}`,
-      messages: [{ role: 'user', content: query.trim() }],
-      stream: true,
-    });
+    const { signal, cleanup } = bindRequestAbort(req);
+    let aborted = false;
+    try {
+      const stream = await anthropic.messages.create({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1500,
+        system: `${system}\n\n${systemContext}`,
+        messages: [{ role: 'user', content: query.trim() }],
+        stream: true,
+      }, { signal });
 
-    for await (const event of stream) {
-      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
-        send({ type: 'chunk', text: event.delta.text });
+      for await (const event of stream) {
+        if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+          send({ type: 'chunk', text: event.delta.text });
+        }
       }
+    } catch (streamErr) {
+      if (isAbortError(streamErr, signal)) {
+        aborted = true;
+        console.warn('[fileChat] Claude stream aborted by client disconnect');
+      } else {
+        throw streamErr;
+      }
+    } finally {
+      cleanup();
     }
 
-    send({ type: 'done' });
+    if (!aborted) send({ type: 'done' });
     res.end();
   } catch (err) {
     console.error('[fileChat] Error:', err);

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const path = require('path');
 const { Octokit } = require('octokit');
 const { supabaseAdmin } = require('../db/supabase');
+const { SAFE_FETCH_CEILING, warnIfCeilingHit } = require('../lib/dbHelpers');
 const _indexer = require('../services/indexer');
 const { isManifestFile, parseManifest } = require('../services/manifestParser');
 const { scanDependencies } = require('../services/osvScanner');
@@ -300,15 +301,19 @@ const getAnalysisData = async (req, res) => {
       { data: issues, error: issuesErr }
     ] = await Promise.all([
       supabaseAdmin.from('repositories').select('has_coverage_files').eq('id', repoId).single(),
-      supabaseAdmin.from('graph_nodes').select('*').eq('repo_id', repoId).order('file_path', { ascending: true }),
-      supabaseAdmin.from('graph_edges').select('*').eq('repo_id', repoId).order('from_path', { ascending: true }).order('to_path', { ascending: true }),
-      supabaseAdmin.from('analysis_issues').select('*').eq('repo_id', repoId).order('id', { ascending: true })
+      supabaseAdmin.from('graph_nodes').select('*').eq('repo_id', repoId).order('file_path', { ascending: true }).range(0, SAFE_FETCH_CEILING - 1),
+      supabaseAdmin.from('graph_edges').select('*').eq('repo_id', repoId).order('from_path', { ascending: true }).order('to_path', { ascending: true }).range(0, SAFE_FETCH_CEILING - 1),
+      supabaseAdmin.from('analysis_issues').select('*').eq('repo_id', repoId).order('id', { ascending: true }).range(0, SAFE_FETCH_CEILING - 1),
     ]);
 
     if (repoMetaErr) throw repoMetaErr;
     if (nodesErr) throw nodesErr;
     if (edgesErr) throw edgesErr;
     if (issuesErr) throw issuesErr;
+
+    warnIfCeilingHit('getAnalysisData.nodes', nodes);
+    warnIfCeilingHit('getAnalysisData.edges', edges);
+    warnIfCeilingHit('getAnalysisData.issues', issues);
 
     console.log(`[getAnalysisData] Found ${nodes.length} nodes, ${edges.length} edges, ${issues.length} issues for repo ${repoId}`);
 
@@ -751,12 +756,15 @@ const getChurn = async (req, res) => {
       { data: churnRows, error: churnErr },
       { data: nodeRows,  error: nodeErr  },
     ] = await Promise.all([
-      supabaseAdmin.from('file_churn').select('file_path,commit_count,unique_authors,lines_changed,last_modified').eq('repo_id', repoId),
-      supabaseAdmin.from('graph_nodes').select('file_path,complexity_score').eq('repo_id', repoId),
+      supabaseAdmin.from('file_churn').select('file_path,commit_count,unique_authors,lines_changed,last_modified').eq('repo_id', repoId).range(0, SAFE_FETCH_CEILING - 1),
+      supabaseAdmin.from('graph_nodes').select('file_path,complexity_score').eq('repo_id', repoId).range(0, SAFE_FETCH_CEILING - 1),
     ]);
 
     if (churnErr) throw churnErr;
     if (nodeErr)  throw nodeErr;
+
+    warnIfCeilingHit('getChurn.file_churn', churnRows);
+    warnIfCeilingHit('getChurn.graph_nodes', nodeRows);
 
     if (!churnRows || churnRows.length === 0) {
       return res.json({ churn: [] });

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -6,6 +6,7 @@ const { OpenAI }        = require('openai');
 const Anthropic         = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage }   = require('../services/usageTracker');
+const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -49,16 +50,22 @@ async function canAccessRepo(repoId, userId) {
   return !!teamRepo;
 }
 
+// Phase 3.3: read the api_usage_daily rollup instead of scanning api_usage.
+// Mirrors the aiRateLimit middleware so per-target audit budget checks (which
+// run once per file in a whole-repo audit) stay O(1) regardless of usage
+// table size. A 24h rolling window straddles at most two UTC days.
 async function dailyTokensUsed(userId) {
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const now    = new Date();
+  const today  = now.toISOString().slice(0, 10);
+  const yest   = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const { data, error } = await supabaseAdmin
-    .from('api_usage')
+    .from('api_usage_daily')
     .select('prompt_tokens, completion_tokens, embedding_tokens')
     .eq('user_id', userId)
-    .gte('created_at', since);
+    .in('usage_date', [today, yest]);
   if (error) return 0;
   return (data || []).reduce(
-    (sum, row) => sum + (row.prompt_tokens || 0) + (row.completion_tokens || 0) + (row.embedding_tokens || 0),
+    (sum, row) => sum + Number(row.prompt_tokens || 0) + Number(row.completion_tokens || 0) + Number(row.embedding_tokens || 0),
     0
   );
 }
@@ -324,31 +331,47 @@ async function embedSnippet(snippet, userId, endpoint = 'review') {
   return embedding;
 }
 
-async function streamClaude({ system, user, send, userId, endpoint = 'review', maxTokens = 1500 }) {
-  const stream = await anthropic.messages.create({
-    model: MODEL,
-    max_tokens: maxTokens,
-    system,
-    messages: [{ role: 'user', content: user }],
-    stream: true,
-  });
-
+async function streamClaude({ system, user, send, userId, endpoint = 'review', maxTokens = 1500, req }) {
+  const { signal, cleanup } = bindRequestAbort(req);
   let text = '';
   let inputTokens = 0;
   let outputTokens = 0;
-  for await (const event of stream) {
-    if (event.type === 'message_start') {
-      inputTokens = event.message?.usage?.input_tokens || 0;
-    } else if (event.type === 'message_delta') {
-      outputTokens = event.usage?.output_tokens || outputTokens;
-    } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
-      text += event.delta.text;
-      send?.({ type: 'chunk', text: event.delta.text });
+  let aborted = false;
+
+  try {
+    const stream = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: 'user', content: user }],
+      stream: true,
+    }, { signal });
+
+    for await (const event of stream) {
+      if (event.type === 'message_start') {
+        inputTokens = event.message?.usage?.input_tokens || 0;
+      } else if (event.type === 'message_delta') {
+        outputTokens = event.usage?.output_tokens || outputTokens;
+      } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+        text += event.delta.text;
+        send?.({ type: 'chunk', text: event.delta.text });
+      }
     }
+  } catch (err) {
+    if (isAbortError(err, signal)) {
+      aborted = true;
+      console.warn(`[review] Claude stream aborted by client disconnect (endpoint=${endpoint}, partial_output_tokens=${outputTokens})`);
+    } else {
+      throw err;
+    }
+  } finally {
+    cleanup();
   }
 
+  // Record usage even on abort — input tokens were already billed and any partial
+  // output tokens count too. Skipping this would let abuse vectors hide cost.
   await recordUsage({ userId, endpoint, provider: 'anthropic', promptTokens: inputTokens, completionTokens: outputTokens });
-  return { text, inputTokens, outputTokens };
+  return { text, inputTokens, outputTokens, aborted };
 }
 
 async function fetchFileSource(repoId, filePath) {
@@ -467,7 +490,10 @@ const review = async (req, res) => {
 
     let chunks;
     try {
-      const retrieved = await retrieveChunks(repoId, embedding, mode === 'security_audit' ? 12 : 5);
+      // Phase 1.6: security_audit fetched 12 chunks then sliced to 5 after re-rank,
+      // wasting ~half the vector compute. 6 keeps the re-rank meaningful while
+      // halving the distance work.
+      const retrieved = await retrieveChunks(repoId, embedding, mode === 'security_audit' ? 6 : 5);
       chunks = mode === 'security_audit' ? rerankSecurityChunks(retrieved).slice(0, 5) : retrieved.slice(0, 5);
     } catch {
       send({ type: 'error', message: 'Failed to search the codebase index. Please try again.' });
@@ -478,7 +504,8 @@ const review = async (req, res) => {
     const { system, user } = buildReviewPrompt(snippet.trim(), contextDescription, chunks, mode, filePath);
     // In security_audit mode, suppress raw chunk events — findings arrive as structured `finding` SSE events instead.
     const chunkSend = mode === 'security_audit' ? null : send;
-    const { text } = await streamClaude({ system, user, send: chunkSend, userId: req.user.id, endpoint: 'review' });
+    const { text, aborted } = await streamClaude({ system, user, send: chunkSend, userId: req.user.id, endpoint: 'review', req });
+    if (aborted) return res.end();
 
     if (mode === 'security_audit') {
       const issues = await fetchDeterministicIssues(repoId, filePath ? [filePath] : []);
@@ -581,7 +608,9 @@ const runSecurityAudit = async (req, res) => {
       send({ type: 'progress', file_path: target.file_path, index: index + 1, total: preparedTargets.length, status: 'auditing', estimated_tokens: estimatedTokens, remaining_tokens: remaining });
 
       const embedding = await embedSnippet(source.slice(0, 12000), req.user.id, 'security_audit');
-      const retrieved = await retrieveChunks(repoId, embedding, 12);
+      // Phase 1.6: retrieve 6 then keep 5 — half the vector distance compute we
+      // were spending when this was 12.
+      const retrieved = await retrieveChunks(repoId, embedding, 6);
       const chunks = rerankSecurityChunks(retrieved).slice(0, 5);
       send({ type: 'sources', file_path: target.file_path, sources: chunks.map(formatSource) });
 
@@ -599,7 +628,17 @@ const runSecurityAudit = async (req, res) => {
       }
 
       const { system, user } = buildReviewPrompt(source.slice(0, 20000), `Whole-repo security audit target: ${target.file_path}`, chunks, 'security_audit', target.file_path);
-      const { text } = await streamClaude({ system, user, send, userId: req.user.id, endpoint: 'security_audit', maxTokens: 1200 });
+      const { text, aborted } = await streamClaude({ system, user, send, userId: req.user.id, endpoint: 'security_audit', maxTokens: 1200, req });
+      if (aborted) {
+        // Client disconnected mid-audit. Persist a partial report so the user
+        // can resume from where we stopped, then exit the loop without billing
+        // for remaining targets.
+        report.status = 'partial';
+        report.summary.narrative = `Security audit aborted by client after ${report.summary.audited_count} file(s).`;
+        const audit = await persistAudit({ userId: req.user.id, repoId, report });
+        try { send({ type: 'aborted', audit }); } catch { /* connection already gone */ }
+        return res.end();
+      }
       report.raw_text += `\n\n--- ${target.file_path} ---\n${text}`;
 
       const fileIssues = deterministicIssues.filter((issue) => (issue.file_paths || []).includes(target.file_path));
@@ -710,21 +749,507 @@ const duplicationRefactor = async (req, res) => {
     }
 
     const { system, user } = buildDuplicationRefactorPrompt(cluster);
-    await streamClaude({
+    const { aborted } = await streamClaude({
       system,
       user,
       send,
       userId: req.user.id,
       endpoint: 'duplication_refactor',
       maxTokens: 1800,
+      req,
     });
 
-    send({ type: 'done' });
+    if (!aborted) send({ type: 'done' });
     res.end();
   } catch (err) {
     console.error('[duplication-refactor] Unhandled error:', err);
     try {
       send({ type: 'error', message: 'Failed to generate a duplication refactor. Please try again.' });
+      res.end();
+    } catch {
+      res.end();
+    }
+  }
+};
+
+// ─── US-064: Refactor proposal generation ─────────────────────────────────────
+
+const PROPOSAL_MAX_TOKENS = 4000;
+const PROPOSAL_FILE_BUDGET_CHARS = 30000; // ≈ 7.5k tokens per file
+const PROPOSAL_NEIGHBOUR_LIMIT = 5;
+const PROPOSAL_IMPORTERS_LIMIT = 30;
+
+const PROPOSAL_SYSTEM_BASE = [
+  'You are a senior engineer proposing a concrete code refactor.',
+  'Output a single JSON object matching this exact schema:',
+  '{ "summary": string, "rationale": string, "changes": [{ "file_path": string, "action": "create"|"modify"|"delete", "diff": string, "full_content": string }], "risks": string[] }',
+  'Return ONLY the JSON object. No commentary, no markdown fences, no prose around it.',
+  'Diffs MUST be in unified format (--- a/path, +++ b/path, @@ hunks).',
+  'For create and modify actions, include the entire resulting file as full_content.',
+  'For delete actions, leave full_content empty and explain in risks.',
+  'List in risks anything the static analysis could miss (reflection, dynamic imports, runtime DI).',
+].join(' ');
+
+async function fetchAnalysisIssue(repoId, issueId) {
+  const { data, error } = await supabaseAdmin
+    .from('analysis_issues')
+    .select('id, repo_id, type, severity, file_paths, description')
+    .eq('id', issueId)
+    .eq('repo_id', repoId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data;
+}
+
+async function fetchCachedPendingProposal(issueId, userId) {
+  const { data } = await supabaseAdmin
+    .from('issue_proposals')
+    .select('id, proposal_json, created_at')
+    .eq('issue_id', issueId)
+    .eq('user_id', userId)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data || null;
+}
+
+function clipFile(source, limit = PROPOSAL_FILE_BUDGET_CHARS) {
+  if (!source) return '';
+  if (source.length <= limit) return source;
+  return source.slice(0, limit) + '\n/* [CodeLens] truncated for context budget */';
+}
+
+async function buildGodFileContext(issue, repoId, filePath) {
+  const source = clipFile(await fetchFileSource(repoId, filePath) || '');
+
+  const { data: importers } = await supabaseAdmin
+    .from('graph_edges')
+    .select('from_path, symbols')
+    .eq('repo_id', repoId)
+    .eq('to_path', filePath);
+
+  const ranked = (importers || []).slice().sort((a, b) => {
+    const al = Array.isArray(a.symbols) ? a.symbols.length : 0;
+    const bl = Array.isArray(b.symbols) ? b.symbols.length : 0;
+    return bl - al;
+  });
+
+  const importerLines = ranked.slice(0, PROPOSAL_IMPORTERS_LIMIT).map((r) => {
+    const syms = (Array.isArray(r.symbols) ? r.symbols : []).filter(Boolean);
+    return syms.length > 0
+      ? `- ${r.from_path}: uses ${syms.join(', ')}`
+      : `- ${r.from_path}: (no symbol tracking on this edge)`;
+  }).join('\n');
+
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: split a god file into focused modules, minimising cross-cuts based on which symbols each importer actually uses. For backward compatibility, the original file should re-export from the new files unless explicitly safe to break.';
+  const user = [
+    `File flagged as a god file: ${filePath}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    '',
+    'Importers and the symbols each one uses:',
+    importerLines || '(no importers found)',
+    '',
+    'Current file content:',
+    '```',
+    source,
+    '```',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildCircularContext(issue, repoId) {
+  const paths = Array.isArray(issue.file_paths) ? issue.file_paths : [];
+  const fileBlocks = [];
+  for (const p of paths.slice(0, 6)) {
+    const src = await fetchFileSource(repoId, p);
+    const trimmed = clipFile(src || '(file content unavailable)', 8000);
+    fileBlocks.push(`--- ${p} ---\n${trimmed}`);
+  }
+
+  let edges = [];
+  if (paths.length > 0) {
+    const { data } = await supabaseAdmin
+      .from('graph_edges')
+      .select('from_path, to_path, symbols')
+      .eq('repo_id', repoId)
+      .in('from_path', paths)
+      .in('to_path', paths);
+    edges = data || [];
+  }
+
+  const edgeLines = edges.map((e) => {
+    const syms = Array.isArray(e.symbols) && e.symbols.length > 0 ? ` (${e.symbols.join(', ')})` : '';
+    return `- ${e.from_path} → ${e.to_path}${syms}`;
+  }).join('\n');
+
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: break a circular import cycle with the cheapest possible cut — usually extracting a shared dependency into a new file, moving one symbol, or inverting a dependency.';
+  const user = [
+    `Circular dependency involves: ${paths.join(', ')}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    '',
+    'Edges between these files (importer → importee, symbols where known):',
+    edgeLines || '(no edges captured)',
+    '',
+    'File contents:',
+    fileBlocks.join('\n\n'),
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildHighCouplingContext(issue, repoId, filePath) {
+  const source = clipFile(await fetchFileSource(repoId, filePath) || '');
+
+  const { data: outEdges } = await supabaseAdmin
+    .from('graph_edges')
+    .select('to_path, symbols')
+    .eq('repo_id', repoId)
+    .eq('from_path', filePath);
+  const { data: inEdges } = await supabaseAdmin
+    .from('graph_edges')
+    .select('from_path, symbols')
+    .eq('repo_id', repoId)
+    .eq('to_path', filePath);
+
+  const neighbourMap = new Map();
+  for (const e of (outEdges || [])) {
+    const n = neighbourMap.get(e.to_path) || { path: e.to_path, count: 0, symbols: new Set() };
+    n.count += 1;
+    (e.symbols || []).forEach((s) => n.symbols.add(s));
+    neighbourMap.set(e.to_path, n);
+  }
+  for (const e of (inEdges || [])) {
+    const n = neighbourMap.get(e.from_path) || { path: e.from_path, count: 0, symbols: new Set() };
+    n.count += 1;
+    (e.symbols || []).forEach((s) => n.symbols.add(s));
+    neighbourMap.set(e.from_path, n);
+  }
+  const top = [...neighbourMap.values()].sort((a, b) => b.count - a.count).slice(0, PROPOSAL_NEIGHBOUR_LIMIT);
+  const lines = top.map((n) => `- ${n.path}${n.symbols.size > 0 ? ` (symbols: ${[...n.symbols].join(', ')})` : ''}`).join('\n');
+
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: reduce coupling by introducing an interface, narrowing the API surface, or relocating responsibilities.';
+  const user = [
+    `High coupling on file: ${filePath}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    '',
+    `Top ${PROPOSAL_NEIGHBOUR_LIMIT} most-coupled neighbours:`,
+    lines || '(no neighbours identified)',
+    '',
+    'File content:',
+    '```',
+    source,
+    '```',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildDeadCodeContext(issue, repoId, filePath) {
+  const source = clipFile(await fetchFileSource(repoId, filePath) || '');
+  const { data: incoming } = await supabaseAdmin
+    .from('graph_edges')
+    .select('from_path')
+    .eq('repo_id', repoId)
+    .eq('to_path', filePath);
+
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: remove dead code. Use action "delete" for files that should be removed entirely. Flag reflection / dynamic-import callers as risks since the static graph could miss them.';
+  const user = [
+    `Dead code candidate: ${filePath}`,
+    `Static incoming edges: ${(incoming || []).length}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    '',
+    'Current file content:',
+    '```',
+    source,
+    '```',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildMissingAuthContext(issue, repoId, filePath) {
+  const source = clipFile(await fetchFileSource(repoId, filePath) || '');
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: add auth protection to an unauthenticated route handler. Re-use the same middleware/decorator pattern the rest of the file already uses for authenticated routes if one is visible. If no auth helper is imported, propose a minimal import based on the file\'s existing dependencies.';
+  const user = [
+    `Route handler file with unauthenticated routes: ${filePath}`,
+    issue.description ? `Issue description (lists the unauthenticated paths): ${issue.description}` : '',
+    '',
+    'File content:',
+    '```',
+    source,
+    '```',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildHardcodedSecretContext(issue, repoId, filePath) {
+  const source = await fetchFileSource(repoId, filePath) || '';
+  const lineMatch = String(issue.description || '').match(/line\s+(\d+)/i);
+  const line = lineMatch ? Number(lineMatch[1]) : null;
+
+  let snippet;
+  if (line) {
+    const lines = source.split('\n');
+    const start = Math.max(0, line - 11);
+    const end = Math.min(lines.length, line + 10);
+    snippet = lines.slice(start, end).map((l, i) => `${start + i + 1}: ${l}`).join('\n');
+  } else {
+    snippet = clipFile(source, 8000);
+  }
+
+  const envExample = await fetchFileSource(repoId, '.env.example');
+
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: replace a hardcoded secret with a runtime read from environment configuration. NEVER repeat the original secret value verbatim. Add the new key to .env.example if it is provided, otherwise list it in risks.';
+  const user = [
+    `File with hardcoded secret: ${filePath}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    line ? `Secret is on line ${line} (±10 lines below).` : '',
+    '',
+    'Source snippet:',
+    '```',
+    snippet,
+    '```',
+    envExample ? `\nExisting .env.example:\n\`\`\`\n${clipFile(envExample, 4000)}\n\`\`\`` : '\n(.env.example not found in repo)',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildVulnDependencyContext(issue, repoId, filePath) {
+  const source = filePath ? clipFile(await fetchFileSource(repoId, filePath) || '', 12000) : '';
+  const system = PROPOSAL_SYSTEM_BASE + ' Specifically: a dependency in this manifest has a known vulnerability. Propose the safe upgrade. For lockfiles, only describe the version change in the diff and list re-generation steps in risks — do not invent a full lockfile diff.';
+  const user = [
+    `Vulnerable dependency in: ${filePath || '(unknown manifest)'}`,
+    issue.description ? `Issue description: ${issue.description}` : '',
+    '',
+    filePath ? `Manifest content:\n\`\`\`\n${source}\n\`\`\`` : '',
+  ].filter(Boolean).join('\n');
+  return { system, user };
+}
+
+async function buildGenericContext(issue, repoId, filePath) {
+  const source = filePath ? clipFile(await fetchFileSource(repoId, filePath) || '') : '';
+  const user = [
+    `Issue type: ${issue.type}`,
+    `Affected file: ${filePath || '(none)'}`,
+    `Severity: ${issue.severity || 'unknown'}`,
+    `Description: ${issue.description || '(no description)'}`,
+    filePath ? `\nFile content:\n\`\`\`\n${source}\n\`\`\`` : '',
+  ].filter(Boolean).join('\n');
+  return { system: PROPOSAL_SYSTEM_BASE, user };
+}
+
+async function buildContextForIssue(issue, repoId) {
+  const primary = Array.isArray(issue.file_paths) ? issue.file_paths[0] : null;
+  switch (issue.type) {
+    case 'god_file':              return buildGodFileContext(issue, repoId, primary);
+    case 'circular_dependency':   return buildCircularContext(issue, repoId);
+    case 'high_coupling':         return buildHighCouplingContext(issue, repoId, primary);
+    case 'dead_code':             return buildDeadCodeContext(issue, repoId, primary);
+    case 'missing_auth':          return buildMissingAuthContext(issue, repoId, primary);
+    case 'hardcoded_secret':      return buildHardcodedSecretContext(issue, repoId, primary);
+    case 'vulnerable_dependency': return buildVulnDependencyContext(issue, repoId, primary);
+    default:                      return buildGenericContext(issue, repoId, primary);
+  }
+}
+
+function extractStreamingSummary(text) {
+  const match = text.match(/"summary"\s*:\s*"((?:[^"\\]|\\.)*)/);
+  if (!match) return '';
+  // Unescape in the correct JSON order: collapse `\\` first via a sentinel so
+  // that a literal backslash followed by `n` (e.g. a Windows path) isn't
+  // mis-interpreted as a newline escape.
+  return match[1]
+    .replace(/\\\\/g, '')
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(//g, '\\');
+}
+
+function normalizeChange(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const action = String(raw.action || '').toLowerCase();
+  if (!['create', 'modify', 'delete'].includes(action)) return null;
+  const filePath = String(raw.file_path || '').trim();
+  if (!filePath) return null;
+  return {
+    file_path: filePath,
+    action,
+    diff: typeof raw.diff === 'string' ? raw.diff : '',
+    full_content: typeof raw.full_content === 'string' ? raw.full_content : '',
+  };
+}
+
+function normalizeProposal(parsed) {
+  if (!parsed || typeof parsed !== 'object') return null;
+  return {
+    summary:   String(parsed.summary || '').trim(),
+    rationale: String(parsed.rationale || '').trim(),
+    changes:   Array.isArray(parsed.changes) ? parsed.changes.map(normalizeChange).filter(Boolean) : [],
+    risks:     Array.isArray(parsed.risks) ? parsed.risks.map((r) => String(r).trim()).filter(Boolean) : [],
+  };
+}
+
+function parseProposalJson(text) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) return null;
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidates = fenced ? [fenced[1].trim(), trimmed] : [trimmed];
+  for (const candidate of candidates) {
+    try {
+      return normalizeProposal(JSON.parse(candidate));
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  // Last-resort: extract the largest brace-balanced JSON substring.
+  const start = trimmed.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < trimmed.length; i++) {
+    if (trimmed[i] === '{') depth++;
+    else if (trimmed[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        try {
+          return normalizeProposal(JSON.parse(trimmed.slice(start, i + 1)));
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function emitProposalEvents(send, proposal) {
+  if (!proposal) return;
+  if (proposal.summary) send({ type: 'summary_delta', delta: proposal.summary });
+  for (const change of (proposal.changes || [])) send({ type: 'change', change });
+  for (const risk of (proposal.risks || [])) send({ type: 'risk', risk });
+}
+
+const generateProposal = async (req, res) => {
+  const { repoId, issueId } = req.params;
+  const regenerate = String(req.query?.regenerate || '').toLowerCase() === 'true';
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  const issue = await fetchAnalysisIssue(repoId, issueId);
+  if (!issue) return res.status(404).json({ error: 'Issue not found' });
+
+  openSse(res);
+  const send = sendFactory(res);
+
+  try {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      send({ type: 'error', message: 'Proposal generation requires the Anthropic API key.' });
+      return res.end();
+    }
+
+    if (!regenerate) {
+      const cached = await fetchCachedPendingProposal(issueId, req.user.id);
+      if (cached?.proposal_json) {
+        emitProposalEvents(send, cached.proposal_json);
+        send({ type: 'done', proposal_id: cached.id, cached: true });
+        return res.end();
+      }
+    }
+
+    const { system, user } = await buildContextForIssue(issue, repoId);
+    const { signal, cleanup } = bindRequestAbort(req);
+
+    let text = '';
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let summaryEmitted = '';
+    let aborted = false;
+
+    try {
+      const stream = await anthropic.messages.create({
+        model: MODEL,
+        max_tokens: PROPOSAL_MAX_TOKENS,
+        system,
+        messages: [{ role: 'user', content: user }],
+        stream: true,
+      }, { signal });
+
+      for await (const event of stream) {
+        if (event.type === 'message_start') {
+          inputTokens = event.message?.usage?.input_tokens || 0;
+        } else if (event.type === 'message_delta') {
+          outputTokens = event.usage?.output_tokens || outputTokens;
+        } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+          text += event.delta.text;
+          const currentSummary = extractStreamingSummary(text);
+          if (currentSummary && currentSummary.length > summaryEmitted.length) {
+            const delta = currentSummary.slice(summaryEmitted.length);
+            summaryEmitted = currentSummary;
+            send({ type: 'summary_delta', delta });
+          }
+        }
+      }
+    } catch (streamErr) {
+      if (isAbortError(streamErr, signal)) {
+        aborted = true;
+        console.warn(`[proposals] Claude stream aborted by client disconnect (issue=${issueId}, partial_output_tokens=${outputTokens})`);
+      } else {
+        throw streamErr;
+      }
+    } finally {
+      cleanup();
+    }
+
+    await recordUsage({
+      userId: req.user.id,
+      endpoint: 'proposal_generation',
+      provider: 'anthropic',
+      promptTokens: inputTokens,
+      completionTokens: outputTokens,
+    });
+
+    if (aborted) return res.end();
+
+    const parsed = parseProposalJson(text);
+    if (!parsed) {
+      send({ type: 'error', message: 'Could not parse a structured proposal from the model output.' });
+      return res.end();
+    }
+
+    // If we never streamed any summary text (model emitted summary after other fields), send it now.
+    if (!summaryEmitted && parsed.summary) {
+      send({ type: 'summary_delta', delta: parsed.summary });
+    }
+    for (const change of parsed.changes) send({ type: 'change', change });
+    for (const risk of parsed.risks) send({ type: 'risk', risk });
+
+    const { data: inserted, error: insErr } = await supabaseAdmin
+      .from('issue_proposals')
+      .insert({
+        issue_id: issueId,
+        user_id: req.user.id,
+        status: 'pending',
+        proposal_json: parsed,
+        prompt_tokens: inputTokens,
+        completion_tokens: outputTokens,
+      })
+      .select('id')
+      .single();
+
+    if (insErr) {
+      console.warn('[proposals] Failed to persist proposal:', insErr.message);
+      send({ type: 'error', message: 'Could not save the generated proposal.' });
+      return res.end();
+    }
+
+    send({ type: 'done', proposal_id: inserted.id });
+    res.end();
+  } catch (err) {
+    console.error('[proposals] Unhandled error:', err);
+    try {
+      send({ type: 'error', message: 'An unexpected error occurred generating the proposal.' });
       res.end();
     } catch {
       res.end();
@@ -738,6 +1263,7 @@ module.exports = {
   listSecurityAudits,
   getSecurityAudit,
   duplicationRefactor,
+  generateProposal,
   _private: {
     parseFindingsFromText,
     rerankSecurityChunks,
@@ -745,5 +1271,9 @@ module.exports = {
     linkFindingsToIssues,
     estimateAuditTokens,
     buildDuplicationRefactorPrompt,
+    parseProposalJson,
+    normalizeProposal,
+    extractStreamingSummary,
+    buildContextForIssue,
   },
 };

--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -18,6 +18,7 @@ const { OpenAI }     = require('openai');
 const Anthropic      = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage } = require('../services/usageTracker');
+const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
 
 const _openai    = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'sk-dummy' });
 const _anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY || 'sk-ant-dummy' });
@@ -244,32 +245,47 @@ const search = async (req, res) => {
 
     // 8. Stream Claude response
     const llmStart = Date.now();
-    const stream = await anthropic.messages.create({
-      model:      'claude-sonnet-4-20250514',
-      max_tokens: 1500,
-      system,
-      messages:   [{ role: 'user', content: user }],
-      stream:     true,
-    });
-
+    const { signal, cleanup } = bindRequestAbort(req);
+    let aborted = false;
     let inputTokens = 0, outputTokens = 0;
-    for await (const event of stream) {
-      if (pipelineTimedOut) break;
-      if (event.type === 'message_start') {
-        inputTokens = event.message?.usage?.input_tokens || 0;
-      } else if (event.type === 'message_delta') {
-        outputTokens = event.usage?.output_tokens || 0;
-      } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
-        send({ type: 'chunk', text: event.delta.text });
+    try {
+      const stream = await anthropic.messages.create({
+        model:      'claude-sonnet-4-20250514',
+        max_tokens: 1500,
+        system,
+        messages:   [{ role: 'user', content: user }],
+        stream:     true,
+      }, { signal });
+
+      for await (const event of stream) {
+        if (pipelineTimedOut) break;
+        if (event.type === 'message_start') {
+          inputTokens = event.message?.usage?.input_tokens || 0;
+        } else if (event.type === 'message_delta') {
+          outputTokens = event.usage?.output_tokens || 0;
+        } else if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+          send({ type: 'chunk', text: event.delta.text });
+        }
       }
+    } catch (streamErr) {
+      if (isAbortError(streamErr, signal)) {
+        aborted = true;
+        console.warn(`[search] Claude stream aborted by client disconnect (partial_output_tokens=${outputTokens})`);
+      } else {
+        throw streamErr;
+      }
+    } finally {
+      cleanup();
     }
 
     recordUsage({ userId: req.user.id, endpoint: 'search', provider: 'anthropic', promptTokens: inputTokens, completionTokens: outputTokens });
 
     clearTimeout(timeoutId);
-    if (!pipelineTimedOut) {
+    if (!pipelineTimedOut && !aborted) {
       console.log(`[search] LLM streaming took ${Date.now() - llmStart}ms, total pipeline ${Date.now() - pipelineStart}ms`);
       send({ type: 'done' });
+      res.end();
+    } else if (aborted) {
       res.end();
     }
 

--- a/backend/src/controllers/toursController.js
+++ b/backend/src/controllers/toursController.js
@@ -6,6 +6,7 @@ const { OpenAI }        = require('openai');
 const Anthropic         = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage }   = require('../services/usageTracker');
+const { bindRequestAbort } = require('../lib/sseAbort');
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -52,16 +53,21 @@ async function canAccessRepo(repoId, userId) {
   return access.isOwner || access.hasTeamAccess;
 }
 
+// Phase 3.3: read the api_usage_daily rollup instead of scanning api_usage.
+// Mirrors the aiRateLimit middleware so per-step tour budget checks stay
+// O(1) regardless of usage table size.
 async function dailyTokensUsed(userId) {
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const now    = new Date();
+  const today  = now.toISOString().slice(0, 10);
+  const yest   = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const { data, error } = await supabaseAdmin
-    .from('api_usage')
+    .from('api_usage_daily')
     .select('prompt_tokens, completion_tokens, embedding_tokens')
     .eq('user_id', userId)
-    .gte('created_at', since);
+    .in('usage_date', [today, yest]);
   if (error) return 0;
   return (data || []).reduce(
-    (sum, row) => sum + (row.prompt_tokens || 0) + (row.completion_tokens || 0) + (row.embedding_tokens || 0),
+    (sum, row) => sum + Number(row.prompt_tokens || 0) + Number(row.completion_tokens || 0) + Number(row.embedding_tokens || 0),
     0
   );
 }
@@ -88,6 +94,7 @@ async function explainSteps({
   buildUserPrompt,
   systemPrompt,
   maxTokens = 300,
+  abortSignal,
 }) {
   // Batch-fetch first chunk for files not already in relevantSet (avoid N+1)
   const fallbackByPath = new Map();
@@ -113,6 +120,12 @@ async function explainSteps({
 
     if (budgetRemaining <= 0) {
       console.warn(`[tour] daily token budget exhausted at step ${i + 1}/${filePaths.length}`);
+      stoppedEarly = true;
+      break;
+    }
+
+    if (abortSignal?.aborted) {
+      console.warn(`[tour] aborted by client disconnect at step ${i + 1}/${filePaths.length}`);
       stoppedEarly = true;
       break;
     }
@@ -146,7 +159,7 @@ async function explainSteps({
         max_tokens: maxTokens,
         system:     systemPrompt,
         messages:   [{ role: 'user', content: userPrompt }],
-      });
+      }, abortSignal ? { signal: abortSignal } : undefined);
       explanation = response.content[0]?.type === 'text' ? response.content[0].text : '';
       const inputTokens  = response.usage?.input_tokens  || 0;
       const outputTokens = response.usage?.output_tokens || 0;
@@ -278,24 +291,35 @@ const generateTour = async (req, res) => {
     }
   }
 
-  // 7. Generate Claude explanation for each step
-  const { steps } = await explainSteps({
-    filePaths:    result,
-    repoId,
-    userId,
-    relevantSet,
-    systemPrompt: 'You are a senior software engineer writing clear, concise guided tour steps for developers exploring an unfamiliar codebase.',
-    buildUserPrompt: ({ filePath, index, excerpt }) => {
-      const previousTitles = result.slice(0, index).join(', ') || 'none yet';
-      return (
-        `You are writing one step of a guided tour through a codebase. The user asked: '${query}'. ` +
-        `The tour so far has covered: ${previousTitles}. ` +
-        `The current step is the file \`${filePath}\`. Here's the relevant excerpt:\n\n${excerpt}\n\n` +
-        `Write 2–4 sentences explaining what role this file plays in answering the user's question. ` +
-        `Do not summarise the whole file — focus on its role in this specific flow.`
-      );
-    },
-  });
+  // 7. Generate Claude explanation for each step. Bind the request's close
+  // event so closing the tab mid-tour aborts the remaining per-step calls.
+  const { signal: abortSignal, cleanup: cleanupAbort } = bindRequestAbort(req);
+  let steps;
+  try {
+    ({ steps } = await explainSteps({
+      filePaths:    result,
+      repoId,
+      userId,
+      relevantSet,
+      abortSignal,
+      systemPrompt: 'You are a senior software engineer writing clear, concise guided tour steps for developers exploring an unfamiliar codebase.',
+      buildUserPrompt: ({ filePath, index, excerpt }) => {
+        const previousTitles = result.slice(0, index).join(', ') || 'none yet';
+        return (
+          `You are writing one step of a guided tour through a codebase. The user asked: '${query}'. ` +
+          `The tour so far has covered: ${previousTitles}. ` +
+          `The current step is the file \`${filePath}\`. Here's the relevant excerpt:\n\n${excerpt}\n\n` +
+          `Write 2–4 sentences explaining what role this file plays in answering the user's question. ` +
+          `Do not summarise the whole file — focus on its role in this specific flow.`
+        );
+      },
+    }));
+  } finally {
+    cleanupAbort();
+  }
+  if (abortSignal.aborted) {
+    return res.status(499).end(); // 499 Client Closed Request — Nginx convention
+  }
 
   // 8. Optionally persist
   if (steps.length === 0) {

--- a/backend/src/db/supabase.js
+++ b/backend/src/db/supabase.js
@@ -9,6 +9,7 @@
  */
 
 const { createClient } = require('@supabase/supabase-js');
+const { recordSupabaseCall } = require('../observability/requestStore');
 
 const SUPABASE_URL              = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY         = process.env.SUPABASE_ANON_KEY;
@@ -21,8 +22,60 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
   );
 }
 
+// Phase 0 observability: a custom fetch records every PostgREST round-trip into
+// the AsyncLocalStorage ledger so the request-timing middleware can summarise
+// "this endpoint spent 800ms across 7 DB calls — slowest was graph_nodes.upsert".
+// Failing observably is worse than not measuring; the wrapper swallows its own errors.
+function parseSupabaseRequest(url, init) {
+  try {
+    const u = typeof url === 'string' ? new URL(url) : url;
+    const pathname = u.pathname || '';
+    // PostgREST: /rest/v1/<table>?<filters>     RPC: /rest/v1/rpc/<name>
+    const match = pathname.match(/\/rest\/v1\/(rpc\/)?([^/?]+)/);
+    const isRpc = Boolean(match && match[1]);
+    const table = match ? match[2] : pathname;
+    const method = (init && init.method) || 'GET';
+    return { table, method, isRpc, url: u.toString() };
+  } catch {
+    return { table: 'unknown', method: 'GET', isRpc: false, url: String(url) };
+  }
+}
+
+function instrumentedFetch(...args) {
+  const [url, init] = args;
+  const meta = parseSupabaseRequest(url, init);
+  const start = process.hrtime.bigint();
+  return globalThis.fetch(url, init).then(
+    (response) => {
+      try {
+        recordSupabaseCall({
+          method: meta.method,
+          table: meta.isRpc ? `rpc:${meta.table}` : meta.table,
+          durationMs: Number(process.hrtime.bigint() - start) / 1e6,
+          status: response.status,
+        });
+      } catch { /* swallow */ }
+      return response;
+    },
+    (err) => {
+      try {
+        recordSupabaseCall({
+          method: meta.method,
+          table: meta.isRpc ? `rpc:${meta.table}` : meta.table,
+          durationMs: Number(process.hrtime.bigint() - start) / 1e6,
+          status: 0,
+          error: err?.message,
+        });
+      } catch { /* swallow */ }
+      throw err;
+    }
+  );
+}
+
 /** Anon client – RLS enforced */
-const _supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const _supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  global: { fetch: instrumentedFetch },
+});
 
 /** Admin client – RLS bypassed (server-side only) */
 const _supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
@@ -30,6 +83,7 @@ const _supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
     autoRefreshToken: false,
     persistSession:   false,
   },
+  global: { fetch: instrumentedFetch },
 });
 
 // Proxies let tests inject mocks via globalThis at any point after module load.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -18,6 +18,7 @@ const usageRoutes    = require('./routes/usage');
 const adminRoutes    = require('./routes/admin');
 const toursRoutes    = require('./routes/tours');
 const errorHandler   = require('./middleware/errorHandler');
+const { requestTimingMiddleware } = require('./observability/requestStore');
 
 const compression = require('compression');
 
@@ -55,6 +56,10 @@ console.warn = (...args) => originalWarn.apply(console, redact(args));
 app.use(compression());
 app.use(helmet());
 app.use(cors({ origin: process.env.FRONTEND_URL || 'http://localhost:3000' }));
+
+// Request timing + per-request Supabase ledger (Phase 0). Must run before
+// route handlers so AsyncLocalStorage is populated for every downstream call.
+app.use(requestTimingMiddleware({ slowRequestMs: parseInt(process.env.SLOW_REQUEST_MS || '500', 10) }));
 
 // Webhook routes use express.raw per-route and must run before express.json()
 // so the signature validator receives the original request body bytes.

--- a/backend/src/lib/dbHelpers.js
+++ b/backend/src/lib/dbHelpers.js
@@ -1,0 +1,66 @@
+/**
+ * Database helpers (Phase 1 — performance roadmap).
+ *
+ * Two utilities:
+ *   - SAFE_FETCH_CEILING: explicit row limit applied to every "fetch all rows
+ *     for a repo" select. PostgREST silently caps unbounded selects at 1000;
+ *     this constant raises that cap and gives us a single knob to tune.
+ *   - warnIfCeilingHit: surfaces silent truncation as a warning so we notice
+ *     when a deployment outgrows the limit.
+ *   - withSupabaseRetry: small retry-with-backoff for critical writes that
+ *     should survive transient 5xx / 429 / network errors.
+ */
+
+const SAFE_FETCH_CEILING = parseInt(process.env.SUPABASE_FETCH_CEILING || '50000', 10);
+
+function warnIfCeilingHit(label, rows) {
+  if (!Array.isArray(rows)) return;
+  if (rows.length >= SAFE_FETCH_CEILING) {
+    console.warn(`[db] ${label}: hit fetch ceiling of ${SAFE_FETCH_CEILING} rows — pagination required for further growth`);
+  }
+}
+
+function isRetryableSupabaseError(err) {
+  if (!err) return false;
+  // Network / undici failures expose a code property.
+  if (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT' || err.code === 'EAI_AGAIN' || err.code === 'ENETUNREACH') return true;
+  // PostgREST error shape: { message, code, status }
+  const status = err.status || err.statusCode;
+  if (status === 429) return true;
+  if (typeof status === 'number' && status >= 500 && status < 600) return true;
+  // Supabase JS sometimes surfaces fetch failures as plain messages.
+  const msg = String(err.message || '').toLowerCase();
+  if (msg.includes('fetch failed') || msg.includes('timeout') || msg.includes('socket hang up')) return true;
+  return false;
+}
+
+async function withSupabaseRetry(fn, { tries = 3, baseMs = 500, label = 'supabase-call' } = {}) {
+  let lastErr;
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      const result = await fn();
+      // Supabase returns errors via { error } rather than throwing — bubble up.
+      if (result && typeof result === 'object' && 'error' in result && result.error) {
+        if (attempt < tries && isRetryableSupabaseError(result.error)) {
+          const delay = baseMs * (2 ** (attempt - 1));
+          console.warn(`[db] ${label}: retryable error on attempt ${attempt}/${tries} (${result.error.message}); retrying in ${delay}ms`);
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+      }
+      return result;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < tries && isRetryableSupabaseError(err)) {
+        const delay = baseMs * (2 ** (attempt - 1));
+        console.warn(`[db] ${label}: thrown error on attempt ${attempt}/${tries} (${err.message}); retrying in ${delay}ms`);
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}
+
+module.exports = { SAFE_FETCH_CEILING, warnIfCeilingHit, withSupabaseRetry, isRetryableSupabaseError };

--- a/backend/src/lib/sseAbort.js
+++ b/backend/src/lib/sseAbort.js
@@ -1,0 +1,47 @@
+/**
+ * SSE abort helper (Phase 1.1).
+ *
+ * Binds a request's `close` event to a new AbortController so upstream calls
+ * (Claude SDK, fetch, etc.) can stop generating output once the client
+ * disconnects. Without this, every closed-tab kicks off the full output stream
+ * to completion while still billing the token output — wasteful at any scale.
+ *
+ *   const { signal, cleanup, isAborted } = bindRequestAbort(req);
+ *   try {
+ *     const stream = await anthropic.messages.create({ ... }, { signal });
+ *     ...
+ *   } finally {
+ *     cleanup();
+ *   }
+ */
+
+function bindRequestAbort(req) {
+  const controller = new AbortController();
+  const onClose = () => {
+    try { controller.abort(); } catch { /* ignore */ }
+  };
+  if (req && typeof req.on === 'function') {
+    req.on('close', onClose);
+  }
+  const cleanup = () => {
+    if (req && typeof req.off === 'function') {
+      req.off('close', onClose);
+    }
+  };
+  return {
+    signal: controller.signal,
+    isAborted: () => controller.signal.aborted,
+    cleanup,
+  };
+}
+
+/** Classifies a thrown error as an abort, matching both the Anthropic SDK and undici flavours. */
+function isAbortError(err, signal) {
+  if (!err) return false;
+  if (signal && signal.aborted) return true;
+  if (err.name === 'AbortError') return true;
+  if (err.code === 'ABORT_ERR') return true;
+  return false;
+}
+
+module.exports = { bindRequestAbort, isAbortError };

--- a/backend/src/middleware/aiRateLimit.js
+++ b/backend/src/middleware/aiRateLimit.js
@@ -27,17 +27,23 @@ setInterval(() => {
   for (const [k, v] of hourCounters)   if (now > v.expiry) hourCounters.delete(k);
 }, 5 * 60 * 1000);
 
+// Phase 3.3: read the api_usage_daily rollup instead of scanning api_usage.
+// A 24h rolling window straddles at most two UTC days, so we fetch today +
+// yesterday and trust the trigger to keep the rollup current.
 async function dailyTokensUsed(userId) {
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const now    = new Date();
+  const today  = now.toISOString().slice(0, 10);
+  const yest   = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
   const { data, error } = await supabaseAdmin
-    .from('api_usage')
+    .from('api_usage_daily')
     .select('prompt_tokens, completion_tokens, embedding_tokens')
     .eq('user_id', userId)
-    .gte('created_at', since);
+    .in('usage_date', [today, yest]);
 
   if (error) return 0; // fail open
   return (data || []).reduce(
-    (sum, r) => sum + (r.prompt_tokens || 0) + (r.completion_tokens || 0) + (r.embedding_tokens || 0),
+    (sum, r) => sum + Number(r.prompt_tokens || 0) + Number(r.completion_tokens || 0) + Number(r.embedding_tokens || 0),
     0
   );
 }

--- a/backend/src/observability/requestStore.js
+++ b/backend/src/observability/requestStore.js
@@ -1,0 +1,79 @@
+/**
+ * Per-request observability store (Phase 0).
+ *
+ * Wires an AsyncLocalStorage that tracks:
+ *   - request start time
+ *   - per-request Supabase call ledger (table, op, durationMs, status)
+ *
+ * Used by:
+ *   - requestTiming middleware (writes start time, emits summary on response close)
+ *   - supabase admin/anon clients (record each network call via custom fetch)
+ *
+ * Designed to fail open: any error in the store is swallowed so observability
+ * never breaks the request path.
+ */
+
+const { AsyncLocalStorage } = require('async_hooks');
+
+const requestStore = new AsyncLocalStorage();
+
+function getStore() {
+  try {
+    return requestStore.getStore() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Records a single Supabase fetch round-trip into the current request's ledger. */
+function recordSupabaseCall(entry) {
+  const store = getStore();
+  if (!store || !Array.isArray(store.supabaseCalls)) return;
+  store.supabaseCalls.push(entry);
+}
+
+/**
+ * Express middleware factory. Initialises the AsyncLocalStorage for the request
+ * and emits a single summary log line on response finish. Slow requests
+ * (>SLOW_REQUEST_MS) are escalated to console.warn.
+ */
+function requestTimingMiddleware({ slowRequestMs = 500 } = {}) {
+  return function requestTiming(req, res, next) {
+    const start = process.hrtime.bigint();
+    const store = {
+      start,
+      supabaseCalls: [],
+    };
+
+    requestStore.run(store, () => {
+      res.on('finish', () => {
+        try {
+          const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
+          const calls = store.supabaseCalls || [];
+          const totalDb = calls.reduce((sum, c) => sum + (c.durationMs || 0), 0);
+          const top = calls
+            .slice()
+            .sort((a, b) => (b.durationMs || 0) - (a.durationMs || 0))
+            .slice(0, 3)
+            .map(c => `${c.method}:${c.table || c.url || '?'} ${Math.round(c.durationMs)}ms`)
+            .join(' | ');
+
+          const userId = req.user?.id ? `user=${req.user.id.slice(0, 8)}` : '';
+          const summary = `[req] ${req.method} ${req.originalUrl} ${res.statusCode} ${durationMs.toFixed(1)}ms db=${calls.length}@${totalDb.toFixed(0)}ms${top ? ` top=[${top}]` : ''} ${userId}`.trim();
+
+          if (durationMs >= slowRequestMs) {
+            console.warn(summary);
+          } else if (process.env.LOG_REQUEST_TIMING === 'true') {
+            console.log(summary);
+          }
+        } catch {
+          // Never let observability throw inside the response lifecycle.
+        }
+      });
+
+      next();
+    });
+  };
+}
+
+module.exports = { requestStore, getStore, recordSupabaseCall, requestTimingMiddleware };

--- a/backend/src/parsers/parser-worker.js
+++ b/backend/src/parsers/parser-worker.js
@@ -1,0 +1,39 @@
+/**
+ * Tree-sitter parser worker (Phase 5.1).
+ *
+ * Piscina spins up one of these per CPU core. Tree-sitter native modules are
+ * loaded once per worker at module load (acceptable: the pool is long-lived)
+ * so the per-file cost is just `parser.parse()` + query matching.
+ *
+ * Input:  { filePath, content, allFiles? (Array<string>), namespaceMap? (Array<[string,string[]]>) }
+ * Output: same shape as parseFile() — { filePath, imports, exports, complexity, importSymbols }
+ *
+ * Structured clone supports Map/Set but Piscina recommends transferring plain
+ * objects, so callers serialise sets/maps to arrays and the worker rehydrates.
+ */
+
+const { parseFile } = require('./repositoryParser');
+
+module.exports = function parseFileTask({ filePath, content, allFiles, namespaceMap }) {
+  let context;
+  if (Array.isArray(namespaceMap)) {
+    context = new Map(namespaceMap);
+  } else if (Array.isArray(allFiles)) {
+    context = new Set(allFiles);
+  } else {
+    context = new Set();
+  }
+  const parsed = parseFile(filePath, content, context);
+  // Explicitly project to JSON-safe fields. parseFile stashes the tree-sitter
+  // `_tree` as a non-enumerable own property for in-process re-use; structured
+  // clone is supposed to skip non-enumerable props, but native tree objects
+  // would throw DataCloneError if the algorithm ever accesses them — return
+  // a fresh plain object so the worker boundary stays bulletproof.
+  return {
+    filePath: parsed.filePath,
+    imports: parsed.imports || [],
+    exports: parsed.exports || [],
+    complexity: parsed.complexity != null ? parsed.complexity : 1,
+    importSymbols: parsed.importSymbols || {},
+  };
+};

--- a/backend/src/parsers/parserPool.js
+++ b/backend/src/parsers/parserPool.js
@@ -1,0 +1,101 @@
+/**
+ * Singleton Piscina pool for tree-sitter parsing (Phase 5.1).
+ *
+ * Node is single-threaded; tree-sitter parsing is CPU-bound and synchronous,
+ * so even `pLimit(10)` only buys I/O overlap. Off-loading parse work to a
+ * worker pool lets the indexer use multiple cores on multi-core hosts.
+ *
+ * Env knobs:
+ *   PARSER_WORKERS_DISABLED  truthy → skip the pool entirely and call parseFile
+ *                            in-process (CI, debug, and parser unit tests).
+ *   PARSER_WORKER_COUNT      override worker count (default: os.cpus().length,
+ *                            capped at 8 — Piscina's diminishing-returns knee).
+ *
+ * Public API:
+ *   getParserPool()        → Piscina instance or null when disabled
+ *   parseFileInPool(args)  → Promise<parsed> with in-process fallback
+ *   shutdownParserPool()   → graceful close (mostly for tests)
+ */
+
+const path = require('path');
+const os = require('os');
+const { parseFile: parseFileInProcess } = require('./repositoryParser');
+
+let pool = null;
+let workersDisabled = null;
+
+function isDisabled() {
+  if (workersDisabled !== null) return workersDisabled;
+  const raw = String(process.env.PARSER_WORKERS_DISABLED || '').toLowerCase();
+  workersDisabled = raw === '1' || raw === 'true' || raw === 'yes';
+  return workersDisabled;
+}
+
+function getParserPool() {
+  if (isDisabled()) return null;
+  if (pool) return pool;
+  try {
+    // Lazy-require so environments without piscina installed (or which set
+    // PARSER_WORKERS_DISABLED) don't pay the cost.
+    // Piscina v3 exported the class as `module.exports`; v4 exposes it as a
+    // named export with CJS interop (and may use a `default` field under
+    // some bundlers). Accept whichever shape the installed version provides.
+    const piscinaExport = require('piscina');
+    const Piscina = piscinaExport.Piscina || piscinaExport.default || piscinaExport;
+    if (typeof Piscina !== 'function') {
+      throw new Error('Piscina constructor not found in module exports');
+    }
+    const cpuCount = Math.max(1, os.cpus().length);
+    const desired = parseInt(process.env.PARSER_WORKER_COUNT || '', 10);
+    const maxThreads = Number.isFinite(desired) && desired > 0
+      ? desired
+      : Math.min(cpuCount, 8);
+
+    pool = new Piscina({
+      filename: path.resolve(__dirname, 'parser-worker.js'),
+      maxThreads,
+      // idleTimeout keeps workers warm during an indexing run (tree-sitter
+      // native module load is non-trivial) but lets them spin down later.
+      idleTimeout: 60_000,
+    });
+    return pool;
+  } catch (err) {
+    console.warn(`[parserPool] Piscina unavailable, falling back to in-process parsing: ${err.message}`);
+    workersDisabled = true;
+    return null;
+  }
+}
+
+/**
+ * Parse a file via the worker pool when available; fall back to in-process
+ * parsing on disable/error so a misconfigured worker can never break indexing.
+ */
+async function parseFileInPool({ filePath, content, allFiles, namespaceMap }) {
+  const activePool = getParserPool();
+  if (!activePool) {
+    return parseFileInProcess(filePath, content, namespaceMap || allFiles || new Set());
+  }
+  try {
+    return await activePool.run({
+      filePath,
+      content,
+      allFiles: Array.isArray(allFiles)
+        ? allFiles
+        : (allFiles instanceof Set ? Array.from(allFiles) : null),
+      namespaceMap: namespaceMap instanceof Map
+        ? Array.from(namespaceMap.entries())
+        : (Array.isArray(namespaceMap) ? namespaceMap : null),
+    });
+  } catch (err) {
+    console.warn(`[parserPool] Worker parse failed for ${filePath} (${err.message}); falling back in-process`);
+    return parseFileInProcess(filePath, content, namespaceMap || allFiles || new Set());
+  }
+}
+
+async function shutdownParserPool() {
+  if (!pool) return;
+  try { await pool.destroy(); } catch { /* ignore */ }
+  pool = null;
+}
+
+module.exports = { getParserPool, parseFileInPool, shutdownParserPool };

--- a/backend/src/parsers/repositoryParser.js
+++ b/backend/src/parsers/repositoryParser.js
@@ -208,10 +208,72 @@ const getLanguageKey = (ext) => {
   return null;
 };
 
+// US-064: collect all import_statement nodes so we can extract per-import
+// symbol lists for the graph_edges.symbols column.
+const collectImportStatements = (node, out) => {
+  if (node.type === 'import_statement') {
+    out.push(node);
+    return; // imports do not nest
+  }
+  for (const child of node.namedChildren) {
+    collectImportStatements(child, out);
+  }
+};
+
+const unquote = (text) => {
+  if (typeof text !== 'string' || text.length < 2) return text;
+  const first = text[0];
+  const last = text[text.length - 1];
+  if ((first === "'" && last === "'") || (first === '"' && last === '"') || (first === '`' && last === '`')) {
+    return text.slice(1, -1);
+  }
+  return text;
+};
+
+// Pulls the imported symbol names from a JS/TS import_statement node.
+// Returns the local-binding name for each specifier — the alias if present,
+// otherwise the original name — so the resulting list reflects what the
+// importing file actually references.
+const extractImportInfo = (importStmt) => {
+  let rawPath = null;
+  const symbols = [];
+  for (const child of importStmt.namedChildren) {
+    if (child.type === 'string') {
+      rawPath = unquote(child.text);
+    } else if (child.type === 'import_clause') {
+      for (const sub of child.namedChildren) {
+        if (sub.type === 'identifier') {
+          symbols.push(sub.text);
+        } else if (sub.type === 'namespace_import') {
+          for (const idChild of sub.namedChildren) {
+            if (idChild.type === 'identifier') symbols.push(idChild.text);
+          }
+        } else if (sub.type === 'named_imports') {
+          for (const spec of sub.namedChildren) {
+            if (spec.type !== 'import_specifier') continue;
+            let chosen = null;
+            if (typeof spec.childForFieldName === 'function') {
+              const alias = spec.childForFieldName('alias');
+              const name = spec.childForFieldName('name');
+              chosen = (alias && alias.text) || (name && name.text) || null;
+            }
+            if (!chosen) {
+              const ids = spec.namedChildren.filter((c) => c.type === 'identifier' || c.type === 'property_identifier');
+              if (ids.length > 0) chosen = ids[ids.length - 1].text;
+            }
+            if (chosen) symbols.push(chosen);
+          }
+        }
+      }
+    }
+  }
+  return { rawPath, symbols };
+};
+
 /**
  * Parse a single file and extract import/dependency edges.
  */
-const parseFile = (filePath, source, allFiles = new Set()) => {
+const parseFile = (filePath, source, allFiles = new Set(), opts = {}) => {
   try {
     const ext = path.extname(filePath).toLowerCase();
 
@@ -228,12 +290,17 @@ const parseFile = (filePath, source, allFiles = new Set()) => {
 
     const parser = getParser(language);
     const src = typeof source === 'string' ? source : (source == null ? '' : String(source));
-    // tree-sitter v0.21.x rejects strings longer than 32767 chars; use callback for large files
-    const tree = src.length < 32768
-      ? parser.parse(src)
-      : parser.parse((i) => i < src.length ? src.slice(i, i + 8192) : null);
+    // Phase 5.3: when a cached tree is supplied (e.g. C# pre-pass result), skip
+    // re-parsing. Tree-sitter parse is the dominant cost; re-running the query
+    // against an existing tree is essentially free.
+    const tree = opts.cachedTree
+      || (src.length < 32768
+        ? parser.parse(src)
+        : parser.parse((i) => i < src.length ? src.slice(i, i + 8192) : null));
 
-    const complexity = calculateComplexity(tree, queryKey);
+    const complexity = opts.cachedComplexity != null
+      ? opts.cachedComplexity
+      : calculateComplexity(tree, queryKey);
 
     const imports = new Set();
     const exports = new Set();
@@ -244,13 +311,7 @@ const parseFile = (filePath, source, allFiles = new Set()) => {
     for (const match of matches) {
       for (const capture of match.captures) {
         if (capture.name === 'import_path') {
-          let rawPath = capture.node.text;
-          // Strip surrounding quotes from the string node
-          if ((rawPath.startsWith("'") && rawPath.endsWith("'")) ||
-              (rawPath.startsWith('"') && rawPath.endsWith('"')) ||
-              (rawPath.startsWith('`') && rawPath.endsWith('`'))) {
-            rawPath = rawPath.slice(1, -1);
-          }
+          const rawPath = unquote(capture.node.text);
           const resolved = resolveImportPath(rawPath, filePath, allFiles, ext);
           if (resolved) {
             if (Array.isArray(resolved)) {
@@ -265,12 +326,40 @@ const parseFile = (filePath, source, allFiles = new Set()) => {
       }
     }
 
-    return {
+    // US-064: build a per-importer symbol map for JS/TS. The tree-sitter Query
+    // path above already collected the file-level imports; this second walk
+    // attaches each statement's specifier names to the resolved target path.
+    const importSymbols = {};
+    if (queryKey === 'javascript') {
+      const importStmts = [];
+      collectImportStatements(tree.rootNode, importStmts);
+      for (const stmt of importStmts) {
+        const { rawPath, symbols } = extractImportInfo(stmt);
+        if (!rawPath || symbols.length === 0) continue;
+        const resolved = resolveImportPath(rawPath, filePath, allFiles, ext);
+        if (!resolved) continue;
+        const paths = Array.isArray(resolved) ? resolved : [resolved];
+        for (const p of paths) {
+          if (!importSymbols[p]) importSymbols[p] = [];
+          for (const sym of symbols) {
+            if (!importSymbols[p].includes(sym)) importSymbols[p].push(sym);
+          }
+        }
+      }
+    }
+
+    const result = {
       filePath,
       imports: Array.from(imports),
       exports: Array.from(exports),
-      complexity
+      complexity,
+      importSymbols,
     };
+    // Non-enumerable so JSON.stringify / structuredClone don't try to ship the
+    // tree-sitter tree object. Consumers that want it for caching read it
+    // directly (Phase 5.3 — C# pre-pass → main pass dedupe).
+    Object.defineProperty(result, '_tree', { value: tree, enumerable: false });
+    return result;
   } catch (err) {
     console.warn(`[Parser] Failed to parse ${filePath}: ${err.message}`);
     return { filePath, imports: [], exports: [], complexity: 1 };

--- a/backend/src/routes/review.js
+++ b/backend/src/routes/review.js
@@ -10,6 +10,9 @@ router.get('/:repoId/security-audits', requireAuth, reviewController.listSecurit
 router.get('/:repoId/security-audits/:auditId', requireAuth, reviewController.getSecurityAudit);
 router.post('/:repoId/duplication-refactor', requireAuth, aiRateLimit, reviewController.duplicationRefactor);
 
+// US-064: refactor proposal generation. Optional ?regenerate=true skips the cache.
+router.post('/:repoId/issues/:issueId/proposals', requireAuth, aiRateLimit, reviewController.generateProposal);
+
 // POST /api/review/:repoId   body: { snippet, context?, mode?, filePath? }
 router.post('/:repoId', requireAuth, aiRateLimit, reviewController.review);
 

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -1,4 +1,5 @@
 const { parseFile } = require('../parsers/repositoryParser');
+const { parseFileInPool } = require('../parsers/parserPool'); // Phase 5.1
 const { extractChunksFromFile } = require('../parsers/chunkParser');
 const { detectIssues } = require('./issueDetection');
 const { scanFileForSecrets } = require('./secretScanner');
@@ -14,6 +15,7 @@ const { scanDependencies } = require('./osvScanner'); // US-045
 const { generateStartHereTour } = require('./startHereTourService'); // US-059
 const { OpenAI } = require('openai');
 const { supabaseAdmin } = require('../db/supabase');
+const { SAFE_FETCH_CEILING, warnIfCeilingHit, withSupabaseRetry } = require('../lib/dbHelpers');
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'sk-dummy' });
 const pLimit = require('p-limit');
 const fs = require('fs/promises');
@@ -55,17 +57,6 @@ function chunkArray(arr, size) {
     chunks.push(arr.slice(i, i + size));
   }
   return chunks;
-}
-
-function toAnalysisIssueInsert(issue, repoId) {
-  return {
-    id: crypto.randomUUID(),
-    repo_id: issue.repo_id || repoId,
-    type: issue.type,
-    severity: issue.severity,
-    file_paths: Array.isArray(issue.file_paths) ? issue.file_paths : [],
-    description: issue.description || null,
-  };
 }
 
 async function fetchGithubZipAndExtract(owner, name, token, destDir) {
@@ -134,22 +125,29 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     const { data: existingNodeRows } = await supabaseAdmin
       .from('graph_nodes')
       .select('file_path, content_hash, language, line_count, complexity_score, node_classification, is_test_file')
-      .eq('repo_id', repoId);
+      .eq('repo_id', repoId)
+      .range(0, SAFE_FETCH_CEILING - 1);
+    warnIfCeilingHit('indexer.graph_nodes pre-fetch', existingNodeRows);
     const existingNodeMap = new Map((existingNodeRows || []).map(n => [n.file_path, n]));
 
-    // Also pre-fetch existing edges for unchanged files (we'll reuse them to skip re-parsing imports)
+    // Also pre-fetch existing edges for unchanged files (we'll reuse them to skip re-parsing imports).
+    // `symbols` is the US-064 per-importer symbol list — empty array on edges written before that migration.
     const { data: existingEdgeRows } = await supabaseAdmin
       .from('graph_edges')
-      .select('from_path, to_path')
-      .eq('repo_id', repoId);
+      .select('from_path, to_path, symbols')
+      .eq('repo_id', repoId)
+      .range(0, SAFE_FETCH_CEILING - 1);
+    warnIfCeilingHit('indexer.graph_edges pre-fetch', existingEdgeRows);
 
-    // Fetch repo owner for usage tracking (US-042)
+    // Phase 2.3: pull repo metadata in ONE fetch instead of separately fetching
+    // user_id here and sast_disabled_rules later in the parsing phase.
     const { data: repoMeta } = await supabaseAdmin
       .from('repositories')
-      .select('user_id')
+      .select('user_id, sast_disabled_rules')
       .eq('id', repoId)
       .single();
     const repoUserId = repoMeta?.user_id || null;
+    const disabledSastRules = repoMeta?.sast_disabled_rules || [];
 
     // 1. Fetch & filter files
     console.time(`[indexer] Phase 1: File discovery (${repoId})`);
@@ -241,53 +239,35 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
 
     const changedOrDeletedPaths = [...changedFilePaths, ...deletedFilePaths];
 
-    // ── Targeted clearing instead of blanket wipe ─────────────────────────────
-    // Pre-fetch per-file issues (secrets + SAST) for unchanged files before clearing.
-    // We skip scanning unchanged files so we need to re-inject their existing issues.
-    const PER_FILE_ISSUE_TYPES = ['hardcoded_secret', 'insecure_pattern'];
-    let preservedPerFileIssues = [];
-    if (unchangedFilePaths.size > 0) {
-      const unchangedArr = [...unchangedFilePaths];
-      const batches = chunkArray(unchangedArr, 150);
-      for (const batch of batches) {
-        const { data: existing } = await supabaseAdmin
-          .from('analysis_issues')
-          .select('*')
-          .eq('repo_id', repoId)
-          .in('type', PER_FILE_ISSUE_TYPES)
-          .overlaps('file_paths', batch);
-        if (existing) preservedPerFileIssues.push(...existing);
-      }
+    // ── Phase 2.1: single RPC handles issue preservation + clearing ───────────
+    // prepare_repo_reindex performs proposal stale-marking, non-preservable
+    // issue delete, dependency_manifests + graph_edges + duplication_candidates
+    // wipes, optional file_churn wipe, coverage-flag reset, and the partial
+    // node/chunk/file_contents purge for changed-or-deleted files — all in one
+    // transactional SQL function. Replaces ~10 sequential PostgREST round-trips.
+    const preserveChurn = Array.isArray(incrementalChurnCommits) && incrementalChurnCommits.length > 0;
+    const { data: prepareResult, error: prepareErr } = await withSupabaseRetry(
+      () => supabaseAdmin.rpc('prepare_repo_reindex', {
+        p_repo_id: repoId,
+        p_unchanged_paths: [...unchangedFilePaths],
+        p_changed_or_deleted_paths: changedOrDeletedPaths,
+        p_preserve_churn: preserveChurn,
+      }),
+      { label: 'indexer.prepare_repo_reindex' },
+    );
+
+    if (prepareErr) {
+      throw new Error(`prepare_repo_reindex failed: ${prepareErr.message}`);
     }
 
-    // Always clear: issues, dependency_manifests, all edges (coupling counts change)
-    // Partial clear: nodes/chunks/file_contents only for changed or deleted files
-    await supabaseAdmin.from('analysis_issues').delete().eq('repo_id', repoId);
-    await supabaseAdmin.from('dependency_manifests').delete().eq('repo_id', repoId);
-    await supabaseAdmin.from('graph_edges').delete().eq('repo_id', repoId);
-    // US-050: full-recompute path wipes churn; incremental webhook path preserves
-    // existing rows so applyIncrementalChurn can add deltas onto them.
-    if (!Array.isArray(incrementalChurnCommits) || incrementalChurnCommits.length === 0) {
-      await supabaseAdmin.from('file_churn').delete().eq('repo_id', repoId);
-    }
-    await supabaseAdmin.from('duplication_candidates').delete().eq('repo_id', repoId); // US-052
-    await supabaseAdmin
-      .from('graph_nodes')
-      .update({ has_test_coverage: false, coverage_percentage: null, is_test_file: false })
-      .eq('repo_id', repoId);
-
-    if (changedOrDeletedPaths.length > 0) {
-      const pathBatches = chunkArray(changedOrDeletedPaths, 150);
-      for (const batch of pathBatches) {
-        await supabaseAdmin.from('graph_nodes').delete().eq('repo_id', repoId).in('file_path', batch);
-        await supabaseAdmin.from('code_chunks').delete().eq('repo_id', repoId).in('file_path', batch);
-        await supabaseAdmin.from('file_contents').delete().eq('repo_id', repoId).in('file_path', batch);
-      }
-    }
+    // RPC returns a one-row table; supabase-js wraps it as an array.
+    const report = Array.isArray(prepareResult) ? prepareResult[0] : prepareResult;
+    console.log(`[indexer] Issues: ${report?.preserved_count ?? 0} preserved, ${report?.deleted_count ?? 0} deleted (single-RPC prepare)`);
 
     const limit = pLimit(10);
-    // Seed with pre-fetched per-file issues from unchanged files (secrets + SAST)
-    const issues = [...preservedPerFileIssues];
+    // `issues` accumulates only newly-detected issues. Preserved (unchanged-file)
+    // issues remain in the DB with their original ids — we never re-insert them.
+    const issues = [];
 
     // Fetch existing suppressions for this repo BEFORE scanning
     const { data: suppressions } = await supabaseAdmin
@@ -296,13 +276,7 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       .eq('repo_id', repoId);
     const suppSet = new Set(suppressions?.map(s => `${s.file_path}:${s.rule_id}:${s.line_number}`) || []);
 
-    // Fetch sast_disabled_rules for this repo (US-046)
-    const { data: repoConfig } = await supabaseAdmin
-      .from('repositories')
-      .select('sast_disabled_rules')
-      .eq('id', repoId)
-      .single();
-    const disabledSastRules = repoConfig?.sast_disabled_rules || [];
+    // sast_disabled_rules (US-046) was already loaded with the repo metadata above.
 
     // 2.5 Optional Pre-pass for C# Namespaces (US-011)
     const namespaceMap = new Map();
@@ -310,6 +284,13 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     const filesToProcess = pendingFiles.filter(f => changedFilePaths.has(f.path));
 
     const isCSharpRepo = pendingFiles.some(f => f.path.toLowerCase().endsWith('.cs'));
+
+    // Phase 5.3: cache C# parses between the pre-pass and the main pass. The
+    // pre-pass needs `exports` (namespaces); the main pass needs the full
+    // parsed result with resolved imports. Without this cache, every .cs file
+    // is parsed twice. We key by file path (content_hash is implied — only
+    // changed files reach this point).
+    const csharpPreParse = new Map();
 
     if (isCSharpRepo) {
       console.log(`[indexer] C# files detected. Running namespace pre-pass on changed files...`);
@@ -321,7 +302,11 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
               if (!file.content) {
                 file.content = await fs.readFile(file.fsPath, 'utf-8');
               }
+              // Pre-pass stays in-process: parses produce a Set-based namespace
+              // map that's mutated below, which is awkward to ship through the
+              // worker pool. The cached result feeds the main pass.
               const parsed = parseFile(file.path, file.content, getAllFilesSet);
+              csharpPreParse.set(file.path, parsed);
               for (const ns of parsed.exports) {
                 if (!namespaceMap.has(ns)) namespaceMap.set(ns, new Set());
                 namespaceMap.get(ns).add(file.path);
@@ -353,8 +338,33 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
             if (!file.content) {
               file.content = await fs.readFile(file.fsPath, 'utf-8');
             }
-            // Parse file directly, passing namespaceMap for C# resolution
-            const parsed = parseFile(file.path, file.content, isCSharpRepo ? namespaceMap : getAllFilesSet);
+
+            // Phase 5.1 + 5.3: parse via the worker pool, except .cs files
+            // (which (a) need the namespace map for resolution, awkward to
+            // pass over the wire, and (b) already have a cached pre-pass tree
+            // we can reuse to skip the dominant tree-sitter parse cost).
+            let parsed;
+            const isCs = file.path.toLowerCase().endsWith('.cs');
+            if (isCs) {
+              const cached = csharpPreParse.get(file.path);
+              const cachedTree = cached && cached._tree ? cached._tree : null;
+              parsed = parseFile(
+                file.path,
+                file.content,
+                namespaceMap,
+                cachedTree
+                  ? { cachedTree, cachedComplexity: cached.complexity }
+                  : {},
+              );
+              // Free the cached tree as soon as the main pass consumes it.
+              csharpPreParse.delete(file.path);
+            } else {
+              parsed = await parseFileInPool({
+                filePath: file.path,
+                content: file.content,
+                allFiles: getAllFilesSet,
+              });
+            }
             parsedFiles.push(parsed);
 
             // Secret scanning (US-044)
@@ -445,10 +455,15 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       }
     }
 
-    // Reconstruct edges originating from unchanged files
+    // Reconstruct edges originating from unchanged files (symbols carried forward)
     for (const edge of (existingEdgeRows || [])) {
       if (unchangedFilePaths.has(edge.from_path)) {
-        allEdges.push({ repo_id: repoId, from_path: edge.from_path, to_path: edge.to_path });
+        allEdges.push({
+          repo_id: repoId,
+          from_path: edge.from_path,
+          to_path: edge.to_path,
+          symbols: Array.isArray(edge.symbols) ? edge.symbols : [],
+        });
       }
     }
 
@@ -485,22 +500,30 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
         coverage_percentage: null,
       });
 
+      const importSymbols = file.importSymbols || {};
       for (const imp of file.imports) {
-        // Create edges correctly
+        // US-064: edges carry the per-importer symbol list when the parser
+        // can extract it. Empty array on languages or import forms where we
+        // can't reliably name the imported symbols.
         allEdges.push({
           repo_id: repoId,
           from_path: file.filePath,
-          to_path: imp
+          to_path: imp,
+          symbols: Array.isArray(importSymbols[imp]) ? importSymbols[imp] : [],
         });
       }
     }
 
-    // Dedupe edges in memory
+    // Dedupe edges in memory, unioning symbols across duplicate (from, to) pairs.
     const edgeMap = new Map();
     for (const edge of allEdges) {
       const edgeKey = `${edge.from_path}->${edge.to_path}`;
       if (!edgeMap.has(edgeKey)) {
-        edgeMap.set(edgeKey, edge);
+        edgeMap.set(edgeKey, { ...edge, symbols: [...(edge.symbols || [])] });
+      } else {
+        const existing = edgeMap.get(edgeKey);
+        const merged = new Set([...(existing.symbols || []), ...(edge.symbols || [])]);
+        existing.symbols = [...merged];
       }
     }
     const uniqueEdges = Array.from(edgeMap.values());
@@ -524,22 +547,24 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     });
     console.log(`[indexer] Coverage: ${testFilesSet.size} test file(s), ${heuristicCoveredPaths.size} heuristic target(s), ${coverageByPath.size} formal override(s).`);
 
-    // 6. bulk insert nodes
+    // 6. bulk insert nodes (retry on transient 5xx / 429 / network errors)
     console.time(`[indexer] Phase 3: DB writes (${repoId})`);
     const nodeChunks = chunkArray(uniqueNodes, 500);
     for (const chunk of nodeChunks) {
-      const { error } = await supabaseAdmin
-        .from('graph_nodes')
-        .upsert(chunk, { onConflict: 'repo_id,file_path', ignoreDuplicates: true });
+      const { error } = await withSupabaseRetry(
+        () => supabaseAdmin.from('graph_nodes').upsert(chunk, { onConflict: 'repo_id,file_path', ignoreDuplicates: true }),
+        { label: 'indexer.graph_nodes.upsert' },
+      );
       if (error) throw new Error(`Database error inserting nodes: ${error.message}`);
     }
 
     // 7. bulk insert edges
     const edgeChunks = chunkArray(uniqueEdges, 500);
     for (const chunk of edgeChunks) {
-      const { error } = await supabaseAdmin
-        .from('graph_edges')
-        .upsert(chunk, { onConflict: 'repo_id,from_path,to_path', ignoreDuplicates: true });
+      const { error } = await withSupabaseRetry(
+        () => supabaseAdmin.from('graph_edges').upsert(chunk, { onConflict: 'repo_id,from_path,to_path', ignoreDuplicates: true }),
+        { label: 'indexer.graph_edges.upsert' },
+      );
       if (error) throw new Error(`Database error inserting edges: ${error.message}`);
     }
 
@@ -564,9 +589,10 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     // 8b. persist metrics to graph_nodes via update
     const metricsChunks = chunkArray(finalNodes, 500);
     for (const chunk of metricsChunks) {
-      const { error } = await supabaseAdmin
-        .from('graph_nodes')
-        .upsert(chunk, { onConflict: 'repo_id,file_path', ignoreDuplicates: false }); // false to DO UPDATE
+      const { error } = await withSupabaseRetry(
+        () => supabaseAdmin.from('graph_nodes').upsert(chunk, { onConflict: 'repo_id,file_path', ignoreDuplicates: false }), // false to DO UPDATE
+        { label: 'indexer.graph_nodes.metrics' },
+      );
       if (error) throw new Error(`Database error updating metrics: ${error.message}`);
     }
     console.timeEnd(`[indexer] Phase 3: DB writes (${repoId})`);
@@ -650,12 +676,25 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       .eq('type', 'untested_critical_file');
 
     if (issues.length > 0) {
-      const issueRows = issues
+      // Phase 2.2: bulk_insert_analysis_issues consolidates 1-N chunked inserts
+      // into a single RPC. Shape validation (type non-null, file_paths
+      // non-empty) is enforced server-side now.
+      const issuePayload = issues
         .filter(issue => issue?.type && Array.isArray(issue.file_paths) && issue.file_paths.length > 0)
-        .map(issue => toAnalysisIssueInsert(issue, repoId));
-      const issueChunks = chunkArray(issueRows, 500);
-      for (const chunk of issueChunks) {
-        const { error } = await supabaseAdmin.from('analysis_issues').insert(chunk);
+        .map(issue => ({
+          type:        issue.type,
+          severity:    issue.severity || null,
+          file_paths:  issue.file_paths,
+          description: issue.description || null,
+        }));
+      if (issuePayload.length > 0) {
+        const { error } = await withSupabaseRetry(
+          () => supabaseAdmin.rpc('bulk_insert_analysis_issues', {
+            p_repo_id: repoId,
+            p_issues: issuePayload,
+          }),
+          { label: 'indexer.bulk_insert_analysis_issues' },
+        );
         if (error) console.error(`[indexer] Database error inserting issues: ${error.message}`);
       }
     }
@@ -684,10 +723,13 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     if (fileContentRows.length > 0) {
       const fcBatches = chunkArray(fileContentRows, 200);
       for (const batch of fcBatches) {
-        const { error: fcErr } = await supabaseAdmin
-          .from('file_contents')
-          .upsert(batch, { onConflict: 'repo_id,file_path', ignoreDuplicates: false });
-        if (fcErr) console.error(`[indexer] file_contents insert error: ${fcErr.message}`);
+        const { error: fcErr } = await withSupabaseRetry(
+          () => supabaseAdmin.from('file_contents').upsert(batch, { onConflict: 'repo_id,file_path', ignoreDuplicates: false }),
+          { label: 'indexer.file_contents.upsert' },
+        );
+        // file_contents drives RAG retrieval — promote from warning to error so we
+        // notice silent breakage. Retry already handled transient cases above.
+        if (fcErr) console.error(`[indexer] file_contents insert error (RAG retrieval may be incomplete): ${fcErr.message}`);
       }
     }
     console.log(`[indexer] Stored ${fileContentRows.length} file contents.`);
@@ -747,10 +789,77 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
 
         console.log(`[indexer] Generated ${allExtractedChunks.length} raw chunks for ${changedFilePaths.size} changed files. Proceeding to OpenAI.`);
 
-        // 10c. Batch API vectors — batch size of 100 (OpenAI supports up to 2048 inputs)
+        // 10b. Phase 5.2: embedding cache lookup by content hash.
+        // Identical chunks across repos (shared library code, copied
+        // components) reuse the cached embedding instead of paying OpenAI
+        // again. Cache is global by content_hash; access is via service_role.
         console.time(`[indexer] Phase 5: Embedding (${repoId})`);
-        const batches = chunkArray(allExtractedChunks, 100);
+        const chunksWithHash = allExtractedChunks.map((chunk) => ({
+          ...chunk,
+          content_hash: sha256(chunk.content),
+        }));
+
+        const uniqueHashes = Array.from(new Set(chunksWithHash.map(c => c.content_hash)));
+        const cachedEmbeddings = new Map();
+        if (uniqueHashes.length > 0) {
+          // Look up in batches — Supabase has a URL length cap on `in.()` filters.
+          const lookupBatches = chunkArray(uniqueHashes, 500);
+          for (const hashBatch of lookupBatches) {
+            const { data: cacheRows, error: cacheErr } = await supabaseAdmin
+              .from('embedding_cache')
+              .select('content_hash, embedding')
+              .in('content_hash', hashBatch);
+            if (cacheErr) {
+              console.warn(`[indexer] embedding_cache lookup failed (continuing without cache): ${cacheErr.message}`);
+              break;
+            }
+            for (const row of (cacheRows || [])) {
+              cachedEmbeddings.set(row.content_hash, row.embedding);
+            }
+          }
+        }
+
         const mappedPayloads = [];
+        const newCacheRows = []; // for write-back, dedup'd by content_hash
+        const seenNewHashes = new Set();
+        const chunksToEmbed = [];
+        for (const chunk of chunksWithHash) {
+          const cached = cachedEmbeddings.get(chunk.content_hash);
+          if (cached) {
+            mappedPayloads.push({
+              repo_id: chunk.repo_id,
+              file_path: chunk.file_path,
+              start_line: chunk.start_line,
+              end_line: chunk.end_line,
+              content: chunk.content,
+              embedding: cached,
+            });
+          } else {
+            chunksToEmbed.push(chunk);
+          }
+        }
+        console.log(`[indexer] Embedding cache: ${cachedEmbeddings.size}/${uniqueHashes.length} unique hashes hit (skipping ${allExtractedChunks.length - chunksToEmbed.length} of ${allExtractedChunks.length} chunks).`);
+
+        // Touch last_used_at for cache hits so the eviction job doesn't drop
+        // hot rows. Fire-and-forget — failure here doesn't affect correctness,
+        // but we must catch rejections to avoid unhandledRejection warnings.
+        if (cachedEmbeddings.size > 0) {
+          const hitHashes = Array.from(cachedEmbeddings.keys());
+          for (const batch of chunkArray(hitHashes, 500)) {
+            supabaseAdmin
+              .from('embedding_cache')
+              .update({ last_used_at: new Date().toISOString() })
+              .in('content_hash', batch)
+              .then(
+                ({ error }) => {
+                  if (error) console.warn(`[indexer] embedding_cache touch failed: ${error.message}`);
+                },
+                (err) => console.warn(`[indexer] embedding_cache touch threw: ${err.message}`),
+              );
+          }
+        }
+
+        const batches = chunkArray(chunksToEmbed, 100);
 
         // Process embedding batches with concurrency limit of 5
         const embedLimit = pLimit(5);
@@ -768,15 +877,30 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
                   recordUsage({ userId: repoUserId, endpoint: 'indexer/embed', provider: 'openai', embeddingTokens: res.usage.total_tokens });
                 }
 
+                const perChunkTokens = batch.length > 0
+                  ? Math.round((res.usage?.total_tokens || 0) / batch.length)
+                  : 0;
                 for (let i = 0; i < batch.length; i++) {
+                  const embedding = res.data[i].embedding;
                   mappedPayloads.push({
                     repo_id: batch[i].repo_id,
                     file_path: batch[i].file_path,
                     start_line: batch[i].start_line,
                     end_line: batch[i].end_line,
                     content: batch[i].content,
-                    embedding: res.data[i].embedding
+                    embedding,
                   });
+                  // Phase 5.2: collect a single row per unique content_hash for
+                  // write-back to embedding_cache.
+                  const hash = batch[i].content_hash;
+                  if (hash && !seenNewHashes.has(hash)) {
+                    seenNewHashes.add(hash);
+                    newCacheRows.push({
+                      content_hash: hash,
+                      embedding,
+                      token_count: perChunkTokens,
+                    });
+                  }
                 }
               } catch (batchErr) {
                 console.warn(`[indexer] Batch ${batchIdx} embed failed: ${batchErr.message}. Falling back to per-chunk.`);
@@ -788,14 +912,24 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
                       input: singleChunk.content,
                       model: "text-embedding-3-small"
                     });
+                    const embedding = singleRes.data[0].embedding;
                     mappedPayloads.push({
                       repo_id: singleChunk.repo_id,
                       file_path: singleChunk.file_path,
                       start_line: singleChunk.start_line,
                       end_line: singleChunk.end_line,
                       content: singleChunk.content,
-                      embedding: singleRes.data[0].embedding
+                      embedding,
                     });
+                    const hash = singleChunk.content_hash;
+                    if (hash && !seenNewHashes.has(hash)) {
+                      seenNewHashes.add(hash);
+                      newCacheRows.push({
+                        content_hash: hash,
+                        embedding,
+                        token_count: singleRes.usage?.total_tokens || 0,
+                      });
+                    }
                   } catch (singleErr) {
                     console.warn(`[indexer] Failed to embed chunk in ${singleChunk.file_path}: ${singleErr.message}`);
                   }
@@ -813,7 +947,24 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
              if (insErr) console.error(`[indexer] DB insert err for vectors: ${insErr.message}`);
            }
         }
-        console.log(`[indexer] Completely finished semantic embeddings mappings. Saved ${mappedPayloads.length} vectors!`);
+
+        // Phase 5.2: write newly-embedded hashes back to the cache so the next
+        // repo that contains the same chunk can skip OpenAI. ON CONFLICT just
+        // bumps last_used_at — a race between concurrent indexing runs is a
+        // duplicate-key conflict, not an error.
+        if (newCacheRows.length > 0) {
+          const cacheBatches = chunkArray(newCacheRows, 500);
+          for (const cBatch of cacheBatches) {
+            const { error: cacheErr } = await supabaseAdmin
+              .from('embedding_cache')
+              .upsert(
+                cBatch.map(r => ({ ...r, last_used_at: new Date().toISOString() })),
+                { onConflict: 'content_hash' }
+              );
+            if (cacheErr) console.warn(`[indexer] embedding_cache writeback failed: ${cacheErr.message}`);
+          }
+        }
+        console.log(`[indexer] Completely finished semantic embeddings mappings. Saved ${mappedPayloads.length} vectors (${newCacheRows.length} new cache rows)!`);
         console.timeEnd(`[indexer] Phase 5: Embedding (${repoId})`);
 
         try {

--- a/backend/test/api.integration.test.js
+++ b/backend/test/api.integration.test.js
@@ -79,6 +79,11 @@ function createSupabaseMock(handlers) {
       this.limitCount = n;
       return this;
     }
+    range(from, to) {
+      this.rangeFrom = from;
+      this.rangeTo = to;
+      return this;
+    }
     single() {
       this.mode = 'single';
       return this;

--- a/backend/test/parsers.test.js
+++ b/backend/test/parsers.test.js
@@ -41,6 +41,31 @@ describe('repositoryParser.parseFile', () => {
     expect(result.imports).toContain('pkg/sub/__init__.py');
   });
 
+  it('extracts per-import symbols from JS/TS ESM imports (US-064)', () => {
+    const allFiles = new Set([
+      'src/foo.ts',
+      'src/bar.ts',
+      'src/side.ts',
+    ]);
+
+    const source = [
+      "import Foo from './foo';",
+      "import { a, b as renamedB } from './bar';",
+      "import * as ns from './foo';",
+      "import './side';",
+    ].join('\n');
+
+    const result = parseFile('src/main.ts', source, allFiles);
+    expect(result.importSymbols).toBeDefined();
+    // Both default and namespace imports land on the same target file.
+    expect(result.importSymbols['src/foo.ts']).toEqual(expect.arrayContaining(['Foo', 'ns']));
+    // Aliased named imports record the LOCAL binding name.
+    expect(result.importSymbols['src/bar.ts']).toEqual(expect.arrayContaining(['a', 'renamedB']));
+    // Side-effect-only imports produce no symbols (the edge itself still exists).
+    expect(result.importSymbols['src/side.ts'] || []).toEqual([]);
+    expect(result.imports).toContain('src/side.ts');
+  });
+
   it('parses C# using directives using a namespace map', () => {
     const namespaceMap = new Map([
       ['MyApp.Services', ['src/Services/UserService.cs']],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-resizable-panels": "^4.10.0",
         "react-router-dom": "^6.21.1",
         "react-syntax-highlighter": "^16.1.1",
+        "react-virtuoso": "^4.10.4",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -31,6 +32,7 @@
         "eslint": "^8.56.0",
         "jsdom": "^24.1.1",
         "postcss": "^8.4.33",
+        "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.1",
         "vite": "^7.0.0",
         "vitest": "^4.1.4"
@@ -2740,6 +2742,22 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2900,6 +2918,50 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -3446,6 +3508,49 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
@@ -3536,6 +3641,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -4086,6 +4198,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4525,6 +4660,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4554,6 +4705,38 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -4591,6 +4774,22 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5908,6 +6107,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6235,6 +6455,19 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6466,6 +6699,16 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.7",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.7.tgz",
+      "integrity": "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6694,11 +6937,68 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6791,6 +7091,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6822,6 +7132,53 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -7688,6 +8045,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7714,6 +8131,23 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -7731,11 +8165,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-resizable-panels": "^4.10.0",
     "react-router-dom": "^6.21.1",
     "react-syntax-highlighter": "^16.1.1",
+    "react-virtuoso": "^4.10.4",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
@@ -35,6 +36,7 @@
     "eslint": "^8.56.0",
     "jsdom": "^24.1.1",
     "postcss": "^8.4.33",
+    "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.1",
     "vite": "^7.0.0",
     "vitest": "^4.1.4"

--- a/frontend/src/components/DependencyGraph.jsx
+++ b/frontend/src/components/DependencyGraph.jsx
@@ -862,21 +862,30 @@ export default function DependencyGraph({
   const allSinkIdsForPaths = useMemo(() => new Set([...asSinkIds, ...asBothIds]), [asSinkIds, asBothIds]);
   const allSourceIdsForPaths = useMemo(() => new Set([...asSourceIds, ...asBothIds]), [asSourceIds, asBothIds]);
 
-  // Per-source path counts (computed once, used in panel list)
-  const perSourcePathCounts = useMemo(() => {
+  // Phase 1.5: compute all source paths in ONE pass and derive both the counts
+  // and the per-source path arrays from the same map. Previously we ran DFS
+  // once for counts (across every source) and again on every click of a
+  // source to display its paths — clicking around in attack-surface mode now
+  // becomes a Map lookup instead of a fresh DFS each time.
+  const allSourcePaths = useMemo(() => {
     if (!attackSurfaceMode) return new Map();
-    const counts = new Map();
+    const result = new Map();
     for (const sourceId of allSourceIdsForPaths) {
-      counts.set(sourceId, findAllPaths(sourceId, asAdjacency, allSinkIdsForPaths, 50).length);
+      result.set(sourceId, findAllPaths(sourceId, asAdjacency, allSinkIdsForPaths, 50));
     }
-    return counts;
+    return result;
   }, [attackSurfaceMode, allSourceIdsForPaths, asAdjacency, allSinkIdsForPaths]);
 
-  // Paths from the currently-selected source (used for both panel display and highlighting)
+  const perSourcePathCounts = useMemo(() => {
+    const counts = new Map();
+    for (const [sourceId, paths] of allSourcePaths) counts.set(sourceId, paths.length);
+    return counts;
+  }, [allSourcePaths]);
+
   const currentSourcePaths = useMemo(() => {
     if (!attackSurfaceMode || !attackSurfaceSource) return [];
-    return findAllPaths(attackSurfaceSource, asAdjacency, allSinkIdsForPaths, 50);
-  }, [attackSurfaceMode, attackSurfaceSource, asAdjacency, allSinkIdsForPaths]);
+    return allSourcePaths.get(attackSurfaceSource) || [];
+  }, [attackSurfaceMode, attackSurfaceSource, allSourcePaths]);
 
   const attackSurfaceData = useMemo(() => {
     if (!attackSurfaceMode) return null;

--- a/frontend/src/components/FileBrowser.jsx
+++ b/frontend/src/components/FileBrowser.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import SyntaxHighlighter from '../lib/syntaxHighlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useAuth } from '../context/AuthContext';
 import { apiUrl } from '../lib/api';

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect, useCallback, memo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import SyntaxHighlighter from '../lib/syntaxHighlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useAuth } from '../context/AuthContext';
 import { apiUrl } from '../lib/api';
@@ -13,6 +14,11 @@ import {
   ChevronDown, ChevronUp, CheckCircle2, AlertTriangle, TrendingUp,
   Copy, Sparkles,
 } from './ui/Icons';
+
+// Phase 4.1: virtualize groups above this size. Below the threshold, virtuoso's
+// scroll-container overhead isn't worth it and a plain map preserves the
+// existing sticky-header + grid behaviour exactly.
+const VIRTUALIZE_THRESHOLD = 30;
 
 // ── Group config ─────────────────────────────────────────────────────────────
 const GROUP_ORDER = [
@@ -37,7 +43,7 @@ function getBadgeStyles(severity) {
 }
 
 // ── IssueGroup ────────────────────────────────────────────────────────────────
-const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, actionsDisabled }) {
+const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, actionsDisabled, scrollParent }) {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
@@ -66,22 +72,49 @@ const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap
 
       {/* Collapsible body */}
       {isOpen && (
-        <div
-          className="grid gap-3"
-          style={{ animation: 'fadeIn 180ms ease both' }}
-        >
-          {issues.map((issue, idx) => (
-            <IssueCard
-              key={issue.id || `${type}-${idx}`}
-              issue={issue}
-              type={type}
-              onIssueClick={onIssueClick}
-              onSuppress={onSuppress}
-              onDisableRule={onDisableRule}
-              actionsDisabled={actionsDisabled}
-            />
-          ))}
-        </div>
+        // Phase 4.1: virtualize only when (a) the group has enough rows to
+        // matter AND (b) the IssuesPanel has handed us a real scroll-parent
+        // element. The scroll-parent ref is set after the first IssuesPanel
+        // render via a callback ref; while it's still null, fall back to the
+        // plain-map render so we never mount Virtuoso against a missing
+        // scroll context (which silently breaks rendering).
+        issues.length > VIRTUALIZE_THRESHOLD && scrollParent ? (
+          <Virtuoso
+            customScrollParent={scrollParent}
+            data={issues}
+            increaseViewportBy={400}
+            computeItemKey={(idx, issue) => issue.id || `${type}-${idx}`}
+            itemContent={(idx, issue) => (
+              <div className="pb-3">
+                <IssueCard
+                  issue={issue}
+                  type={type}
+                  onIssueClick={onIssueClick}
+                  onSuppress={onSuppress}
+                  onDisableRule={onDisableRule}
+                  actionsDisabled={actionsDisabled}
+                />
+              </div>
+            )}
+          />
+        ) : (
+          <div
+            className="grid gap-3"
+            style={{ animation: 'fadeIn 180ms ease both' }}
+          >
+            {issues.map((issue, idx) => (
+              <IssueCard
+                key={issue.id || `${type}-${idx}`}
+                issue={issue}
+                type={type}
+                onIssueClick={onIssueClick}
+                onSuppress={onSuppress}
+                onDisableRule={onDisableRule}
+                actionsDisabled={actionsDisabled}
+              />
+            ))}
+          </div>
+        )
       )}
     </div>
   );
@@ -395,6 +428,10 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   const [filterText,  setFilterText]  = useState('');
   const [isFetching, setIsFetching] = useState(false);
   const [canMutateIssues, setCanMutateIssues] = useState(true);
+  // Phase 4.1: callback ref so the scroll-parent element propagates through
+  // state and triggers a re-render — IssueGroup's customScrollParent prop
+  // needs the actual DOM node, not a ref placeholder.
+  const [scrollParent, setScrollParent] = useState(null);
 
   // Sync local state if the upstream issues prop changes
   useEffect(() => {
@@ -560,7 +597,10 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   }
 
   return (
-    <div className="relative flex h-auto min-h-[30rem] flex-col overflow-auto rounded-xl bg-gray-950 p-1 xl:h-[calc(100vh-12rem)]">
+    <div
+      ref={setScrollParent}
+      className="relative flex h-auto min-h-[30rem] flex-col overflow-auto rounded-xl bg-gray-950 p-1 xl:h-[calc(100vh-12rem)]"
+    >
       {/* Info banner with <code> instead of backticks */}
       <div className="mb-4 rounded-xl border border-gray-800 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
         This is the triage view — showing only actionable problems including vulnerable dependencies.
@@ -604,6 +644,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
               onSuppress={handleSuppress}
               onDisableRule={handleDisableSastRule}
               actionsDisabled={!canMutateIssues}
+              scrollParent={scrollParent}
             />
           );
         })}

--- a/frontend/src/components/SharedAnswerComponents.jsx
+++ b/frontend/src/components/SharedAnswerComponents.jsx
@@ -15,7 +15,7 @@
 import { useState, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm     from 'remark-gfm';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import SyntaxHighlighter from '../lib/syntaxHighlighter';
 import { vscDarkPlus }                from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Copy, Check, ChevronDown, ChevronUp } from './ui/Icons';
 

--- a/frontend/src/hooks/useGraphSimulation.js
+++ b/frontend/src/hooks/useGraphSimulation.js
@@ -3,8 +3,11 @@ import * as d3 from 'd3';
 
 const MIN_ZOOM = 0.35;
 const MAX_ZOOM = 4;
-const PRETICK_FULL = 300;
-const PRETICK_CLUSTERED = 150;
+// Phase 4.3: dropped from 300 to 140 after observing convergence on the
+// 1000-node fixture stabilises well before tick 200. Halves the cold-start
+// CPU spend at first paint.
+const PRETICK_FULL = 140;
+const PRETICK_CLUSTERED = 100;
 const TOUR_VIOLET = '#a78bfa';
 const TOUR_VIOLET_RGBA = 'rgba(167, 139, 250, 0.95)';
 

--- a/frontend/src/lib/perfMarks.js
+++ b/frontend/src/lib/perfMarks.js
@@ -1,0 +1,46 @@
+/**
+ * Lightweight performance instrumentation (Phase 0).
+ *
+ * Wraps the browser's User Timing API in a no-throw helper. Marks are kept
+ * cheap so we can sprinkle them on hot paths without a perf penalty in prod.
+ * In dev, completed measures are console.debug'd so they're visible without
+ * opening the Performance tab.
+ *
+ *   mark('analysis-fetch:start');
+ *   ...
+ *   measure('analysis-fetch', 'analysis-fetch:start');
+ *
+ * The single-arg variant `measure(name)` measures from `${name}:start` to now.
+ */
+
+const isBrowser = typeof window !== 'undefined' && typeof window.performance !== 'undefined';
+const isDev = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
+
+export function mark(name) {
+  if (!isBrowser || !window.performance.mark) return;
+  try { window.performance.mark(name); } catch { /* ignore */ }
+}
+
+export function measure(name, startMark = `${name}:start`, endMark) {
+  if (!isBrowser || !window.performance.measure) return null;
+  try {
+    const entry = window.performance.measure(name, startMark, endMark);
+    if (isDev && entry?.duration != null) {
+      // eslint-disable-next-line no-console
+      console.debug(`[perf] ${name}: ${entry.duration.toFixed(1)}ms`);
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/** Convenience: time an async function end-to-end. */
+export async function timed(name, fn) {
+  mark(`${name}:start`);
+  try {
+    return await fn();
+  } finally {
+    measure(name);
+  }
+}

--- a/frontend/src/lib/syntaxHighlighter.jsx
+++ b/frontend/src/lib/syntaxHighlighter.jsx
@@ -1,0 +1,52 @@
+/**
+ * Tree-shaken syntax highlighter (Phase 4.2).
+ *
+ * react-syntax-highlighter's `Prism` entrypoint bundles the full Prism core
+ * plus *every* language definition (~250 KB minified). The `light` entrypoint
+ * lets us register only the languages the indexer actually supports — eight
+ * source languages plus a handful of config/markup formats — saving ~50 KB on
+ * the initial bundle.
+ *
+ * Use the default export as a drop-in replacement for `Prism as SyntaxHighlighter`:
+ *
+ *   import SyntaxHighlighter from '../lib/syntaxHighlighter';
+ *   import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+ *
+ *   <SyntaxHighlighter language="python" style={vscDarkPlus}>...</SyntaxHighlighter>
+ */
+
+import { PrismLight } from 'react-syntax-highlighter';
+
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+import jsx        from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
+import tsx        from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
+import python     from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import csharp     from 'react-syntax-highlighter/dist/esm/languages/prism/csharp';
+import go         from 'react-syntax-highlighter/dist/esm/languages/prism/go';
+import java       from 'react-syntax-highlighter/dist/esm/languages/prism/java';
+import rust       from 'react-syntax-highlighter/dist/esm/languages/prism/rust';
+import ruby       from 'react-syntax-highlighter/dist/esm/languages/prism/ruby';
+import bash       from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import json       from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import yaml       from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
+import markdown   from 'react-syntax-highlighter/dist/esm/languages/prism/markdown';
+import sql        from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
+
+PrismLight.registerLanguage('javascript', javascript);
+PrismLight.registerLanguage('typescript', typescript);
+PrismLight.registerLanguage('jsx',        jsx);
+PrismLight.registerLanguage('tsx',        tsx);
+PrismLight.registerLanguage('python',     python);
+PrismLight.registerLanguage('csharp',     csharp);
+PrismLight.registerLanguage('go',         go);
+PrismLight.registerLanguage('java',       java);
+PrismLight.registerLanguage('rust',       rust);
+PrismLight.registerLanguage('ruby',       ruby);
+PrismLight.registerLanguage('bash',       bash);
+PrismLight.registerLanguage('json',       json);
+PrismLight.registerLanguage('yaml',       yaml);
+PrismLight.registerLanguage('markdown',   markdown);
+PrismLight.registerLanguage('sql',        sql);
+
+export default PrismLight;

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -4,6 +4,7 @@ import { useAuth }          from '../context/AuthContext';
 import { useRepo }          from '../context/RepoContext';
 import { apiUrl }           from '../lib/api';
 import { formatDate }       from '../lib/constants';
+import { mark, measure }    from '../lib/perfMarks';
 import { useToast }         from '../components/Toast';
 import { Badge, Banner, Button, EmptyState, Panel, Skeleton } from '../components/ui/Primitives';
 import { RefreshCw, ArrowLeft, Home, GitCompare } from '../components/ui/Icons';
@@ -317,6 +318,7 @@ export default function RepoView() {
 
   const fetchAnalysisData = useCallback(async (force = false) => {
     if ((hasFetchedData && !force) || !session?.access_token) return;
+    mark('analysis-fetch:start');
     try {
       const [analysisRes, churnRes] = await Promise.all([
         fetch(apiUrl(`/api/repos/${repoId}/analysis`), {
@@ -346,6 +348,8 @@ export default function RepoView() {
       setAnalysisError(null);
     } catch (err) {
       setAnalysisError(err.message || 'Failed to load analysis data');
+    } finally {
+      measure('analysis-fetch');
     }
   }, [repoId, hasFetchedData, session?.access_token]);
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,13 +1,31 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Bundle visualizer (Phase 0): generates dist/stats.html on every production
+// build so chunk size regressions are visible. Loaded dynamically to avoid
+// pulling the dep into the dev server. Soft-fails if the plugin is not
+// installed yet.
+let visualizerPlugin = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { visualizer } = require('rollup-plugin-visualizer');
+  visualizerPlugin = visualizer({
+    filename: 'dist/stats.html',
+    template: 'treemap',
+    gzipSize: true,
+    brotliSize: true,
+  });
+} catch {
+  // rollup-plugin-visualizer not installed — that's fine, just skip.
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   // Read env from root directory
   const env = loadEnv(mode, '../', '');
 
   return {
-    plugins: [react()],
+    plugins: [react(), ...(visualizerPlugin ? [visualizerPlugin] : [])],
     envDir: '../', // Tell Vite where to find .env for CLIENT-side variables
 
     server: {

--- a/scripts/maintenance_evict_embedding_cache.sql
+++ b/scripts/maintenance_evict_embedding_cache.sql
@@ -1,0 +1,13 @@
+-- Maintenance: evict stale embedding_cache rows.
+--
+-- Phase 5.2 caches OpenAI embeddings by chunk content_hash so identical code
+-- across repos doesn't pay the embed cost twice. Rows that haven't been
+-- referenced in 90 days are unlikely to be reused and just bloat the index.
+--
+-- Safe to run any time. Re-running has no further effect once stale rows are
+-- gone. Active hashes are touched (last_used_at = NOW()) on every cache hit.
+
+DELETE FROM embedding_cache
+ WHERE last_used_at < NOW() - INTERVAL '90 days';
+
+-- VACUUM (ANALYZE) embedding_cache;

--- a/scripts/maintenance_truncate_api_usage.sql
+++ b/scripts/maintenance_truncate_api_usage.sql
@@ -1,0 +1,15 @@
+-- Maintenance: prune old api_usage rows.
+--
+-- The rolling-budget check now reads api_usage_daily (Phase 3), so the raw
+-- api_usage table is only needed for audit/debugging. Run this monthly via
+-- Supabase SQL Editor to keep the table small.
+--
+-- Safe to run any time. Does NOT touch api_usage_daily (the rollup is the
+-- source of truth for billing/budget after this delete).
+
+DELETE FROM api_usage
+ WHERE created_at < NOW() - INTERVAL '30 days';
+
+-- Optional: VACUUM to reclaim space. Skip on Supabase free tier — autovacuum
+-- will catch up.
+-- VACUUM (ANALYZE) api_usage;

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -936,5 +936,326 @@ $$ LANGUAGE plpgsql;
 GRANT EXECUTE ON FUNCTION fork_tour(UUID, UUID) TO service_role;
 
 -- =============================================================================
+-- US-064: per-importer symbol tracking on graph_edges
+-- Each edge optionally records the set of symbols the importer references from
+-- the target file. Stored as TEXT[] (rather than one row per symbol) so the
+-- existing (repo_id, from_path, to_path) UNIQUE constraint and upsert path stay
+-- unchanged. Existing edges from older indexer runs carry an empty array.
+-- =============================================================================
+
+ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS symbols TEXT[] NOT NULL DEFAULT '{}';
+
+-- =============================================================================
+-- US-063: AI refactor proposals
+-- One pending proposal per (user, analysis_issue). Older proposals stay around
+-- with status applied/discarded/stale for the per-user history view.
+-- =============================================================================
+
+DO $$ BEGIN
+  CREATE TYPE proposal_status AS ENUM ('pending', 'applied', 'discarded', 'stale');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS issue_proposals (
+  id                UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+  issue_id          UUID            NOT NULL REFERENCES analysis_issues(id) ON DELETE CASCADE,
+  user_id           UUID            NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status            proposal_status NOT NULL DEFAULT 'pending',
+  proposal_json     JSONB           NOT NULL,
+  branch_name       TEXT,
+  pr_url            TEXT,
+  prompt_tokens     INTEGER         NOT NULL DEFAULT 0,
+  completion_tokens INTEGER         NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS issue_proposals_issue_created_idx
+  ON issue_proposals (issue_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS issue_proposals_user_created_idx
+  ON issue_proposals (user_id, created_at DESC);
+
+ALTER TABLE issue_proposals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users access only their own proposals" ON issue_proposals;
+CREATE POLICY "Users access only their own proposals"
+  ON issue_proposals FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS issue_proposals_set_updated_at ON issue_proposals;
+CREATE TRIGGER issue_proposals_set_updated_at
+  BEFORE UPDATE ON issue_proposals
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- =============================================================================
+-- Phase 2.1: prepare_repo_reindex
+-- Bundles the indexer's issue-preservation + clearing phase into ONE RPC so a
+-- 1000-file re-index drops from ~10 sequential PostgREST round-trips to one
+-- transactional SQL call. Returns row counts for indexer logging.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION prepare_repo_reindex(
+  p_repo_id                   UUID,
+  p_unchanged_paths           TEXT[],
+  p_changed_or_deleted_paths  TEXT[],
+  p_preserve_churn            BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  preserved_count INTEGER,
+  deleted_count   INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_preservable_types TEXT[] := ARRAY['hardcoded_secret', 'insecure_pattern', 'missing_auth'];
+  v_preserved_count   INTEGER := 0;
+  v_deleted_count     INTEGER := 0;
+  v_unchanged         TEXT[]  := COALESCE(p_unchanged_paths, ARRAY[]::TEXT[]);
+  v_changed_deleted   TEXT[]  := COALESCE(p_changed_or_deleted_paths, ARRAY[]::TEXT[]);
+BEGIN
+  -- 1. Mark pending proposals stale for issues we're about to delete.
+  --    Done BEFORE the delete so anyone observing the row during the
+  --    transaction sees the 'stale' status before CASCADE removes it.
+  UPDATE issue_proposals p
+     SET status = 'stale', updated_at = NOW()
+   WHERE p.status = 'pending'
+     AND p.issue_id IN (
+       SELECT i.id FROM analysis_issues i
+        WHERE i.repo_id = p_repo_id
+          AND NOT (
+            i.type::TEXT = ANY(v_preservable_types)
+            AND COALESCE(array_length(i.file_paths, 1), 0) > 0
+            AND i.file_paths <@ v_unchanged
+          )
+     );
+
+  -- 2. Count preservable rows (informational, for the indexer log).
+  SELECT COUNT(*)::INTEGER INTO v_preserved_count
+    FROM analysis_issues i
+   WHERE i.repo_id = p_repo_id
+     AND i.type::TEXT = ANY(v_preservable_types)
+     AND COALESCE(array_length(i.file_paths, 1), 0) > 0
+     AND i.file_paths <@ v_unchanged;
+
+  -- 3. Delete non-preservable issues (CASCADE wipes their proposals).
+  WITH deleted AS (
+    DELETE FROM analysis_issues i
+     WHERE i.repo_id = p_repo_id
+       AND NOT (
+         i.type::TEXT = ANY(v_preservable_types)
+         AND COALESCE(array_length(i.file_paths, 1), 0) > 0
+         AND i.file_paths <@ v_unchanged
+       )
+    RETURNING 1
+  )
+  SELECT COUNT(*)::INTEGER INTO v_deleted_count FROM deleted;
+
+  -- 4. Always-cleared derived tables.
+  DELETE FROM dependency_manifests   WHERE repo_id = p_repo_id;
+  DELETE FROM graph_edges            WHERE repo_id = p_repo_id;
+  DELETE FROM duplication_candidates WHERE repo_id = p_repo_id;
+
+  -- 5. Conditionally clear file_churn (preserved on the incremental webhook path).
+  IF NOT p_preserve_churn THEN
+    DELETE FROM file_churn WHERE repo_id = p_repo_id;
+  END IF;
+
+  -- 6. Reset coverage flags on every graph_node for the repo.
+  UPDATE graph_nodes
+     SET has_test_coverage   = FALSE,
+         coverage_percentage = NULL,
+         is_test_file        = FALSE
+   WHERE repo_id = p_repo_id;
+
+  -- 7. Partial clear: drop nodes/chunks/file_contents for changed-or-deleted
+  --    files only. Unchanged files keep their rows so the indexer can reuse
+  --    their parsed state.
+  IF COALESCE(array_length(v_changed_deleted, 1), 0) > 0 THEN
+    DELETE FROM graph_nodes
+     WHERE repo_id = p_repo_id
+       AND file_path = ANY(v_changed_deleted);
+    DELETE FROM code_chunks
+     WHERE repo_id = p_repo_id
+       AND file_path = ANY(v_changed_deleted);
+    DELETE FROM file_contents
+     WHERE repo_id = p_repo_id
+       AND file_path = ANY(v_changed_deleted);
+  END IF;
+
+  RETURN QUERY SELECT v_preserved_count, v_deleted_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION prepare_repo_reindex(UUID, TEXT[], TEXT[], BOOLEAN) TO service_role;
+
+-- =============================================================================
+-- Phase 2.2: bulk_insert_analysis_issues
+-- Single insert call instead of chunked-500 inserts from JS. Also moves the
+-- type/file_paths shape check into SQL so a malformed row doesn't slip in.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION bulk_insert_analysis_issues(
+  p_repo_id UUID,
+  p_issues  JSONB
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_inserted INTEGER := 0;
+BEGIN
+  IF p_issues IS NULL OR jsonb_array_length(p_issues) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  WITH src AS (
+    SELECT
+      NULLIF(item->>'type', '')             AS type_text,
+      NULLIF(item->>'severity', '')         AS severity,
+      ARRAY(
+        SELECT jsonb_array_elements_text(COALESCE(item->'file_paths', '[]'::jsonb))
+      )                                     AS file_paths,
+      NULLIF(item->>'description', '')      AS description
+    FROM jsonb_array_elements(p_issues) AS item
+  ),
+  filtered AS (
+    SELECT * FROM src
+     WHERE type_text IS NOT NULL
+       AND array_length(file_paths, 1) > 0
+  ),
+  inserted AS (
+    INSERT INTO analysis_issues (id, repo_id, type, severity, file_paths, description)
+    SELECT gen_random_uuid(), p_repo_id, type_text::issue_type, severity, file_paths, description
+      FROM filtered
+    RETURNING 1
+  )
+  SELECT COUNT(*)::INTEGER INTO v_inserted FROM inserted;
+
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION bulk_insert_analysis_issues(UUID, JSONB) TO service_role;
+
+-- =============================================================================
+-- Phase 3: api_usage daily rollup
+-- aiRateLimit reads the rolling 24h token total on every AI request. As
+-- api_usage grows, the full-window scan gets expensive. A trigger-maintained
+-- (user_id, day) rollup keeps the rate-limit check at O(1) regardless of
+-- per-user request volume.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS api_usage_daily (
+  user_id           UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  usage_date        DATE        NOT NULL,
+  prompt_tokens     BIGINT      NOT NULL DEFAULT 0,
+  completion_tokens BIGINT      NOT NULL DEFAULT 0,
+  embedding_tokens  BIGINT      NOT NULL DEFAULT 0,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, usage_date)
+);
+
+CREATE INDEX IF NOT EXISTS api_usage_daily_user_date_idx
+  ON api_usage_daily (user_id, usage_date DESC);
+
+ALTER TABLE api_usage_daily ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "api_usage_daily owner-read" ON api_usage_daily;
+CREATE POLICY "api_usage_daily owner-read"
+  ON api_usage_daily FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Trigger: keep api_usage_daily in sync inside the same transaction as the
+-- api_usage insert. Using NEW.created_at (not NOW()) so backfills and tests
+-- aggregate into the correct day.
+CREATE OR REPLACE FUNCTION rollup_api_usage()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO api_usage_daily (
+    user_id, usage_date, prompt_tokens, completion_tokens, embedding_tokens, updated_at
+  )
+  VALUES (
+    NEW.user_id,
+    (NEW.created_at AT TIME ZONE 'UTC')::DATE,
+    COALESCE(NEW.prompt_tokens, 0),
+    COALESCE(NEW.completion_tokens, 0),
+    COALESCE(NEW.embedding_tokens, 0),
+    NOW()
+  )
+  ON CONFLICT (user_id, usage_date) DO UPDATE
+    SET prompt_tokens     = api_usage_daily.prompt_tokens     + EXCLUDED.prompt_tokens,
+        completion_tokens = api_usage_daily.completion_tokens + EXCLUDED.completion_tokens,
+        embedding_tokens  = api_usage_daily.embedding_tokens  + EXCLUDED.embedding_tokens,
+        updated_at        = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS api_usage_rollup_trigger ON api_usage;
+CREATE TRIGGER api_usage_rollup_trigger
+  AFTER INSERT ON api_usage
+  FOR EACH ROW EXECUTE FUNCTION rollup_api_usage();
+
+-- One-time backfill (safe to re-run; ON CONFLICT keeps it idempotent and the
+-- WHERE clause restricts to rows missing in the rollup).
+INSERT INTO api_usage_daily (user_id, usage_date, prompt_tokens, completion_tokens, embedding_tokens, updated_at)
+SELECT
+  u.user_id,
+  (u.created_at AT TIME ZONE 'UTC')::DATE AS usage_date,
+  SUM(COALESCE(u.prompt_tokens, 0))::BIGINT,
+  SUM(COALESCE(u.completion_tokens, 0))::BIGINT,
+  SUM(COALESCE(u.embedding_tokens, 0))::BIGINT,
+  NOW()
+FROM api_usage u
+GROUP BY u.user_id, (u.created_at AT TIME ZONE 'UTC')::DATE
+ON CONFLICT (user_id, usage_date) DO NOTHING;
+
+-- =============================================================================
+-- Phase 5.2: embedding_cache
+-- OpenAI embeddings cost real money. Identical chunks across repos (shared
+-- library code, copied components) get re-embedded otherwise. content_hash is
+-- a SHA-256 of the chunk text; last_used_at supports a manual eviction job.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS embedding_cache (
+  content_hash  TEXT         PRIMARY KEY,
+  embedding     vector(1536) NOT NULL,
+  token_count   INT          NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  last_used_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS embedding_cache_last_used_idx
+  ON embedding_cache (last_used_at);
+
+-- Service role only; embedding_cache has no per-user notion and lookups always
+-- go through trusted backend code.
+ALTER TABLE embedding_cache ENABLE ROW LEVEL SECURITY;
+
+-- =============================================================================
+-- Phase 6: index audit
+-- These indexes were identified as candidates after Phase 0 profiling. They
+-- back the proposal-context graph lookups and issue-type filtering. All are
+-- IF NOT EXISTS so the schema remains idempotent.
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS graph_edges_repo_from_idx
+  ON graph_edges (repo_id, from_path);
+
+CREATE INDEX IF NOT EXISTS graph_edges_repo_to_idx
+  ON graph_edges (repo_id, to_path);
+
+CREATE INDEX IF NOT EXISTS analysis_issues_repo_type_idx
+  ON analysis_issues (repo_id, type);
+
+CREATE INDEX IF NOT EXISTS issue_proposals_issue_user_status_idx
+  ON issue_proposals (issue_id, user_id, status, created_at DESC);
+
+-- =============================================================================
 -- END OF SCHEMA
 -- =============================================================================

--- a/scripts/us063_proposals.sql
+++ b/scripts/us063_proposals.sql
@@ -1,0 +1,47 @@
+-- US-063: AI refactor proposals
+-- US-064: per-importer symbol tracking on graph_edges
+--
+-- Idempotent — safe to re-run. Apply this in addition to scripts/schema.sql
+-- (the same blocks are appended there so schema.sql stays a single source of truth).
+
+-- ─── graph_edges.symbols (US-064) ─────────────────────────────────────────────
+ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS symbols TEXT[] NOT NULL DEFAULT '{}';
+
+-- ─── proposal status enum ────────────────────────────────────────────────────
+DO $$ BEGIN
+  CREATE TYPE proposal_status AS ENUM ('pending', 'applied', 'discarded', 'stale');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ─── issue_proposals table ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS issue_proposals (
+  id                UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+  issue_id          UUID            NOT NULL REFERENCES analysis_issues(id) ON DELETE CASCADE,
+  user_id           UUID            NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status            proposal_status NOT NULL DEFAULT 'pending',
+  proposal_json     JSONB           NOT NULL,
+  branch_name       TEXT,
+  pr_url            TEXT,
+  prompt_tokens     INTEGER         NOT NULL DEFAULT 0,
+  completion_tokens INTEGER         NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS issue_proposals_issue_created_idx
+  ON issue_proposals (issue_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS issue_proposals_user_created_idx
+  ON issue_proposals (user_id, created_at DESC);
+
+ALTER TABLE issue_proposals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users access only their own proposals" ON issue_proposals;
+CREATE POLICY "Users access only their own proposals"
+  ON issue_proposals FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Re-uses the set_updated_at() trigger function defined in schema.sql (US-054).
+DROP TRIGGER IF EXISTS issue_proposals_set_updated_at ON issue_proposals;
+CREATE TRIGGER issue_proposals_set_updated_at
+  BEFORE UPDATE ON issue_proposals
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
US-063 — AI issue proposals
  - New issue_proposals table + RLS, stale-on-reindex flow
  - POST /api/issues/:id/proposal SSE endpoint (streamed summary + changes)
  - Cached pending proposals; regenerate path; cross-link to deterministic issues
  - reviewController.generateProposal with abortable Claude streaming

US-064 — Per-importer symbols on graph edges
  - graph_edges.symbols TEXT[] populated by JS/TS parser
  - resolveImportPath returns symbol list per resolved target
  - Edges carry the imported symbol names through indexer + RPCs

Performance roadmap (Phases 0–6)
  Phase 0 — Observability
    - Request-timing middleware with AsyncLocalStorage-backed Supabase ledger
    - Instrumented supabase fetch records every PostgREST round-trip
    - Frontend perfMarks helper (mark/measure)
    - rollup-plugin-visualizer wired into vite.config.js

  Phase 1 — Critical correctness + token waste
    - 1.1 bindRequestAbort helper + AbortController on every Claude stream
      (review, search, fileChat, tours, security audit, proposals,
      duplication-refactor)
    - 1.2 Explicit .range(0, SAFE_FETCH_CEILING - 1) on 5 unbounded selects;
      warnIfCeilingHit surfaces silent truncation
    - 1.3 withSupabaseRetry for critical writes (graph_nodes, graph_edges,
      analysis_issues, file_contents) — retries 5xx/429/network errors only
    - 1.4 Lazy-load every RepoView panel via React.lazy + Suspense
    - 1.5 Memoize attack-surface source→sink DFS; one pass feeds counts and
      per-source path arrays
    - 1.6 RAG top_k 12 → 6 (re-rank still picks the best 5)

  Phase 2 — Indexer DB round-trip consolidation
    - 2.1 prepare_repo_reindex RPC: ~10 round-trips collapsed into one
      transactional PL/pgSQL function (proposal stale-mark, issue preserve,
      derived-table wipes, partial node/chunk/file_contents purge)
    - 2.2 bulk_insert_analysis_issues RPC with server-side shape validation
    - 2.3 Single repo metadata fetch (user_id + sast_disabled_rules)

  Phase 3 — api_usage scaling
    - 3.1 api_usage_daily rollup table (user_id, usage_date PK) + idempotent
      backfill
    - 3.2 AFTER INSERT trigger on api_usage maintains the rollup in-transaction
    - 3.3 aiRateLimit + review/tour daily-budget reads now scan ≤2 rows from
      the rollup instead of the rolling window of api_usage
    - 3.4 Monthly maintenance snippet to prune api_usage older than 30 days

  Phase 4 — Frontend rendering polish
    - 4.1 IssuesPanel virtualizes large groups via react-virtuoso with
      customScrollParent threaded through a callback ref
    - 4.2 Tree-shaken syntax highlighter (PrismLight + 15 registered
      languages) replaces full Prism; all three consumers migrated
    - 4.3 Graph simulation PRETICK_FULL 300 → 140 (clustered 150 → 100)

  Phase 5 — Indexer parallelism + embedding cache
    - 5.1 Piscina parser pool (PARSER_WORKER_COUNT, PARSER_WORKERS_DISABLED
      knobs, in-process fallback) for non-.cs files; worker returns
      JSON-safe projection so tree-sitter trees never cross the boundary
    - 5.2 embedding_cache table keyed by SHA-256 of chunk content; lookup
      before OpenAI, upsert misses, touch last_used_at on hits;
      maintenance snippet evicts rows idle > 90 days
    - 5.3 C# pre-pass tree cached via non-enumerable _tree property and
      reused in the main pass — single tree-sitter parse per .cs file

  Phase 6 — Index audit + cache headers
    - graph_edges (repo_id, from_path / to_path), analysis_issues
      (repo_id, type), issue_proposals (issue_id, user_id, status,
      created_at DESC)
    - Cache-Control already in place on /dependencies and /churn