### PR TITLE
feat(proposals): Apply via PR + finalize refactor proposals epic (US-066)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,14 @@ CodeLens is a full-stack web app that helps developers understand large, unfamil
 - Architectural issue detection (circular deps, god files, dead code, high coupling)
 - Security scanning: secret detection, SAST pattern matching, dependency vulnerability scanning, attack surface mapping, auth coverage checking
 - AI security audit mode with whole-repo auditing and structured findings
+- **AI refactor proposals** with one-click "Apply via PR" producing a draft GitHub PR in a single commit (US-063–US-066)
+- AI-generated code tours / guided walkthroughs (US-060, US-061), with fork + share-impact
+- Duplicate-code clustering + AI shared-utility refactor suggestion
 - RAG-powered natural language code search
 - File complexity/impact ("blast radius") analysis
+- Per-file AI chat
+- Team-shared repos (access via ownership or team membership)
+- Auto-sync on `git push` via per-repo GitHub webhook
 
 ---
 
@@ -71,24 +77,34 @@ CodeLens-hub/
 │   ├── components/         # UI components
 │   │   ├── DependencyGraph.jsx       # D3 graph + attack surface overlay (US-047)
 │   │   ├── CodeReviewPanel.jsx       # AI review + security audit mode (US-048)
-│   │   ├── IssuesPanel.jsx           # All issue types including missing_auth (US-049)
+│   │   ├── IssuesPanel.jsx           # All issue types + duplication + "PR opened" badges (US-066)
+│   │   ├── ProposalPanel.jsx         # AI refactor proposal review + Apply via PR (US-065, US-066)
 │   │   ├── ImpactAnalysisPanel.jsx   # Blast-radius panel
 │   │   ├── MetricsPanel.jsx
 │   │   ├── SearchPanel.jsx
-│   │   └── ui/                       # Primitives, Icons (lucide-react re-exports)
-│   ├── pages/              # Login, Dashboard, RepoView, Search
+│   │   └── ui/                       # Primitives, Icons (lucide-react re-exports), Toast
+│   ├── pages/              # Login, AuthCallback, Dashboard, RepoView, Search
 │   ├── context/            # AuthContext
 │   ├── hooks/
 │   │   └── useGraphSimulation.js     # D3 physics + visual modes (selection/impact/attack surface)
-│   └── lib/                # supabase.js client, api.js, constants.js
+│   └── lib/                # supabase.js client, api.js (apiUrl helper), constants.js, syntaxHighlighter
 │
 ├── backend/src/
-│   ├── index.js            # Express setup + all route mounting
-│   ├── routes/             # Route definitions
+│   ├── index.js            # Express setup + all route mounting + global token-redacting console
+│   ├── routes/             # auth, repo, search, analysis, review, webhooks, teams, fileChat, usage, admin, tours
 │   ├── controllers/        # Request handlers
 │   │   ├── analysisController.js     # Issues, suppress, impact
-│   │   └── reviewController.js       # AI review + security audit (US-048)
+│   │   ├── reviewController.js       # AI review + security audit + refactor proposals + apply-via-PR (US-048, US-064–US-066)
+│   │   ├── repoController.js         # Connect, upload, status, reindex, churn, duplication, branches, diff, dependencies
+│   │   ├── teamController.js         # Team CRUD + repo sharing
+│   │   ├── fileChatController.js     # Per-file AI chat
+│   │   ├── toursController.js        # Code-tour generation/edit/fork (US-060, US-061)
+│   │   ├── usageController.js        # /api/usage/today
+│   │   ├── webhookController.js      # GitHub push → auto-reindex
+│   │   ├── authController.js         # GitHub OAuth handshake
+│   │   └── searchController.js       # RAG search
 │   ├── services/           # Business logic
+│   │   ├── indexer.js                # Top-level indexing entry
 │   │   ├── indexerService.js         # Core indexing pipeline
 │   │   ├── secretScanner.js          # Hardcoded secret detection (US-044)
 │   │   ├── sastEngine.js             # AST-based SAST rules (US-046)
@@ -96,6 +112,13 @@ CodeLens-hub/
 │   │   ├── attackSurfaceClassifier.js # Source/sink classification (US-047)
 │   │   ├── manifestParser.js         # Dependency manifest parsing (US-045)
 │   │   ├── osvScanner.js             # OSV.dev vulnerability lookup (US-045)
+│   │   ├── duplicationScanner.js     # Cosine-similarity duplicate clustering over code_chunks
+│   │   ├── churnService.js           # Per-file git churn from history
+│   │   ├── diffService.js            # Structural (node/edge) diff between two refs (US-051)
+│   │   ├── issueDetection.js         # Circular dep / god file / coupling / dead code
+│   │   ├── startHereTourService.js   # Auto-generated "Start Here" tour
+│   │   ├── testCoverageService.js    # Test/coverage file detection
+│   │   ├── queue.js                  # Indexing job queue
 │   │   └── usageTracker.js           # Daily token budget (US-042)
 │   ├── sast/
 │   │   ├── secret-rules.json         # Regex rules for secret scanning
@@ -103,7 +126,7 @@ CodeLens-hub/
 │   ├── parsers/            # Tree-sitter AST parsing per language
 │   │   ├── parserPool.js             # Piscina worker pool singleton (Phase 5.1)
 │   │   └── parser-worker.js          # Worker entry — JSON-safe parsed result
-│   ├── lib/                # Shared helpers — dbHelpers, sseAbort
+│   ├── lib/                # Shared helpers — dbHelpers, sseAbort, githubAuth
 │   ├── observability/      # AsyncLocalStorage request ledger (Phase 0)
 │   ├── ai/                 # ragService.js (RAG pipeline)
 │   ├── db/                 # Supabase admin client (instrumented fetch)
@@ -113,6 +136,9 @@ CodeLens-hub/
 │   ├── setup.sh                              # Idempotent bootstrap
 │   ├── schema.sql                            # Full DB schema — apply via Supabase SQL Editor
 │   ├── us048_security_audits.sql             # security_audits table + RLS
+│   ├── us051_arch_diff.sql                   # Architectural diff (US-051) support
+│   ├── us063_proposals.sql                   # issue_proposals table + RLS + stale-detection (US-063)
+│   ├── perf_reindex_migration.sql            # prepare_repo_reindex RPC migration
 │   ├── maintenance_truncate_api_usage.sql    # Monthly — prune raw api_usage > 30 days
 │   └── maintenance_evict_embedding_cache.sql # Quarterly — evict embedding_cache idle > 90 days
 │
@@ -127,9 +153,16 @@ CodeLens-hub/
 |---|---|---|
 | `GET` | `/health` | Health check |
 | `*` | `/api/auth/*` | GitHub OAuth |
-| `*` | `/api/repos/*` | Connect repos, upload ZIPs, patch config |
+| `*` | `/api/repos/*` | Connect repos, upload ZIPs, list, status, re-index, delete; PATCH `auto_sync_enabled` / `sast_disabled_rules` |
+| `GET` | `/api/repos/:id/status` | Indexing status (`pending \| indexing \| ready \| failed`) + per-stage readiness flags |
+| `GET` | `/api/repos/:id/file` | File contents for the viewer (US-037, US-043) |
 | `GET` | `/api/repos/:id/dependencies` | SCA vulnerability data (US-045) |
-| `*` | `/api/search/*` | RAG code search |
+| `GET` | `/api/repos/:id/duplication` | Duplicate-code clusters |
+| `GET` | `/api/repos/:id/churn` | Per-file git churn |
+| `GET` | `/api/repos/:id/branches` | List branches (Octokit) |
+| `GET` | `/api/repos/:id/diff` | Structural diff (node/edge changes) between two refs (US-051) |
+| `GET` | `/api/repos/:id/webhook` | Generate a webhook secret for the repo |
+| `*` | `/api/search/*` | RAG code search (Groq + pgvector HNSW) |
 | `*` | `/api/analysis/*` | Graph, metrics, issues, impact |
 | `POST` | `/api/analysis/:id/issues/suppress` | Suppress an issue (secrets + missing_auth) |
 | `POST` | `/api/review/:id` | Single-file AI review or security audit |
@@ -137,7 +170,16 @@ CodeLens-hub/
 | `GET` | `/api/review/:id/security-audits` | Audit history |
 | `GET` | `/api/review/:id/security-audits/:auditId` | Single audit |
 | `POST` | `/api/review/:id/duplication-refactor` | SSE: AI shared-utility refactor for a duplicate cluster |
-| `POST` | `/api/issues/:issueId/proposal` | SSE: AI fix proposal for an `analysis_issues` row (US-063) |
+| `POST` | `/api/review/:id/issues/:issueId/proposals` | SSE: AI fix proposal for an `analysis_issues` row; `?regenerate=true` skips cache (US-064) |
+| `PATCH` | `/api/review/:id/issues/:issueId/proposals/:proposalId` | Update proposal status (discard) |
+| `GET` | `/api/review/:id/proposals/summary` | Latest proposal per issue for IssueCard badges (US-066) |
+| `POST` | `/api/review/:id/proposals/:proposalId/apply` | Apply a proposal as a GitHub draft PR via single-commit Git Data API (US-066) |
+| `POST` | `/api/file-chat/:id` | Per-file AI chat |
+| `*` | `/api/tours/*` | Generate/list/update/fork/delete AI-authored code tours (US-060, US-061) |
+| `*` | `/api/teams/*` | Create teams, add repos to teams, list team repos |
+| `GET` | `/api/usage/today` | Today's per-user token usage (US-042) |
+| `POST` | `/api/webhooks/github` | GitHub push webhook → auto-reindex when `auto_sync_enabled` is set |
+| `*` | `/api/admin/*` | Internal/ops endpoints |
 
 ---
 
@@ -145,22 +187,25 @@ CodeLens-hub/
 
 Tables (all with RLS):
 - `profiles` — user metadata + `github_token_secret_id` (UUID referencing Supabase Vault; tokens never stored plaintext — US-039)
-- `repositories` — connected repos, status: `pending | indexing | ready | failed`; `sast_disabled_rules TEXT[]` for per-repo SAST rule opt-outs (US-046)
+- `repositories` — connected repos: `status` (`pending | indexing | ready | failed`), `full_name` (`owner/repo`), `default_branch`, `source` (`github | upload`), `auto_sync_enabled`, `sast_disabled_rules TEXT[]` for per-repo SAST rule opt-outs (US-046), `webhook_secret`
 - `graph_nodes` — files with metrics: `line_count`, `complexity_score` (true cyclomatic via Tree-sitter), `incoming_count`, `outgoing_count`, `content_hash`, `node_classification` (`source | sink | both | null` — US-047)
-- `graph_edges` — dependency edges (`from_path → to_path`)
+- `graph_edges` — dependency edges (`from_path → to_path`); `symbols TEXT[]` carries per-importer symbol list (US-064)
 - `code_chunks` — chunked source with 1536-dim pgvector embeddings (HNSW index m=16, ef_construction=64)
-- `analysis_issues` — issue types: `circular_dependency | god_file | dead_code | high_coupling | hardcoded_secret | insecure_pattern | vulnerable_dependency | missing_auth`
+- `file_contents` — full file bodies keyed by `(repo_id, file_path)`; backs AI review retrieval (US-043) and `read_file` tool calls
+- `analysis_issues` — issue types: `circular_dependency | god_file | dead_code | high_coupling | hardcoded_secret | insecure_pattern | vulnerable_dependency | missing_auth | refactoring_candidate`
 - `issue_suppressions` — per-instance suppression: `{ repo_id, file_path, rule_id, line_number, created_by, created_at }` — used by secrets (US-044) and missing_auth (US-049)
 - `vulnerability_cache` — OSV.dev results per `(ecosystem, name, version)` with 24 h TTL (US-045)
 - `dependency_manifests` — per-package SCA results for the Dependencies tab; cleared on re-index (US-045)
-- `security_audits` — whole-repo AI audit reports: `{ id, user_id, repo_id, findings_json, created_at }` (US-048)
+- `security_audits` — whole-repo AI audit reports: `{ id, user_id, repo_id, findings_json, status, created_at }` (US-048); `status` supports `partial` when the daily budget runs out mid-audit
 - `api_usage` — per-user token usage log (audit/debug; truncated monthly — see Maintenance)
 - `api_usage_daily` — `(user_id, usage_date)` rollup maintained by an `AFTER INSERT` trigger on `api_usage`; read by every budget check so the rolling-24 h scan never grows
-- `issue_proposals` — AI fix proposals for `analysis_issues` (US-063); status `pending | accepted | dismissed | stale`. Re-index sets `stale` on any proposal whose underlying issue is being deleted
+- `issue_proposals` — AI fix proposals for `analysis_issues` (US-063); status `pending | applied | discarded | stale`; carries `proposal_json` (`{ summary, rationale, changes[], risks }`), `prompt_tokens`, `completion_tokens`, plus `branch_name` + `pr_url` populated after US-066 Apply via PR. Re-index marks proposals `stale` when their underlying file changes
 - `embedding_cache` — global, content-hash-keyed OpenAI embedding cache; rows shared across repos and accessed only via `service_role`. `last_used_at` drives quarterly eviction
-- `graph_edges.symbols TEXT[]` — per-importer symbol list (US-064); empty array on edges written before the column existed
+- `duplication_candidates` — output of the cosine-similarity clustering pass over `code_chunks`; rendered as the "Duplication" section in IssuesPanel and as the source for `POST /api/review/:id/duplication-refactor`
+- `tours` — AI-authored code tours (US-060, US-061): ordered steps with file/line anchors and prose; supports forking with a `forked_from` lineage column used by the share-impact endpoint
+- `teams`, `team_members`, `team_repositories` — team-based repo sharing; access checks centralised in the `can_access_repo(repo_id, user_id)` Postgres RPC
 
-**Schema migration:** `scripts/schema.sql` is idempotent and safe to re-run. Apply via Supabase SQL Editor. The `scripts/us048_security_audits.sql` file creates the `security_audits` table separately.
+**Schema migration:** `scripts/schema.sql` is idempotent and safe to re-run. Apply via Supabase SQL Editor. Auxiliary migrations applied separately on top: `us048_security_audits.sql`, `us051_arch_diff.sql`, `us063_proposals.sql`, `perf_reindex_migration.sql`.
 
 **Indexer-side RPCs** (also in `scripts/schema.sql`):
 - `prepare_repo_reindex(repo_id, unchanged_paths, changed_or_deleted_paths, preserve_churn)` — single PL/pgSQL call that stale-marks pending proposals, deletes non-preservable issues (preserves `hardcoded_secret` / `insecure_pattern` / `missing_auth` whose `file_paths` are entirely in `unchanged_paths`), wipes derived tables, and partial-purges nodes/chunks/file_contents for changed-or-deleted files
@@ -178,8 +223,9 @@ VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_API_URL, VITE_API_PROXY_TARGET
 GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_CALLBACK_URL
 OPENAI_API_KEY        # for text-embedding-3-small
 GROQ_API_KEY          # for RAG LLM responses
-ANTHROPIC_API_KEY     # for AI code review + security audit (US-048)
+ANTHROPIC_API_KEY     # for AI code review + security audit + refactor proposals (US-048, US-064)
 NODE_ENV, PORT
+FRONTEND_URL          # base URL used in CORS + as the deep-link host in Apply-via-PR PR bodies (US-066)
 MAX_DAILY_TOKENS_PER_USER   # optional, default 500000 (US-042)
 
 # Performance / observability knobs (all optional)
@@ -320,6 +366,93 @@ GitHub tokens stored encrypted in Supabase Vault — never plaintext.
 
 ---
 
+## AI Refactor Proposals (US-063 – US-066)
+
+A one-click "Propose fix" path on every issue card. The model receives the issue, the file, and structural context relevant to the issue type, then emits a structured proposal containing both unified diffs (for display) and full file contents (for application). The user can apply the proposal as a draft GitHub PR.
+
+**Schema (US-063):** `issue_proposals` — see Database Schema above.
+
+**Generation (US-064)** — `backend/src/controllers/reviewController.js`:
+- `POST /api/review/:repoId/issues/:issueId/proposals` (SSE, `requireAuth` + `aiRateLimit`); optional `?regenerate=true` skips the per-issue cache.
+- Per-issue-type structural context bundles:
+  - `god_file` → file + per-importer symbol breakdown (uses `graph_edges.symbols`)
+  - `circular_dependency` → all files in the cycle + interconnecting edges
+  - `high_coupling` → file + top-5 neighbours with aggregated symbol use
+  - `dead_code` → file + zero-incoming-edges confirmation
+  - `missing_auth` → route file + existing auth patterns visible nearby
+  - `hardcoded_secret` → ±10 lines around the secret + `.env.example` if present
+  - `vulnerable_dependency` → manifest + safe-version target
+- Structured output: `{ summary, rationale, changes: [{ file_path, action: 'create'|'modify'|'delete', diff, full_content }], risks }`
+- SSE events: `summary_delta`, `rationale_delta`, `change`, `risk`, `done` (carries `prompt_tokens` + `completion_tokens`), `error`
+- `normalizeProposal` validates that every `create` / `modify` change has non-empty `full_content`; missing contents are surfaced as `risks` and block Apply via PR
+
+**Review panel (US-065)** — `frontend/src/components/ProposalPanel.jsx`:
+- Slide-in panel with `Summary`, `Rationale`, per-file `Changes` (unified-diff renderer via `react-syntax-highlighter` with green/red/dimmed line classes), and `Risks`.
+- Stale banner with a one-click Regenerate.
+- Action row: **Discard** (PATCH), **Regenerate** (`?regenerate=true`), **Copy diff**, **Apply via PR**. Token-cost line in the header.
+
+**Apply via PR (US-066)** — single-commit Git Data API flow:
+- `POST /api/review/:repoId/proposals/:proposalId/apply`
+- Pulls the user's PAT via `backend/src/lib/githubAuth.js::getGithubTokenForUser` (Supabase Vault).
+- Resolves `default_branch` → `getRef` → `getCommit` → for each change `createBlob` (or `sha: null` for delete) → `createTree` (with `base_tree`) → `createCommit` → `createRef refs/heads/codelens/refactor/<id-prefix>-<slug>` → `pulls.create({ draft: true })`.
+- Slug: `<issue_type>-<basename(file)>`, lowercased, `[^a-z0-9]+ → '-'`, truncated to 40 chars.
+- PR body embeds the rationale, risks, and a deep link back to the CodeLens issue (`FRONTEND_URL`).
+- Idempotent: if `status='applied'` and `pr_url` is set, returns existing values without retrying GitHub. If the branch already exists on GitHub, the endpoint reuses the open PR or fast-forwards the ref.
+- Error mapping (no raw GitHub error text): 401 (token revoked), 403 (no write access), 404 (file disappeared), 422 (branch / encoding), 5xx / 429 → 502 "temporarily unavailable", missing `full_content` → 422 "regenerate it".
+- On success: `withSupabaseRetry`-wrapped update sets `status='applied'`, `branch_name`, `pr_url`.
+
+**IssueCard apply badge (US-066):** `IssuesPanel.jsx` fetches `GET /api/review/:repoId/proposals/summary` on mount → latest proposal per issue. Cards whose latest proposal is `applied` render a green "PR opened" badge linking to `pr_url`, and the "Propose fix" button relabels to "Open proposal". `ProposalPanel` calls back via `onApplied` so the badge appears optimistically without a re-fetch.
+
+---
+
+## Duplication Detection
+
+`backend/src/services/duplicationScanner.js` — cosine-similarity clustering over `code_chunks` embeddings, persisted to `duplication_candidates`.
+
+- **`GET /api/repos/:id/duplication`** returns clusters with `{ severity, member_count, total_lines, similarity_min, similarity_max, members[] }`.
+- **`IssuesPanel.jsx` → DuplicationSection / DuplicationDetailModal** — side-by-side picker comparing any two cluster members with syntax-highlighted source.
+- **`POST /api/review/:id/duplication-refactor`** — SSE-streamed Claude proposal for extracting a shared utility across a cluster.
+
+---
+
+## Code Tours (US-060, US-061)
+
+`backend/src/controllers/toursController.js` + `backend/src/services/startHereTourService.js` — AI-authored guided walkthroughs.
+
+- **Generate** (`POST /:repoId/tours/generate`, `aiRateLimit`) — Claude writes an ordered list of steps anchored to specific files/lines with prose.
+- **List / Update / Delete** — tours persist per `(user_id, repo_id)`.
+- **Fork** (US-061, `POST /:repoId/tours/:tourId/fork`) — branches off another user's tour, tracking lineage in a `forked_from` column.
+- **Share-impact** (US-061, `GET /:repoId/tours/:tourId/share-impact`) — reports forks downstream of a tour so the author understands the blast radius of an edit.
+- **Start Here tour** — auto-generated from repo structure as the first tour suggested to a new user.
+
+---
+
+## Teams (Shared Repos)
+
+`backend/src/controllers/teamController.js` — team-based repo sharing.
+
+- Tables `teams`, `team_members`, `team_repositories` (all RLS-enabled).
+- Routes: `POST /api/teams`, `GET /api/teams`, `POST /api/teams/:teamId/repos`, `GET /api/teams/:teamId/repos`.
+- Access centralised in `can_access_repo(repo_id, user_id)` RPC — returns true if the user owns the repo OR is a member of a team that includes it. Every read/write controller calls this helper before touching repo-scoped data.
+
+---
+
+## Auto-Sync via GitHub Webhooks
+
+`backend/src/routes/webhooks.js` + `backend/src/controllers/webhookController.js`.
+
+- `POST /api/webhooks/github` runs before `express.json()` (mounted via `express.raw({ type: 'application/json' })`) so the HMAC signature validator sees the original request bytes.
+- Each repo has a `webhook_secret` generated via `GET /api/repos/:id/webhook`.
+- On `push` events for repos with `auto_sync_enabled = true`, the backend kicks an incremental re-index; the global Vault-stored PAT is reused for the GitHub fetch.
+
+---
+
+## Per-File AI Chat
+
+`backend/src/controllers/fileChatController.js` — `POST /api/file-chat/:repoId` accepts a file path + a question and streams a Claude response grounded in the file content. Reuses the per-user daily token budget.
+
+---
+
 ## Dependency Vulnerability Scanning (US-045)
 
 OSV.dev SCA during indexing. Supported manifests: `package.json`, `package-lock.json`, `yarn.lock`, `requirements.txt`, `Pipfile.lock`, `go.mod`, `Cargo.lock`, `Gemfile.lock`, `*.csproj`. Results cached 24 h. Best-effort — never blocks indexing.
@@ -349,6 +482,9 @@ CREATE INDEX ON code_chunks USING hnsw (embedding vector_cosine_ops)
 | `god_file` | God Files | FileWarning |
 | `high_coupling` | High Coupling | Link2 |
 | `dead_code` | Dead Code | FileX |
+| `refactoring_candidate` | Refactoring Candidates | TrendingUp |
+
+Each card also exposes a **"Propose fix"** action (US-064) and, once a proposal has been applied via PR, a green **"PR opened"** badge linking to the draft PR (US-066). Duplicate-code clusters render below in a separate section.
 
 Suppression actions:
 - `hardcoded_secret` → "Mark as false positive" (requires `Rule ID:` + `line N` in description)
@@ -383,6 +519,7 @@ ESLint in both `frontend/` and `backend/`. No Prettier, no commit hooks. Run `np
 - **Shared backend helpers** (`backend/src/lib/`):
   - `dbHelpers.js` — `SAFE_FETCH_CEILING` + `warnIfCeilingHit` for bulk `.range(0, SAFE_FETCH_CEILING - 1)` selects; `withSupabaseRetry(fn, { tries, baseMs, label })` for critical writes (retries on 5xx / 429 / network errors only)
   - `sseAbort.js` — `bindRequestAbort(req)` returns `{ signal, cleanup, isAborted }`; pass `signal` to any upstream SDK call and call `cleanup()` in `finally`
+  - `githubAuth.js` — `getGithubTokenForUser(userId)` resolves the user's `github_token_secret_id` from `profiles` and reads the plaintext PAT via the `get_github_token_secret` Vault RPC (US-039). Used by `repoController` for re-indexing and by `reviewController` for Apply via PR (US-066)
 - **Observability (Phase 0):** every request runs inside an `AsyncLocalStorage` ledger (`backend/src/observability/requestStore.js`); the Supabase client's custom fetch records `(method, table, durationMs, status)` per round-trip. Requests slower than `SLOW_REQUEST_MS` log a one-line summary with the top 3 DB calls. Set `LOG_REQUEST_TIMING=true` to log every request
 
 ---
@@ -391,7 +528,7 @@ ESLint in both `frontend/` and `backend/`. No Prettier, no commit hooks. Run `np
 
 - Tree-sitter native modules require build tools (python3, make, g++) — `backend/Dockerfile.dev` handles this
 - `docker-compose.yml` runs `npm install` on every container start for `backend` and `frontend` so new dependencies in `package.json` are picked up without a manual rebuild — the anonymous `/app/node_modules` volume otherwise persists across `docker compose build` and silently hides them
-- Apply `scripts/schema.sql` + `scripts/us048_security_audits.sql` via Supabase SQL Editor before first run
+- Apply `scripts/schema.sql` then the auxiliary migrations (`us048_security_audits.sql`, `us051_arch_diff.sql`, `us063_proposals.sql`, `perf_reindex_migration.sql`) via the Supabase SQL Editor before first run
 - Frontend Vite proxy (`/api/*` → port 3001) configured in `frontend/vite.config.js`
 - Attack surface toggle forces `clusteringEnabled = false` — clustering uses cluster-level edge IDs incompatible with individual-node path IDs
 - `issue_suppressions` is rule-agnostic: `rule_id` is a free-text string, `line_number: 0` is the convention for file-level suppressions (used by `missing_auth`)

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -2,11 +2,15 @@
  * Review controller — AI Code Review (US-026) + Security Audit Mode (US-048)
  */
 
+const path              = require('path');
+const { Octokit }       = require('octokit');
 const { OpenAI }        = require('openai');
 const Anthropic         = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage }   = require('../services/usageTracker');
 const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
+const { withSupabaseRetry } = require('../lib/dbHelpers');
+const { getGithubTokenForUser } = require('../lib/githubAuth');
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -804,7 +808,7 @@ async function fetchAnalysisIssue(repoId, issueId) {
 async function fetchCachedPendingProposal(issueId, userId) {
   const { data } = await supabaseAdmin
     .from('issue_proposals')
-    .select('id, proposal_json, created_at')
+    .select('id, proposal_json, prompt_tokens, completion_tokens, created_at')
     .eq('issue_id', issueId)
     .eq('user_id', userId)
     .eq('status', 'pending')
@@ -1081,11 +1085,23 @@ function normalizeChange(raw) {
 
 function normalizeProposal(parsed) {
   if (!parsed || typeof parsed !== 'object') return null;
+  const changes = Array.isArray(parsed.changes) ? parsed.changes.map(normalizeChange).filter(Boolean) : [];
+  const risks   = Array.isArray(parsed.risks) ? parsed.risks.map((r) => String(r).trim()).filter(Boolean) : [];
+
+  // The apply-as-PR endpoint commits change.full_content verbatim, so any
+  // create/modify missing it would silently produce an empty file. Surface
+  // those as risks here rather than letting the user discover them on Apply.
+  for (const change of changes) {
+    if ((change.action === 'create' || change.action === 'modify') && !change.full_content.trim()) {
+      risks.push(`Proposed ${change.action} of ${change.file_path} is missing file contents — cannot be applied as a PR. Regenerate the proposal.`);
+    }
+  }
+
   return {
     summary:   String(parsed.summary || '').trim(),
     rationale: String(parsed.rationale || '').trim(),
-    changes:   Array.isArray(parsed.changes) ? parsed.changes.map(normalizeChange).filter(Boolean) : [],
-    risks:     Array.isArray(parsed.risks) ? parsed.risks.map((r) => String(r).trim()).filter(Boolean) : [],
+    changes,
+    risks,
   };
 }
 
@@ -1154,7 +1170,13 @@ const generateProposal = async (req, res) => {
       const cached = await fetchCachedPendingProposal(issueId, req.user.id);
       if (cached?.proposal_json) {
         emitProposalEvents(send, cached.proposal_json);
-        send({ type: 'done', proposal_id: cached.id, cached: true });
+        send({
+          type: 'done',
+          proposal_id: cached.id,
+          cached: true,
+          prompt_tokens: cached.prompt_tokens || 0,
+          completion_tokens: cached.completion_tokens || 0,
+        });
         return res.end();
       }
     }
@@ -1246,7 +1268,12 @@ const generateProposal = async (req, res) => {
       return res.end();
     }
 
-    send({ type: 'done', proposal_id: inserted.id });
+    send({
+      type: 'done',
+      proposal_id: inserted.id,
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+    });
     res.end();
   } catch (err) {
     console.error('[proposals] Unhandled error:', err);
@@ -1257,6 +1284,290 @@ const generateProposal = async (req, res) => {
       res.end();
     }
   }
+};
+
+// ── US-066: Apply proposal as a GitHub draft PR ─────────────────────────────
+
+function buildBranchSlug(issueType, filePath) {
+  const base = `${issueType || 'refactor'}-${path.basename(filePath || 'file')}`;
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40) || 'refactor';
+}
+
+function mapGithubError(err) {
+  const status = err?.status || err?.response?.status;
+  if (status === 401) return { http: 401, message: 'Your GitHub token has expired. Reconnect GitHub from Settings.' };
+  if (status === 403) return { http: 403, message: "You don't have write access to this repository." };
+  if (status === 404) return { http: 404, message: 'The repository or one of the files in this proposal no longer exists on GitHub.' };
+  if (status === 422) return { http: 422, message: 'GitHub rejected the changes — likely a path/encoding issue.' };
+  if (status === 429 || (typeof status === 'number' && status >= 500 && status < 600)) {
+    return { http: 502, message: 'GitHub is temporarily unavailable. Try again in a minute.' };
+  }
+  return { http: 500, message: 'Failed to open the pull request.' };
+}
+
+function buildPrBody({ rationale, risks, repoId, issueId, proposalId, issueType }) {
+  const frontendUrl = (process.env.FRONTEND_URL || '').replace(/\/+$/, '');
+  const issueLink = frontendUrl
+    ? `${frontendUrl}/repos/${repoId}/issues?issue=${issueId}&proposal=${proposalId}`
+    : `/repos/${repoId}/issues?issue=${issueId}&proposal=${proposalId}`;
+
+  const sections = [];
+  if (rationale) sections.push(`## Why\n${rationale}`);
+  if (risks && risks.length) {
+    sections.push(`## Risks\n${risks.map((r) => `- ${r}`).join('\n')}`);
+  }
+  sections.push(`## Source\nOpened from a [CodeLens proposal](${issueLink}) for issue type \`${issueType || 'unknown'}\`.`);
+  return sections.join('\n\n');
+}
+
+async function findExistingOpenPr(octokit, owner, repo, branchName) {
+  try {
+    const { data } = await octokit.rest.pulls.list({
+      owner,
+      repo,
+      head: `${owner}:${branchName}`,
+      state: 'open',
+      per_page: 1,
+    });
+    return data && data[0] ? data[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+const applyProposalAsPr = async (req, res) => {
+  const { repoId, proposalId } = req.params;
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  // Load the proposal joined to its issue so we know the issue type / first file.
+  const { data: proposal, error: propErr } = await supabaseAdmin
+    .from('issue_proposals')
+    .select('id, issue_id, user_id, status, proposal_json, branch_name, pr_url, analysis_issues!inner(id, type, repo_id, file_paths)')
+    .eq('id', proposalId)
+    .eq('user_id', req.user.id)
+    .maybeSingle();
+
+  if (propErr) {
+    console.error('[proposals.apply] Failed to load proposal:', propErr);
+    return res.status(500).json({ error: 'Failed to load proposal' });
+  }
+  if (!proposal) return res.status(404).json({ error: 'Proposal not found' });
+  if (proposal.analysis_issues.repo_id !== repoId) {
+    return res.status(404).json({ error: 'Proposal not found' });
+  }
+  if (proposal.status === 'discarded' || proposal.status === 'stale') {
+    return res.status(409).json({ error: `Cannot apply a ${proposal.status} proposal — regenerate it first.` });
+  }
+
+  // Idempotent short-circuit.
+  if (proposal.status === 'applied' && proposal.pr_url && proposal.branch_name) {
+    return res.json({ branch_name: proposal.branch_name, pr_url: proposal.pr_url, reused: true });
+  }
+
+  const payload = proposal.proposal_json || {};
+  const changes = Array.isArray(payload.changes) ? payload.changes : [];
+  if (changes.length === 0) {
+    return res.status(422).json({ error: 'Proposal has no changes to apply.' });
+  }
+  for (const change of changes) {
+    if ((change.action === 'create' || change.action === 'modify') && !String(change.full_content || '').trim()) {
+      return res.status(422).json({ error: 'This proposal is missing file contents; please regenerate it.' });
+    }
+  }
+
+  const { data: repoRow, error: repoErr } = await supabaseAdmin
+    .from('repositories')
+    .select('id, full_name, default_branch, source')
+    .eq('id', repoId)
+    .single();
+  if (repoErr || !repoRow) return res.status(404).json({ error: 'Repository not found' });
+  if (repoRow.source !== 'github' || !repoRow.full_name || !repoRow.full_name.includes('/')) {
+    return res.status(400).json({ error: 'Only GitHub-connected repositories support Apply via PR.' });
+  }
+
+  const githubToken = await getGithubTokenForUser(req.user.id);
+  if (!githubToken) {
+    return res.status(401).json({ error: 'Your GitHub token has expired. Reconnect GitHub from Settings.' });
+  }
+
+  const [owner, repoName] = repoRow.full_name.split('/');
+  const octokit = new Octokit({ auth: githubToken });
+  const issue = proposal.analysis_issues;
+  const primaryPath = Array.isArray(issue.file_paths) ? issue.file_paths[0] : null;
+  const slug = buildBranchSlug(issue.type, primaryPath);
+  const branchName = `codelens/refactor/${String(proposalId).slice(0, 8)}-${slug}`;
+
+  try {
+    // Resolve default branch — prefer the stored one, fall back to a live lookup.
+    let defaultBranch = repoRow.default_branch;
+    if (!defaultBranch) {
+      const { data: repoMeta } = await octokit.rest.repos.get({ owner, repo: repoName });
+      defaultBranch = repoMeta.default_branch;
+    }
+
+    const { data: baseRef } = await octokit.rest.git.getRef({
+      owner,
+      repo: repoName,
+      ref: `heads/${defaultBranch}`,
+    });
+    const baseSha = baseRef.object.sha;
+
+    const { data: baseCommit } = await octokit.rest.git.getCommit({
+      owner,
+      repo: repoName,
+      commit_sha: baseSha,
+    });
+    const baseTreeSha = baseCommit.tree.sha;
+
+    // Build the new tree: one blob per create/modify, null sha for delete.
+    const treeEntries = [];
+    for (const change of changes) {
+      if (change.action === 'create' || change.action === 'modify') {
+        const { data: blob } = await octokit.rest.git.createBlob({
+          owner,
+          repo: repoName,
+          content: change.full_content,
+          encoding: 'utf-8',
+        });
+        treeEntries.push({ path: change.file_path, mode: '100644', type: 'blob', sha: blob.sha });
+      } else if (change.action === 'delete') {
+        treeEntries.push({ path: change.file_path, mode: '100644', type: 'blob', sha: null });
+      }
+    }
+
+    const { data: newTree } = await octokit.rest.git.createTree({
+      owner,
+      repo: repoName,
+      base_tree: baseTreeSha,
+      tree: treeEntries,
+    });
+
+    const commitMessage = (payload.summary && String(payload.summary).trim()) || `Refactor: ${slug}`;
+    const { data: commit } = await octokit.rest.git.createCommit({
+      owner,
+      repo: repoName,
+      message: commitMessage.slice(0, 4096),
+      tree: newTree.sha,
+      parents: [baseSha],
+    });
+
+    // Create the branch ref, or reuse an existing one (e.g. retry).
+    let branchExists = false;
+    try {
+      await octokit.rest.git.createRef({
+        owner,
+        repo: repoName,
+        ref: `refs/heads/${branchName}`,
+        sha: commit.sha,
+      });
+    } catch (refErr) {
+      if (refErr?.status === 422) {
+        branchExists = true;
+      } else {
+        throw refErr;
+      }
+    }
+
+    let prUrl;
+    if (branchExists) {
+      const existing = await findExistingOpenPr(octokit, owner, repoName, branchName);
+      if (existing) {
+        prUrl = existing.html_url;
+      } else {
+        // Our branch, our commits — fast-forward it to the new commit and open a PR.
+        await octokit.rest.git.updateRef({
+          owner,
+          repo: repoName,
+          ref: `heads/${branchName}`,
+          sha: commit.sha,
+          force: true,
+        });
+      }
+    }
+
+    if (!prUrl) {
+      const title = `Refactor: ${(payload.summary || slug).trim()}`.slice(0, 72);
+      const body = buildPrBody({
+        rationale: payload.rationale,
+        risks: payload.risks,
+        repoId,
+        issueId: issue.id,
+        proposalId,
+        issueType: issue.type,
+      });
+      const { data: pr } = await octokit.rest.pulls.create({
+        owner,
+        repo: repoName,
+        draft: true,
+        head: branchName,
+        base: defaultBranch,
+        title,
+        body,
+      });
+      prUrl = pr.html_url;
+    }
+
+    const persistResult = await withSupabaseRetry(
+      () => supabaseAdmin
+        .from('issue_proposals')
+        .update({ status: 'applied', branch_name: branchName, pr_url: prUrl, updated_at: new Date().toISOString() })
+        .eq('id', proposalId)
+        .eq('user_id', req.user.id),
+      { label: 'issue_proposals.update_applied' },
+    );
+    if (persistResult?.error) {
+      console.warn('[proposals.apply] PR opened but DB write failed:', persistResult.error.message);
+    }
+
+    return res.json({ branch_name: branchName, pr_url: prUrl, reused: false });
+  } catch (err) {
+    const { http, message } = mapGithubError(err);
+    console.error('[proposals.apply] Failed:', err?.status, err?.message);
+    return res.status(http).json({ error: message });
+  }
+};
+
+// ── Lightweight summary for IssueCard badges ────────────────────────────────
+
+const listProposalSummaries = async (req, res) => {
+  const { repoId } = req.params;
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  // Newest row per issue. We fetch all of the user's proposals on issues that
+  // belong to this repo (inner-join filter), then pick the latest per issue_id.
+  const { data, error } = await supabaseAdmin
+    .from('issue_proposals')
+    .select('id, issue_id, status, pr_url, created_at, analysis_issues!inner(repo_id)')
+    .eq('user_id', req.user.id)
+    .eq('analysis_issues.repo_id', repoId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('[proposals.summary] Failed to load summaries:', error);
+    return res.status(500).json({ error: 'Failed to load proposal summaries' });
+  }
+
+  const latestPerIssue = new Map();
+  for (const row of data || []) {
+    if (!latestPerIssue.has(row.issue_id)) {
+      latestPerIssue.set(row.issue_id, {
+        id: row.id,
+        issue_id: row.issue_id,
+        status: row.status,
+        pr_url: row.pr_url || null,
+      });
+    }
+  }
+
+  res.json({ proposals: [...latestPerIssue.values()] });
 };
 
 const updateProposalStatus = async (req, res) => {
@@ -1299,6 +1610,8 @@ module.exports = {
   duplicationRefactor,
   generateProposal,
   updateProposalStatus,
+  applyProposalAsPr,
+  listProposalSummaries,
   _private: {
     parseFindingsFromText,
     rerankSecurityChunks,

--- a/backend/src/lib/githubAuth.js
+++ b/backend/src/lib/githubAuth.js
@@ -1,0 +1,29 @@
+/**
+ * GitHub token helper — pulls the user's GitHub PAT out of Supabase Vault
+ * via the get_github_token_secret RPC (US-039). Centralised so callers
+ * outside repoController.js don't have to know about the secret_id indirection.
+ */
+
+const { supabaseAdmin } = require('../db/supabase');
+
+async function getGithubTokenForUser(userId) {
+  if (!userId) return null;
+
+  const { data: profile, error: profileErr } = await supabaseAdmin
+    .from('profiles')
+    .select('github_token_secret_id')
+    .eq('id', userId)
+    .single();
+
+  if (profileErr || !profile?.github_token_secret_id) return null;
+
+  const { data: tokenData, error: tokenErr } = await supabaseAdmin.rpc(
+    'get_github_token_secret',
+    { secret_id: profile.github_token_secret_id },
+  );
+
+  if (tokenErr || !tokenData) return null;
+  return tokenData;
+}
+
+module.exports = { getGithubTokenForUser };

--- a/backend/src/routes/review.js
+++ b/backend/src/routes/review.js
@@ -14,6 +14,10 @@ router.post('/:repoId/duplication-refactor', requireAuth, aiRateLimit, reviewCon
 router.post('/:repoId/issues/:issueId/proposals', requireAuth, aiRateLimit, reviewController.generateProposal);
 router.patch('/:repoId/issues/:issueId/proposals/:proposalId', requireAuth, reviewController.updateProposalStatus);
 
+// US-066: apply a generated proposal as a GitHub draft PR + summary list for IssueCard badges.
+router.get('/:repoId/proposals/summary', requireAuth, reviewController.listProposalSummaries);
+router.post('/:repoId/proposals/:proposalId/apply', requireAuth, reviewController.applyProposalAsPr);
+
 // POST /api/review/:repoId   body: { snippet, context?, mode?, filePath? }
 router.post('/:repoId', requireAuth, aiRateLimit, reviewController.review);
 

--- a/features.md
+++ b/features.md
@@ -1,0 +1,282 @@
+# CodeLens — Feature Inventory
+
+A snapshot of everything CodeLens does today. Written for planning conversations about future epics. Each section names the feature, what it does for the user, how it's implemented (briefly), and the user story (US-#) where applicable.
+
+---
+
+## 1. Repo Connection & Indexing
+
+**What it does:** Onboards a codebase so every other feature has data to work with.
+
+- **GitHub connect** — OAuth-based; the user's token is stored encrypted in Supabase Vault (US-039). Tokens are never logged in plaintext (global `console` redactor strips `ghp_/gho_/ghu_/...` strings).
+- **ZIP upload** — for private/local repos with no GitHub connection.
+- **Re-indexing** — manual via the UI, or automatic on push (see Webhooks).
+- **Incremental indexing** — files whose `content_hash` is unchanged skip parse + scan; their DB state is preserved across re-indexes.
+- **Indexing status** — pending → indexing → ready → failed, surfaced live in the dashboard.
+
+Pipeline (per indexing run):
+1. Repo tree fetched (Octokit) or ZIP extracted.
+2. Tree-sitter AST parsing in a Piscina worker pool (multi-core); cyclomatic complexity computed (US-040).
+3. Per-file scanners: secrets, SAST, auth coverage, attack-surface classification.
+4. Dependency graph + metrics + architectural issues.
+5. SCA: manifest files → OSV.dev → vulnerability cache (US-045).
+6. Semantic chunking + 1536-dim embeddings (text-embedding-3-small), cache-keyed by content hash.
+
+---
+
+## 2. Dependency Graph (D3 Force Layout)
+
+**What it does:** Interactive visualisation of the whole repo's structural dependency graph.
+
+- **Force-directed layout** — D3.js v7, custom simulation in `useGraphSimulation.js`.
+- **Clustering** — collapses dense subgraphs by directory/feature; toggleable.
+- **Node sizing/coloring** — by metrics (incoming count, complexity, classification).
+- **Selection + neighbourhood highlighting** — click a file, see direct dependents and dependencies.
+- **Impact / blast-radius mode** (US-021) — BFS from a node showing transitive dependents.
+- **Attack-surface overlay** (US-047) — sources red, sinks orange, both yellow, neutrals dimmed; animated source→sink paths.
+
+---
+
+## 3. Architectural Issue Detection
+
+Deterministic, runs every index. Surfaced in the Issues tab.
+
+| Issue type | What it flags | Heuristic |
+|---|---|---|
+| `circular_dependency` | Import cycles | DFS over `graph_edges` |
+| `god_file` | Files doing too much | complexity > 30 OR 500+ lines + high incoming OR incoming > 30% of nodes |
+| `high_coupling` | Files with too many neighbours | `outgoing_count > 15` |
+| `dead_code` | Probably-unused files | Zero incoming edges + filename heuristics |
+| `refactoring_candidate` | (group present in UI) | (see code) |
+
+---
+
+## 4. Security Suite
+
+### 4.1 Secret Scanning (US-044)
+- Regex rules in `secret-rules.json` (AWS, GitHub, OpenAI/Anthropic, Stripe, Google, Slack, JWTs, RSA/SSH private blocks).
+- High-entropy catch-all on `*_key / *_secret / *_token / *_password` variables (Shannon > 4.5, ≥ 20 chars).
+- Per-instance suppression via "Mark as false positive" → `issue_suppressions`.
+
+### 4.2 SAST Pattern Scanning (US-046)
+- AST-query rules per language (`backend/src/sast/rules/<lang>.json`).
+- Targets: `eval()`, `dangerouslySetInnerHTML`, `child_process.exec` with template literals, `pickle.loads`, `subprocess(shell=True)`, weak crypto (MD5/SHA1/DES), SQL string concat, etc.
+- Per-repo opt-out: `repositories.sast_disabled_rules TEXT[]` ("Disable this rule" in UI).
+
+### 4.3 Dependency Vulnerability Scanning / SCA (US-045)
+- Manifests: `package.json`, `package-lock.json`, `yarn.lock`, `requirements.txt`, `Pipfile.lock`, `go.mod`, `Cargo.lock`, `Gemfile.lock`, `*.csproj`.
+- OSV.dev lookups, 24h cache.
+- **Dependencies tab** in the UI — vulnerable packages, severities, fix versions.
+
+### 4.4 Auth Coverage Check (US-049)
+- Two-layer heuristic: in-file markers (`requireAuth`, `passport.authenticate`, `[Authorize]`, `@login_required`, `@UseGuards`, Devise/Sorcery patterns) + auth-related import paths.
+- Public allow-list (`/health`, `/login`, `/.well-known/*`, etc.) avoids false positives.
+- Suppressed via "Mark as intentionally public".
+
+### 4.5 Attack-Surface Mapping (US-047)
+- Pure-regex source/sink classifier per file → `graph_nodes.node_classification`.
+- **Sources**: HTTP routes (Express/Flask/FastAPI/Spring/ASP.NET/actix/axum/Rails), CLI args, stdin.
+- **Sinks**: SQL exec, shell/process exec, FS writes, deserialisation (pickle, yaml.load, ObjectInputStream), dynamic outbound HTTP.
+- Client-side DFS finds source→sink reachability paths (capped 50 paths, depth 20).
+- Drillable `AttackSurfacePanel` with per-source path counts.
+
+### 4.6 AI Security Audit Mode (US-048)
+- **Single-file audit** — Claude-Sonnet-driven, security-focused system prompt, 12 chunks re-ranked by security-keyword frequency, structured findings (`severity, category, line_reference, explanation, suggested_fix, confidence`).
+- **Whole-repo audit** — top 20 files by `incoming_count + complexity_score`, sequential per-file with budget checks, persisted to `security_audits` table; supports `partial` status when budget runs out.
+- Cross-links AI findings to deterministic `analysis_issues` rows on the same file.
+
+---
+
+## 5. AI Code Review (US-026)
+
+- **Single-file review** via Claude Sonnet 4 (`claude-sonnet-4-20250514`).
+- **Focus presets**: Performance, Bug Hunt, Architecture (the Security preset was replaced by Security Audit mode in US-048).
+- **Modes**: General | Security Audit (segmented control).
+- SSE streaming with abort on tab close.
+- Counts against the per-user daily token budget.
+
+---
+
+## 6. AI Refactor Proposals (US-063 – US-066)
+
+The "Propose fix" path on every issue card.
+
+- **Generation** (US-064): one-click for any `analysis_issues` row. Per-issue-type structural context:
+  - `god_file` → file + per-importer symbol breakdown (uses `graph_edges.symbols`)
+  - `circular_dependency` → all cycle files + interconnecting edges
+  - `high_coupling` → file + top-5 neighbours with symbol aggregation
+  - `dead_code` → file + incoming-edge confirmation
+  - `missing_auth` → route file + existing auth patterns
+  - `hardcoded_secret` → ±10 lines around secret + `.env.example` if present
+  - `vulnerable_dependency` → manifest + safe version proposal
+- **Structured output**: `{ summary, rationale, changes: [{file_path, action, diff, full_content}], risks }`.
+- **Streaming SSE**: `summary_delta`, `rationale_delta`, `change`, `risk`, `done`.
+- **Caching** — most-recent pending proposal returned without re-calling Claude; `?regenerate=true` bypasses.
+- **Persistence** — `issue_proposals` table; stale-marked on re-index when underlying file's content_hash changes.
+- **Review panel** (US-065) — slide-in panel with summary, rationale, per-file unified-diff renderer (added/removed/context coloring), risks list. Stale-banner with one-click regenerate. Token cost displayed.
+- **Apply via PR** (US-066) — opens a GitHub draft PR in a single commit via the Git Data API (createBlob → createTree → createCommit → createRef → pulls.create). PR body embeds rationale, risks, and a deep link back to the CodeLens issue. Idempotent on retry. Per-issue "PR opened" badge on the IssueCard after success.
+
+---
+
+## 7. RAG-Powered Code Search
+
+- **Embedding model**: OpenAI `text-embedding-3-small` (1536-dim), HNSW index `m=16 ef_construction=64` (US-041).
+- **LLM**: Groq for fast RAG response synthesis (separate from Anthropic for review/audit).
+- **Endpoints**: `/api/search/*`, dedicated Search page in the frontend.
+
+---
+
+## 8. File-Level Features
+
+- **File chat** (`POST /api/file-chat/:repoId`) — AI conversation grounded in a single file.
+- **File viewer** (US-037) — syntax-highlighted with line anchors; linked to from issues, paths, AI references.
+- **File contents storage** (US-043) — `file_contents` table backs AI review retrieval; available to the agent epic when it ships.
+- **Blast-radius / impact panel** — direct + transitive dependents for any file.
+- **Per-file metrics** — line count, true cyclomatic complexity (US-040), incoming/outgoing counts.
+
+---
+
+## 9. Duplication Detection
+
+- Cosine-similarity clustering over `code_chunks` embeddings → `duplicationScanner`.
+- **Duplication section** in the Issues panel with severity, member count, total duplicated lines, similarity range.
+- **DuplicationDetailModal** — side-by-side picker comparing any two cluster members.
+- **AI shared-utility refactor** — Claude-driven extraction proposal (SSE-streamed) for a selected cluster.
+
+---
+
+## 10. Code Tours (US-060, US-061)
+
+- **Generate** — AI-authored guided walkthroughs (`POST /:repoId/tours/generate`, behind `aiRateLimit`).
+- **List / Update / Delete** — tours persist per user/repo.
+- **Fork** (US-061) — branch off someone else's tour to create your own variant; `share-impact` endpoint reports downstream tours that would be affected by editing the source.
+
+---
+
+## 11. Teams (Shared Repos)
+
+- **Create / list teams** (`/api/teams`).
+- **Add repos to a team** so other team members can access them.
+- **Access check** centralised in the `can_access_repo` Postgres RPC — checks ownership OR team membership.
+
+---
+
+## 12. Webhooks (Auto-Sync)
+
+- **GitHub push webhook** (`POST /api/webhooks/github`) — runs before `express.json()` so the signature validator sees raw bytes.
+- **`auto_sync_enabled`** column on `repositories` — re-indexes the repo on each push event.
+- Per-repo webhook secret generated via `GET /api/repos/:repoId/webhook`.
+
+---
+
+## 13. Branch / Diff Viewing
+
+- `GET /api/repos/:repoId/branches` — list branches.
+- `GET /api/repos/:repoId/diff` — structural diff between two refs (`diffService` computes node/edge changes, not unified file diffs).
+
+---
+
+## 14. Churn Analysis
+
+- `GET /api/repos/:repoId/churn` — per-file churn from git history. Surfaced in the metrics view alongside complexity.
+- Used by the "what's been changing a lot" heuristic.
+
+---
+
+## 15. Usage & Budget (US-042)
+
+- **Per-user daily token budget** (default 500k, env `MAX_DAILY_TOKENS_PER_USER`).
+- **`api_usage_daily` rollup** — maintained by an `AFTER INSERT` trigger on `api_usage`; budget checks are O(1).
+- `GET /api/usage/today` — exposes today's usage for the UI.
+- `aiRateLimit` middleware returns 429 with a clear message when exhausted.
+
+---
+
+## 16. Observability & Performance
+
+- **AsyncLocalStorage request ledger** (Phase 0) — every request records per-Supabase-call `(method, table, durationMs, status)`. Requests slower than `SLOW_REQUEST_MS` log a one-line summary with the top 3 DB calls.
+- **Parser worker pool** (Phase 5.1) — Piscina-based, default `min(cpus, 8)` workers.
+- **HNSW vector index** (US-041) — fast semantic search.
+- **Embedding cache** — content-hash-keyed, shared across repos; trims OpenAI cost.
+- **Supabase retry helper** — `withSupabaseRetry` for critical writes; bulk-select ceiling (`SAFE_FETCH_CEILING`) with truncation warnings.
+- **Maintenance scripts**: monthly truncate of raw `api_usage`, quarterly eviction of stale `embedding_cache` rows.
+
+---
+
+## 17. Issue Suppressions
+
+A unified suppression mechanism reusable by any rule-based scanner:
+- `issue_suppressions` table — `(repo_id, file_path, rule_id, line_number, created_by, created_at)`.
+- Per-rule actions in `IssuesPanel`:
+  - Secrets → "Mark as false positive".
+  - Missing auth → "Mark as intentionally public" (file-level, `line_number: 0`).
+  - Insecure pattern → "Disable this rule" (writes to `repositories.sast_disabled_rules`).
+- Suppressions persist across re-indexes.
+
+---
+
+## 18. Frontend Pages & Navigation
+
+| Page | Purpose |
+|---|---|
+| Login | GitHub OAuth |
+| AuthCallback | OAuth handshake |
+| Dashboard | Repo list (own + team-shared) |
+| RepoView | Tabs: Graph · Issues · Metrics · Dependencies · Tours · Review |
+| Search | RAG-powered natural-language search |
+
+---
+
+## 19. Admin
+
+- `routes/admin.js` — internal endpoints (not user-facing; reserved for ops).
+
+---
+
+## Tech Stack (TL;DR)
+
+| Layer | Choice |
+|---|---|
+| Frontend | React 18 · Vite · Tailwind · D3.js v7 · React Router 6 |
+| Backend | Node 20 · Express 4 · Octokit · `@anthropic-ai/sdk` · openai · piscina |
+| DB | Postgres 15 (Supabase) + pgvector (HNSW) |
+| Auth | Supabase Auth + GitHub OAuth |
+| AST | Tree-sitter (JS · TS · TSX · Python · C# · Go · Java · Rust · Ruby) |
+| Models | OpenAI `text-embedding-3-small`, Groq (RAG), Claude Sonnet 4 (review/audit/proposals) |
+
+---
+
+## Currently Open / Planned Epics
+
+From `issues.md`:
+
+- **AI Repo Agent (US-067 – US-071)** — conversational agent over the deterministic analysis as a tool surface (`get_blast_radius`, `list_issues`, `find_paths`, `get_attack_paths`, `propose_fix`, etc.). Tool-use loop with Anthropic, SSE-streamed, persisted trace per turn. Replaces the current Search tab. **Not yet started.**
+
+---
+
+## What Recently Shipped (for context)
+
+The most recent epic completed is **AI Refactor Proposals (US-063–US-066)**:
+- DB schema + stale-detection
+- Per-issue-type structural context generation
+- Streaming review panel with diff renderer
+- GitHub draft-PR creation in one commit via Git Data API
+- Token-cost display, "PR opened" badges on IssueCards, applied-state banner with "View PR"
+
+---
+
+## Notable Gaps / Opportunities
+
+Things that exist as primitives but aren't user-facing yet, or that overlap and could be unified:
+
+- **Code tours + AI proposals** both produce structured AI artefacts but use unrelated UI patterns — could share a "review and apply" surface.
+- **File chat** is per-file; the planned Repo Agent is whole-repo. There's no per-PR / per-diff chat today.
+- **Webhooks** trigger re-indexing but don't yet notify users in-app when the index updates.
+- **Teams** support sharing repos but not per-resource ACLs (e.g. a private security-audit shared with one teammate).
+- **Branch/diff endpoint** computes structural diffs but doesn't yet feed into a "review this PR" workflow.
+- **Tours** can be forked but there's no discovery / marketplace; tours are user-private today.
+- **Dependency upgrades** are flagged via SCA but the "Propose fix" path for `vulnerable_dependency` doesn't yet auto-PR a `package.json` bump alongside lockfile re-generation.
+- **Attack-surface paths** are visualised but no "fix this exposure" workflow exists.
+- **No multi-repo / org-wide view** — every screen scopes to a single repo.
+- **No metrics on AI quality** — proposals can be discarded but there's no aggregate "% applied" / "% discarded" telemetry.
+- **No diff-aware review** — the AI code review is per-snippet, not per-PR; a PR-review epic would dovetail with the existing Octokit + Vault integration.

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -13,7 +13,7 @@ import {
   Package, Lock, ShieldAlert, GitMerge,
   FileWarning, Link2, FileX, Search,
   ChevronDown, ChevronUp, CheckCircle2, AlertTriangle, TrendingUp,
-  Copy, Sparkles,
+  Copy, Sparkles, GitBranch,
 } from './ui/Icons';
 
 // Phase 4.1: virtualize groups above this size. Below the threshold, virtuoso's
@@ -44,7 +44,7 @@ function getBadgeStyles(severity) {
 }
 
 // ── IssueGroup ────────────────────────────────────────────────────────────────
-const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled, scrollParent }) {
+const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled, scrollParent, proposalsByIssue }) {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
@@ -95,6 +95,7 @@ const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap
                   onDisableRule={onDisableRule}
                   onProposeFix={onProposeFix}
                   actionsDisabled={actionsDisabled}
+                  appliedProposal={proposalsByIssue?.[issue.id]}
                 />
               </div>
             )}
@@ -114,6 +115,7 @@ const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap
                 onDisableRule={onDisableRule}
                 onProposeFix={onProposeFix}
                 actionsDisabled={actionsDisabled}
+                appliedProposal={proposalsByIssue?.[issue.id]}
               />
             ))}
           </div>
@@ -124,16 +126,32 @@ const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap
 });
 
 // ── IssueCard ─────────────────────────────────────────────────────────────────
-const IssueCard = memo(function IssueCard({ issue, type, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled }) {
+const IssueCard = memo(function IssueCard({ issue, type, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled, appliedProposal }) {
+  const hasPrOpen = appliedProposal?.status === 'applied' && appliedProposal?.pr_url;
   return (
     <div
       onClick={() => onIssueClick(issue)}
       className="flex flex-col bg-gray-900/50 hover:bg-gray-800/80 border border-gray-800 hover:border-gray-700 rounded-xl p-5 cursor-pointer transition-all duration-200 hover:-translate-y-px hover:shadow-lg group"
     >
       <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium uppercase tracking-wider ${getBadgeStyles(issue.severity)}`}>
-          {issue.severity || 'UNKNOWN'}
-        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium uppercase tracking-wider ${getBadgeStyles(issue.severity)}`}>
+            {issue.severity || 'UNKNOWN'}
+          </span>
+          {hasPrOpen && (
+            <a
+              href={appliedProposal.pr_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-2 py-1 text-xs font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30 hover:bg-emerald-500/20 transition-colors"
+              title="View the draft PR opened from a CodeLens proposal"
+            >
+              <GitBranch className="h-3 w-3" />
+              PR opened
+            </a>
+          )}
+        </div>
 
         <div className="flex flex-wrap items-center gap-2 sm:justify-end">
           <button
@@ -143,7 +161,7 @@ const IssueCard = memo(function IssueCard({ issue, type, onIssueClick, onSuppres
             className="inline-flex items-center gap-1.5 rounded-md border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium text-indigo-200 transition-colors hover:bg-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Sparkles className="h-3.5 w-3.5" />
-            Propose fix
+            {hasPrOpen ? 'Open proposal' : 'Propose fix'}
           </button>
 
           {/* Suppress button for secrets */}
@@ -444,6 +462,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   const [isFetching, setIsFetching] = useState(false);
   const [canMutateIssues, setCanMutateIssues] = useState(true);
   const [selectedProposalIssue, setSelectedProposalIssue] = useState(null);
+  const [proposalsByIssue, setProposalsByIssue] = useState({});
   // Phase 4.1: callback ref so the scroll-parent element propagates through
   // state and triggers a re-render — IssueGroup's customScrollParent prop
   // needs the actual DOM node, not a ref placeholder.
@@ -474,6 +493,27 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
     };
 
     fetchDuplication();
+  }, [repoId, accessToken]);
+
+  useEffect(() => {
+    const fetchProposalSummary = async () => {
+      if (!accessToken || !repoId) return;
+      try {
+        const res = await fetch(apiUrl(`/api/review/${repoId}/proposals/summary`), {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const map = {};
+        for (const p of data.proposals || []) {
+          if (p.issue_id) map[p.issue_id] = p;
+        }
+        setProposalsByIssue(map);
+      } catch {
+        // Best-effort — the badges are purely informational.
+      }
+    };
+    fetchProposalSummary();
   }, [repoId, accessToken]);
 
   useEffect(() => {
@@ -583,11 +623,16 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
     }
   }, [canMutateIssues, repoId, session]);
 
-  const handleApplyProposal = useCallback((proposal) => {
-    window.dispatchEvent(new CustomEvent('codelens:apply-proposal', {
-      detail: { proposal, issue: selectedProposalIssue },
+  // Wired by ProposalPanel after a successful Apply via PR. Updates the local
+  // proposal-summary map so the IssueCard badge ("PR opened") reflects the new
+  // state without requiring a panel re-fetch.
+  const handleProposalApplied = useCallback(({ proposalId, issueId, pr_url }) => {
+    if (!issueId) return;
+    setProposalsByIssue((prev) => ({
+      ...prev,
+      [issueId]: { id: proposalId, issue_id: issueId, status: 'applied', pr_url: pr_url || null },
     }));
-  }, [selectedProposalIssue]);
+  }, []);
 
   if ((!localIssues || localIssues.length === 0) && duplicationClusters.length === 0) {
     return (
@@ -620,7 +665,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
           token={accessToken}
           open={!!selectedProposalIssue}
           onClose={() => setSelectedProposalIssue(null)}
-          onApplyProposal={handleApplyProposal}
+          onApplied={handleProposalApplied}
         />
       </>
     );
@@ -677,6 +722,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
               onProposeFix={setSelectedProposalIssue}
               actionsDisabled={!canMutateIssues}
               scrollParent={scrollParent}
+              proposalsByIssue={proposalsByIssue}
             />
           );
         })}
@@ -707,7 +753,7 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
       token={accessToken}
       open={!!selectedProposalIssue}
       onClose={() => setSelectedProposalIssue(null)}
-      onApplyProposal={handleApplyProposal}
+      onApplied={handleProposalApplied}
     />
     </>
   );

--- a/frontend/src/components/ProposalPanel.jsx
+++ b/frontend/src/components/ProposalPanel.jsx
@@ -6,7 +6,9 @@ import { Badge, Banner, Button, Skeleton, cx } from './ui/Primitives';
 import {
   AlertTriangle,
   Check,
+  CheckCircle2,
   Copy,
+  ExternalLink,
   GitBranch,
   RefreshCw,
   Sparkles,
@@ -22,6 +24,10 @@ const EMPTY_PROPOSAL = {
   rationale: '',
   changes: [],
   risks: [],
+  branch_name: null,
+  pr_url: null,
+  prompt_tokens: 0,
+  completion_tokens: 0,
 };
 
 function normalizeProposal(raw = {}) {
@@ -36,6 +42,10 @@ function normalizeProposal(raw = {}) {
     rationale: proposal.rationale || '',
     changes: Array.isArray(proposal.changes) ? proposal.changes : [],
     risks: Array.isArray(proposal.risks) ? proposal.risks : [],
+    branch_name: proposal.branch_name || raw.branch_name || null,
+    pr_url: proposal.pr_url || raw.pr_url || null,
+    prompt_tokens: Number(proposal.prompt_tokens || raw.prompt_tokens || 0),
+    completion_tokens: Number(proposal.completion_tokens || raw.completion_tokens || 0),
   };
 }
 
@@ -48,6 +58,10 @@ function mergeProposal(current, incoming) {
     rationale: next.rationale || current.rationale,
     changes: next.changes.length ? next.changes : current.changes,
     risks: next.risks.length ? next.risks : current.risks,
+    branch_name: next.branch_name || current.branch_name,
+    pr_url: next.pr_url || current.pr_url,
+    prompt_tokens: next.prompt_tokens || current.prompt_tokens,
+    completion_tokens: next.completion_tokens || current.completion_tokens,
   };
 }
 
@@ -132,13 +146,14 @@ function DiffBlock({ change }) {
   );
 }
 
-export default function ProposalPanel({ repoId, issue, token, open, onClose, onApplyProposal }) {
+export default function ProposalPanel({ repoId, issue, token, open, onClose, onApplied }) {
   const [proposal, setProposal] = useState(EMPTY_PROPOSAL);
   const [isStreaming, setIsStreaming] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [copyState, setCopyState] = useState('idle');
   const [isDiscarding, setIsDiscarding] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
 
   const abortRef = useRef(null);
   const panelRef = useRef(null);
@@ -156,7 +171,9 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
     proposal.summary || proposal.rationale || proposal.changes.length || proposal.risks.length
   );
   const isStale = proposal.status === 'stale';
-  const canMutate = Boolean(proposal.id) && !isStreaming;
+  const isApplied = proposal.status === 'applied';
+  const canMutate = Boolean(proposal.id) && !isStreaming && !isApplying;
+  const totalTokens = (proposal.prompt_tokens || 0) + (proposal.completion_tokens || 0);
 
   const abortActiveStream = useCallback(() => {
     if (abortRef.current) {
@@ -194,6 +211,8 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
           ...merged,
           id: event.proposal_id || merged.id,
           status: event.status || merged.status || 'pending',
+          prompt_tokens: Number(event.prompt_tokens || merged.prompt_tokens || 0),
+          completion_tokens: Number(event.completion_tokens || merged.completion_tokens || 0),
         };
       });
       setIsStreaming(false);
@@ -344,6 +363,38 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
     }
   };
 
+  const handleApply = async () => {
+    if (!repoId || !proposal.id || !token || isApplying) return;
+    setIsApplying(true);
+    setError(null);
+    try {
+      const res = await fetch(apiUrl(`/api/review/${repoId}/proposals/${proposal.id}/apply`), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || `Server error ${res.status}`);
+      }
+      setProposal((prev) => ({
+        ...prev,
+        status: 'applied',
+        branch_name: data.branch_name || prev.branch_name,
+        pr_url: data.pr_url || prev.pr_url,
+      }));
+      onApplied?.({
+        proposalId: proposal.id,
+        issueId: issue?.id,
+        branch_name: data.branch_name,
+        pr_url: data.pr_url,
+      });
+    } catch (err) {
+      setError(err.message || 'Failed to open the pull request.');
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
   if (!open || !issue) return null;
 
   return (
@@ -367,6 +418,9 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
             </div>
             <h2 id="proposal-panel-title" className="text-base font-semibold text-white">Refactor proposal</h2>
             <p className="mt-1 break-all font-mono text-xs text-accent-soft">{getPrimaryPath(issue)}</p>
+            {proposal.id && totalTokens > 0 && (
+              <p className="mt-1 text-xs text-gray-500">{totalTokens.toLocaleString()} tokens</p>
+            )}
           </div>
           <button
             ref={closeButtonRef}
@@ -388,6 +442,30 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
                 <p>This file has changed since this proposal was generated</p>
                 <Button size="sm" variant="outline" icon={RefreshCw} onClick={() => loadProposal({ regenerate: true })}>
                   Regenerate
+                </Button>
+              </div>
+            </Banner>
+          )}
+
+          {isApplied && proposal.pr_url && (
+            <Banner tone="success" icon={CheckCircle2} className="items-center">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <p className="font-medium">Draft PR opened on GitHub</p>
+                  {proposal.branch_name && (
+                    <p className="mt-0.5 break-all font-mono text-xs opacity-80">{proposal.branch_name}</p>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  icon={ExternalLink}
+                  as="a"
+                  href={proposal.pr_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View PR
                 </Button>
               </div>
             </Banner>
@@ -449,12 +527,16 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
             >
               Cancel
             </Button>
+          ) : isApplied ? (
+            <Button variant="secondary" icon={copyState === 'copied' ? Check : Copy} disabled={!allDiffs} onClick={handleCopyDiff}>
+              {copyState === 'copied' ? 'Copied' : 'Copy diff'}
+            </Button>
           ) : (
             <>
               <Button variant="danger" icon={Trash2} disabled={!canMutate || isDiscarding} loading={isDiscarding} onClick={handleDiscard}>
                 Discard
               </Button>
-              <Button variant="secondary" icon={RefreshCw} disabled={isStreaming} onClick={() => loadProposal({ regenerate: true })}>
+              <Button variant="secondary" icon={RefreshCw} disabled={!canMutate} onClick={() => loadProposal({ regenerate: true })}>
                 Regenerate
               </Button>
               <Button variant="secondary" icon={copyState === 'copied' ? Check : Copy} disabled={!allDiffs || isStreaming} onClick={handleCopyDiff}>
@@ -463,10 +545,11 @@ export default function ProposalPanel({ repoId, issue, token, open, onClose, onA
               <Button
                 variant="primary"
                 icon={GitBranch}
-                disabled={!canMutate}
-                onClick={() => onApplyProposal?.(proposal)}
+                disabled={!canMutate || isStale}
+                loading={isApplying}
+                onClick={handleApply}
               >
-                Apply via PR
+                {isApplying ? 'Opening PR…' : 'Apply via PR'}
               </Button>
             </>
           )}


### PR DESCRIPTION
Closes the AI Refactor Proposals epic by wiring the "Apply via PR" button
that US-065 shipped but left as a dead window.dispatchEvent.

Backend
- New POST /api/review/:repoId/proposals/:proposalId/apply opens a draft
  GitHub PR via the Git Data API in a single commit (createBlob ->
  createTree -> createCommit -> createRef -> pulls.create). Reuses the
  existing open PR / fast-forwards the ref on retry; maps GitHub 401/403/
  404/422/5xx to user-readable messages. Persists status='applied',
  branch_name, pr_url via withSupabaseRetry.
- New GET /api/review/:repoId/proposals/summary returns the latest
  proposal per issue for IssueCard "PR opened" badges.
- Extracted getGithubTokenForUser into backend/src/lib/githubAuth.js so
  reviewController and repoController share one Vault-token lookup.
- Tightened normalizeProposal to surface missing full_content on
  create/modify changes as risks, so the apply step can fail fast.
- proposal SSE 'done' event + cached-proposal path now carry
  prompt_tokens / completion_tokens for UI display.

Frontend
- ProposalPanel: removed the dead onApplyProposal window event;
  handleApply calls the new endpoint, sets status='applied', renders a
  green "Draft PR opened" banner with a View PR link, shows total token
  cost in the header. Action row collapses to Copy diff once applied.
- IssuesPanel: fetches proposals/summary on mount and threads it into
  IssueCard so applied proposals render a clickable "PR opened" badge
  and the button relabels to "Open proposal". Optimistic update via
  onApplied callback.

Docs
- CLAUDE.md: refreshed project structure, API route table, schema, and
  added sections for AI Refactor Proposals, Duplication Detection, Code
  Tours, Teams, Auto-Sync webhooks, and Per-File AI Chat that were
  previously undocumented. Corrected the issue_proposals status enum.
- New features.md inventory for planning future epics.
