### PR TITLE
feat(pr-review,ci,notifications): CI status check + in-app notifications (US-076, 077)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ AGENT_MAX_ITERATIONS=15
 # Per-conversation cumulative token cap; once hit, the agent emits budget_stopped.
 AGENT_TOKEN_CAP=50000
 
+# ─── CI Integration (US-076) ────────────────────────────────────────────────────
+# Server secret used to HMAC-hash per-repo CI API tokens before storage.
+# Required for generating and verifying CI tokens. Use a long random string.
+CI_TOKEN_HMAC_SECRET=
+
 # ─── Frontend (Vite public vars) ────────────────────────────────────────────────
 # Vite only exposes vars prefixed with VITE_ to the browser bundle
 VITE_SUPABASE_URL=https://your-project.supabase.co

--- a/.github/actions/codelens-review/action.yml
+++ b/.github/actions/codelens-review/action.yml
@@ -1,0 +1,32 @@
+name: 'CodeLens PR Review'
+description: 'Run CodeLens deterministic PR review and report the result as a GitHub status check.'
+author: 'CodeLens'
+branding:
+  icon: 'shield'
+  color: 'purple'
+inputs:
+  repo_id:
+    description: 'CodeLens repository UUID (from the repo URL / settings).'
+    required: true
+  codelens_api_token:
+    description: 'Per-repo CodeLens CI API token (codelens_pat_...). Store as a secret.'
+    required: true
+  fail_on_severity:
+    description: 'Comma-separated severities that fail the check.'
+    required: false
+    default: 'critical,high'
+  wait_timeout_seconds:
+    description: 'Maximum seconds to wait for the review to complete.'
+    required: false
+    default: '300'
+  codelens_api_url:
+    description: 'Base URL of the CodeLens API.'
+    required: false
+    default: 'https://app.codelens.dev'
+  github_token:
+    description: 'Token used to create the check run. Needs checks:write.'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: 'node20'
+  main: 'index.js'

--- a/.github/actions/codelens-review/index.js
+++ b/.github/actions/codelens-review/index.js
@@ -1,0 +1,104 @@
+/**
+ * CodeLens PR Review action (US-076).
+ *
+ * Dependency-free Node 20 action: reads inputs from INPUT_* env vars, calls the
+ * CodeLens CI-check endpoint, and reports the result as a GitHub check run.
+ * No bundling step required — uses global fetch + the built-in event payload.
+ */
+const fs = require('fs');
+
+function getInput(name, def = '') {
+  const value = process.env[`INPUT_${name.toUpperCase().replace(/ /g, '_')}`];
+  return value === undefined || value === '' ? def : value.trim();
+}
+
+function info(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function setFailed(message) {
+  process.stdout.write(`::error::${message}\n`);
+  process.exitCode = 1;
+}
+
+async function httpJson(method, url, headers, body) {
+  const res = await fetch(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
+  const text = await res.text();
+  let json = null;
+  try { json = text ? JSON.parse(text) : null; } catch { /* non-JSON body */ }
+  return { status: res.status, ok: res.ok, json, text };
+}
+
+(async () => {
+  try {
+    const repoId = getInput('repo_id');
+    const apiToken = getInput('codelens_api_token');
+    const failOn = getInput('fail_on_severity', 'critical,high');
+    const waitTimeout = getInput('wait_timeout_seconds', '300');
+    const apiUrl = getInput('codelens_api_url', 'https://app.codelens.dev').replace(/\/+$/, '');
+    const ghToken = getInput('github_token') || process.env.GITHUB_TOKEN;
+
+    if (!repoId || !apiToken) {
+      return setFailed('Inputs repo_id and codelens_api_token are required.');
+    }
+
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    const event = eventPath && fs.existsSync(eventPath) ? JSON.parse(fs.readFileSync(eventPath, 'utf8')) : {};
+    const pr = event.pull_request;
+    if (!pr || !pr.number) {
+      return setFailed('This action must run on pull_request events.');
+    }
+    const prNumber = pr.number;
+    const headSha = pr.head?.sha || process.env.GITHUB_SHA;
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY || '/').split('/');
+
+    info(`Requesting CodeLens review for PR #${prNumber} (head ${String(headSha).slice(0, 7)})...`);
+    const resp = await httpJson(
+      'POST',
+      `${apiUrl}/api/repos/${repoId}/pulls/${prNumber}/reviews/ci-check`,
+      { Authorization: `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+      { fail_on_severity: failOn, wait_timeout_seconds: Number(waitTimeout) },
+    );
+
+    if (!resp.ok) {
+      return setFailed(`CodeLens CI check failed (HTTP ${resp.status}): ${resp.json?.error || resp.text || 'unknown error'}`);
+    }
+
+    const result = resp.json || {};
+    const counts = result.severity_counts || {};
+    const conclusion = result.status === 'pass' ? 'success' : 'failure';
+    const title = result.status === 'pass'
+      ? 'CodeLens: no blocking findings'
+      : `CodeLens: ${failOn} findings present`;
+    const summary = result.summary_markdown || 'CodeLens PR review complete.';
+
+    if (ghToken && owner && repo && headSha) {
+      const checkRes = await httpJson(
+        'POST',
+        `${process.env.GITHUB_API_URL || 'https://api.github.com'}/repos/${owner}/${repo}/check-runs`,
+        {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          'User-Agent': 'codelens-review-action',
+        },
+        { name: 'CodeLens Review', head_sha: headSha, status: 'completed', conclusion, output: { title, summary } },
+      );
+      if (!checkRes.ok) {
+        info(`Warning: could not create check run (HTTP ${checkRes.status}): ${checkRes.json?.message || ''}`);
+      }
+    } else {
+      info('Skipping check-run creation (missing github token or repo context).');
+    }
+
+    info(`CodeLens result: ${result.status} — critical ${counts.critical || 0}, high ${counts.high || 0}, medium ${counts.medium || 0}, low ${counts.low || 0}`);
+    if (result.codelens_url) info(`Full review: ${result.codelens_url}`);
+
+    if (result.status !== 'pass') {
+      return setFailed(`CodeLens found ${failOn} severity findings. See ${result.codelens_url || 'CodeLens'}.`);
+    }
+    info('CodeLens check passed.');
+  } catch (err) {
+    setFailed(`CodeLens action error: ${err.message || err}`);
+  }
+})();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@ CodeLens is a full-stack web app that helps developers understand large, unfamil
 - Architectural issue detection (circular deps, god files, dead code, high coupling)
 - Security scanning: secret detection, SAST pattern matching, dependency vulnerability scanning, attack surface mapping, auth coverage checking
 - AI security audit mode with whole-repo auditing and structured findings
+- **PR review workflow** — deterministic scanners + blast radius run on a PR diff, persisted, viewable in-app, and posted back as inline GitHub review comments (US-072–US-075)
+- **CI status check** — a GitHub Action + per-repo CI API token that runs the PR review from CI and reports a pass/fail check (US-076)
+- **In-app notifications** — bell + feed for index/issue/vulnerability/PR-review/tour events, with 30-day dedup (US-077)
 - **AI refactor proposals** with one-click "Apply via PR" producing a draft GitHub PR in a single commit (US-063–US-066)
 - AI-generated code tours / guided walkthroughs (US-060, US-061), with fork + share-impact
 - Duplicate-code clustering + AI shared-utility refactor suggestion
@@ -78,12 +81,16 @@ CodeLens-hub/
 │   │   ├── DependencyGraph.jsx       # D3 graph + attack surface overlay (US-047)
 │   │   ├── CodeReviewPanel.jsx       # AI review + security audit mode (US-048)
 │   │   ├── IssuesPanel.jsx           # All issue types + duplication + "PR opened" badges (US-066)
+│   │   ├── IssueCard.jsx             # Shared issue/finding card (reused by Issues + PR review — US-075)
 │   │   ├── ProposalPanel.jsx         # AI refactor proposal review + Apply via PR (US-065, US-066)
+│   │   ├── PullRequestsPanel.jsx     # PR review viewer: list + full-page detail + findings (US-075)
+│   │   ├── NotificationBell.jsx      # Sidebar bell + dropdown feed; exports shared type meta (US-077)
+│   │   ├── SettingsPanel.jsx         # Auto-sync, auto-publish, PR-review severity, CI token gen (US-073/076)
 │   │   ├── ImpactAnalysisPanel.jsx   # Blast-radius panel
 │   │   ├── MetricsPanel.jsx
 │   │   ├── AgentPanel.jsx            # AI Repo Agent chat + tool-call cards + history rail (US-070, US-071)
 │   │   └── ui/                       # Primitives, Icons (lucide-react re-exports), Toast
-│   ├── pages/              # Login, AuthCallback, Dashboard, RepoView, Search
+│   ├── pages/              # Login, AuthCallback, Dashboard, RepoView, NotificationsPage (US-077)
 │   ├── context/            # AuthContext
 │   ├── hooks/
 │   │   └── useGraphSimulation.js     # D3 physics + visual modes (selection/impact/attack surface)
@@ -91,16 +98,18 @@ CodeLens-hub/
 │
 ├── backend/src/
 │   ├── index.js            # Express setup + all route mounting + global token-redacting console
-│   ├── routes/             # auth, repo, search, analysis, review, webhooks, teams, fileChat, usage, admin, tours, agent
+│   ├── routes/             # auth, repo, search, analysis, review, reviews, webhooks, teams, fileChat, usage, admin, tours, agent, notifications
 │   ├── controllers/        # Request handlers
 │   │   ├── analysisController.js     # Issues, suppress, impact
-│   │   ├── reviewController.js       # AI review + security audit + refactor proposals + apply-via-PR (US-048, US-064–US-066)
+│   │   ├── reviewController.js       # AI review + security audit + refactor proposals + apply-via-PR + PR review pipeline/publish/ci-check (US-048, US-064–US-066, US-072–US-076)
 │   │   ├── repoController.js         # Connect, upload, status, reindex, churn, duplication, branches, diff, dependencies
+│   │   ├── ciTokenController.js      # Per-repo CI API token generate/list/revoke (US-076)
+│   │   ├── notificationsController.js # In-app notification feed endpoints (US-077)
 │   │   ├── teamController.js         # Team CRUD + repo sharing
 │   │   ├── fileChatController.js     # Per-file AI chat
-│   │   ├── toursController.js        # Code-tour generation/edit/fork (US-060, US-061)
+│   │   ├── toursController.js        # Code-tour generation/edit/fork + tour_shared notify (US-060, US-061, US-077)
 │   │   ├── usageController.js        # /api/usage/today
-│   │   ├── webhookController.js      # GitHub push → auto-reindex
+│   │   ├── webhookController.js      # GitHub push → auto-reindex (gated on auto_sync_enabled); pull_request → PR review (US-073)
 │   │   ├── authController.js         # GitHub OAuth handshake
 │   │   ├── agentController.js        # AI Repo Agent tool-use loop + history (US-069 – US-071)
 │   │   └── searchController.js       # RAG search
@@ -122,7 +131,9 @@ CodeLens-hub/
 │   │   ├── graphService.js           # BFS/DFS over graph_edges + Tarjan cycle count (US-068)
 │   │   ├── fileService.js            # Indexed file read (file_contents + code_chunks fallback)
 │   │   ├── agentTools.js             # Anthropic-schema tools + handlers for the agent (US-068)
-│   │   ├── queue.js                  # Indexing job queue
+│   │   ├── notificationEvents.js     # In-process EventEmitter (pr_review.ready) — test-observable (US-073)
+│   │   ├── notifications.js          # enqueueNotification (30-day dedup) + recipientsForRepo (US-077)
+│   │   ├── queue.js                  # Indexing + pr-review job queue
 │   │   └── usageTracker.js           # Daily token budget (US-042)
 │   ├── sast/
 │   │   ├── secret-rules.json         # Regex rules for secret scanning
@@ -134,7 +145,10 @@ CodeLens-hub/
 │   ├── observability/      # AsyncLocalStorage request ledger (Phase 0)
 │   ├── ai/                 # ragService.js (RAG pipeline)
 │   ├── db/                 # Supabase admin client (instrumented fetch)
-│   └── middleware/         # Auth, error handling, AI rate limiting
+│   └── middleware/         # Auth (requireAuth), ciTokenAuth (US-076), error handling, AI rate limiting
+│
+├── .github/actions/codelens-review/   # Zero-dep Node 20 GitHub Action for CI status check (US-076)
+├── docs/ci-integration.md             # CI integration guide + copy-paste workflow YAML (US-076)
 │
 ├── scripts/
 │   ├── setup.sh                              # Idempotent bootstrap
@@ -180,6 +194,18 @@ CodeLens-hub/
 | `PATCH` | `/api/review/:id/issues/:issueId/proposals/:proposalId` | Update proposal status (discard) |
 | `GET` | `/api/review/:id/proposals/summary` | Latest proposal per issue for IssueCard badges (US-066) |
 | `POST` | `/api/review/:id/proposals/:proposalId/apply` | Apply a proposal as a GitHub draft PR via single-commit Git Data API (US-066) |
+| `POST` | `/api/review/:id/pr-findings/proposals` | SSE: AI fix proposal for a PR-review finding (US-075) |
+| `PATCH` | `/api/review/:id/pr-findings/proposals/:proposalId` | Update PR-finding proposal status (discard) (US-075) |
+| `POST` | `/api/review/:id/pr-findings/proposals/:proposalId/apply` | Apply a PR-finding proposal as a draft PR (US-075) |
+| `GET` | `/api/repos/:id/pulls` | List PRs (Octokit) with their latest review (US-075) |
+| `GET\|POST` | `/api/repos/:id/pulls/:number/reviews` | List PR review history / run a deterministic PR review (SSE) (US-073) |
+| `POST` | `/api/repos/:id/pulls/:number/reviews/ci-check` | CI-token-auth: blocks until review ready, returns pass/fail (US-076) |
+| `POST` | `/api/repos/:id/reviews/:reviewId/publish` | Post the review to GitHub as inline comments (US-074) |
+| `GET` | `/api/reviews/:reviewId` | Full PR review detail incl. stale-index banner data (US-075) |
+| `POST\|GET\|DELETE` | `/api/repos/:id/ci-tokens[/:tokenId]` | Generate (once) / list / revoke per-repo CI API tokens (US-076) |
+| `GET` | `/api/notifications` | Cursor-paginated feed `?limit&before` (US-077) |
+| `GET` | `/api/notifications/unread-count` | Unread badge count (US-077) |
+| `POST` | `/api/notifications/:id/read` \| `/api/notifications/mark-all-read` | Mark one / all read (US-077) |
 | `POST` | `/api/file-chat/:id` | Per-file AI chat |
 | `POST` | `/api/repos/:id/agent/chat` | SSE: AI Repo Agent tool-use loop (US-069). Body `{ conversation_id?, message }` |
 | `GET` | `/api/repos/:id/agent/conversations` | Paginated conversation list (US-071) |
@@ -188,7 +214,7 @@ CodeLens-hub/
 | `*` | `/api/tours/*` | Generate/list/update/fork/delete AI-authored code tours (US-060, US-061) |
 | `*` | `/api/teams/*` | Create teams, add repos to teams, list team repos |
 | `GET` | `/api/usage/today` | Today's per-user token usage (US-042) |
-| `POST` | `/api/webhooks/github` | GitHub push webhook → auto-reindex when `auto_sync_enabled` is set |
+| `POST` | `/api/webhooks/github` | GitHub webhook → push auto-reindex (when `auto_sync_enabled`); `pull_request` → PR review (when `pr_review_enabled`) |
 | `*` | `/api/admin/*` | Internal/ops endpoints |
 
 ---
@@ -197,7 +223,7 @@ CodeLens-hub/
 
 Tables (all with RLS):
 - `profiles` — user metadata + `github_token_secret_id` (UUID referencing Supabase Vault; tokens never stored plaintext — US-039)
-- `repositories` — connected repos: `status` (`pending | indexing | ready | failed`), `full_name` (`owner/repo`), `default_branch`, `source` (`github | upload`), `auto_sync_enabled`, `sast_disabled_rules TEXT[]` for per-repo SAST rule opt-outs (US-046), `webhook_secret`
+- `repositories` — connected repos: `status` (`pending | indexing | ready | failed`), `full_name` (`owner/repo`), `default_branch`, `source` (`github | upload`), `auto_sync_enabled`, `sast_disabled_rules TEXT[]` for per-repo SAST rule opt-outs (US-046), `webhook_secret`, `latest_indexed_sha` (drives PR-review stale-index banner), and PR-review flags `pr_review_enabled` / `pr_review_auto_publish` / `pr_review_block_on_severity` (`critical | high`) (US-073/074)
 - `graph_nodes` — files with metrics: `line_count`, `complexity_score` (true cyclomatic via Tree-sitter), `incoming_count`, `outgoing_count`, `content_hash`, `node_classification` (`source | sink | both | null` — US-047)
 - `graph_edges` — dependency edges (`from_path → to_path`); `symbols TEXT[]` carries per-importer symbol list (US-064)
 - `code_chunks` — chunked source with 1536-dim pgvector embeddings (HNSW index m=16, ef_construction=64)
@@ -216,8 +242,13 @@ Tables (all with RLS):
 - `teams`, `team_members`, `team_repositories` — team-based repo sharing; access checks centralised in the `can_access_repo(repo_id, user_id)` Postgres RPC
 - `agent_conversations` — AI Repo Agent chats (US-067): `{ id, repo_id, user_id, title, total_tokens, created_at, updated_at }`. `title` is auto-generated by a one-shot Haiku call after the first assistant turn.
 - `agent_messages` — full tool-call trace for the agent (US-067). `role` enum `user | assistant | tool_use | tool_result`; `content_json` is polymorphic by role (`{ text }` for user/assistant, `{ tool_name, input, tool_use_id }` for tool_use, `{ tool_use_id, output, is_error }` for tool_result). `tool_use_id` matches Anthropic's protocol id so traces replay verbatim.
+- `pr_reviews` — per-PR-head deterministic review (US-072): `{ id, repo_id, pr_number, pr_head_sha, pr_base_sha, user_id, status (pending|analyzing|ready|failed|stale), findings_json, summary, total_findings, severity_counts }`. Unique `(repo_id, pr_number, pr_head_sha)`; a re-push marks the prior review `stale`. `findings_json` mirrors `analysis_issues` shape so `IssueCard` renders either source
+- `pr_review_comments` — GitHub comment ids for idempotent (re-)publishing (US-074): `{ review_id, github_comment_id, file_path, line_number, kind (inline|summary) }`
+- `pr_finding_proposals` — AI fix proposals for PR-review findings (US-075), mirrors `issue_proposals` but keyed by `(review_id, finding_id)`; `status`, `proposal_json`, `branch_name`, `pr_url`
+- `repo_api_tokens` — per-repo CI API tokens (US-076): `{ id, repo_id, token_hash, name, created_by, created_at, last_used_at, revoked_at }`. Stored as HMAC-SHA256(`CI_TOKEN_HMAC_SECRET`, token); plaintext shown once
+- `notifications` — in-app feed (US-077): `{ id, user_id, repo_id, type, severity (info|warning|critical), payload_json, link_url, read_at, created_at }`. `type` enum `new_critical_issue | new_vulnerability | index_ready | index_failed | pr_review_ready | proposal_shared | tour_shared | webhook_paused`. Indexes on `(user_id, read_at, created_at DESC)` and `(user_id, repo_id, type, created_at DESC)` (the latter powers 30-day dedup)
 
-**Schema migration:** `scripts/schema.sql` is idempotent and safe to re-run. Apply via Supabase SQL Editor. Auxiliary migrations applied separately on top: `us048_security_audits.sql`, `us051_arch_diff.sql`, `us063_proposals.sql`, `us067_agent.sql`, `perf_reindex_migration.sql`.
+**Schema migration:** `scripts/schema.sql` is idempotent and safe to re-run. Apply via Supabase SQL Editor. The PR-review (US-072), CI-token (US-076), and notifications (US-077) tables are appended to `scripts/schema.sql` directly. Auxiliary migrations applied separately on top: `us048_security_audits.sql`, `us051_arch_diff.sql`, `us063_proposals.sql`, `us067_agent.sql`, `perf_reindex_migration.sql`.
 
 **Indexer-side RPCs** (also in `scripts/schema.sql`):
 - `prepare_repo_reindex(repo_id, unchanged_paths, changed_or_deleted_paths, preserve_churn)` — single PL/pgSQL call that stale-marks pending proposals, deletes non-preservable issues (preserves `hardcoded_secret` / `insecure_pattern` / `missing_auth` whose `file_paths` are entirely in `unchanged_paths`), wipes derived tables, and partial-purges nodes/chunks/file_contents for changed-or-deleted files
@@ -241,6 +272,7 @@ FRONTEND_URL          # base URL used in CORS + as the deep-link host in Apply-v
 MAX_DAILY_TOKENS_PER_USER   # optional, default 500000 (US-042)
 AGENT_MAX_ITERATIONS        # max tool-use iterations per agent turn, default 15 (US-069)
 AGENT_TOKEN_CAP             # per-conversation cumulative token cap, default 50000 (US-069)
+CI_TOKEN_HMAC_SECRET        # server secret used to HMAC-hash per-repo CI API tokens (US-076)
 
 # Performance / observability knobs (all optional)
 SLOW_REQUEST_MS             # WARN threshold for the request-timing middleware, default 500
@@ -498,7 +530,41 @@ Every handler gates on `canAccessRepo(repoId, userId)` first (per-call — a cra
 
 - `POST /api/webhooks/github` runs before `express.json()` (mounted via `express.raw({ type: 'application/json' })`) so the HMAC signature validator sees the original request bytes.
 - Each repo has a `webhook_secret` generated via `GET /api/repos/:id/webhook`.
-- On `push` events for repos with `auto_sync_enabled = true`, the backend kicks an incremental re-index; the global Vault-stored PAT is reused for the GitHub fetch.
+- On `push` events for repos with `auto_sync_enabled = true`, the backend kicks an incremental re-index; the global Vault-stored PAT is reused for the GitHub fetch. (The repo lookup no longer filters on `auto_sync_enabled` — `pull_request` events have their own opt-in — so the push branch re-checks the flag explicitly before re-indexing.)
+- On `pull_request` events (`opened | synchronize | reopened`) for repos with `pr_review_enabled = true`, the backend enqueues a `pr-review` job (US-073).
+
+---
+
+## PR Review Workflow (US-072 – US-075)
+
+Deterministic-only review of a PR diff (no AI tokens in the pipeline), persisted and viewable in-app, optionally posted to GitHub as inline review comments.
+
+- **Pipeline** (`reviewController.runPrReviewBackground`): fetch the PR (Octokit), stale-mark prior reviews for the PR, upsert a `pr_reviews` row, cap to the 50 files with the most additions (emit `truncated`), then per file run secret scan (added lines), SAST (full new content, only findings on added lines AND absent from base), auth-coverage (new vs base), and SCA on changed manifests. Blast radius is attached from the most recent index. Findings are filtered against `issue_suppressions` and pre-PR `analysis_issues`, then written to `findings_json`. SSE events: `analyzing_file | finding | truncated | summary | done | error`.
+- **Triggers**: `POST /api/repos/:id/pulls/:number/reviews` (SSE, `requireAuth`) or the `pull_request` webhook → `pr-review` queue job.
+- **Publish (US-074)**: `POST /api/repos/:id/reviews/:reviewId/publish` posts a single `pulls.createReview` (`COMMENT`, or `REQUEST_CHANGES` per `pr_review_block_on_severity`); inline findings → per-line comments, file-level → summary body; comment ids saved to `pr_review_comments`. Idempotent across re-pushes (cleans prior comments) and re-publishes of the same review (`resetCurrentReviewComments`). On 422, out-of-diff comments are dropped and it retries once. Auto-publishes when `pr_review_auto_publish`. Errors mapped (401/403/404/422/5xx) with no raw GitHub text.
+- **Viewer (US-075)**: "Pull Requests" tab → `PullRequestsPanel` (list with status/severity, filters, 30s poll) → full-page detail (`GET /api/reviews/:reviewId`) reusing `IssueCard`, with "Generate fix" (`pr_finding_proposals`) and "Suppress". Stale-index banner when `latest_indexed_sha != pr_head_sha`.
+
+---
+
+## CI Status Check (US-076)
+
+A GitHub Action that runs the PR review from CI and reports a status check.
+
+- **Per-repo CI tokens**: `repo_api_tokens`, format `codelens_pat_<hex>`, stored as HMAC-SHA256(`CI_TOKEN_HMAC_SECRET`, token). Managed via `POST|GET|DELETE /api/repos/:id/ci-tokens[/:tokenId]` (`requireAuth` + `can_access_repo`); generated in Settings → CI Integration (shown once).
+- **`ciTokenAuth` middleware** (`requireCiToken`): resolves `Authorization: Bearer codelens_pat_...` to a single repo via indexed hash lookup, enforces it matches `:repoId`, bumps `last_used_at`.
+- **CI-check endpoint**: `POST /api/repos/:id/pulls/:number/reviews/ci-check` (CI-token auth) resolves the PR head SHA, reuses a `ready` review or **auto-triggers `runPrReviewBackground` and polls** until ready/timeout (default 300s, fail-closed), returns `{ status: 'pass'|'fail', severity_counts, summary_markdown, codelens_url }` based on `fail_on_severity` (default `critical,high`).
+- **Action**: zero-dependency Node 20 action at `.github/actions/codelens-review/` (`action.yml` + `index.js`) — POSTs to ci-check, writes a check run via the GitHub checks API. See `docs/ci-integration.md`.
+
+---
+
+## Notifications (US-077)
+
+In-app notification feed (no email/preferences — that's US-078).
+
+- **Service** `backend/src/services/notifications.js`: `enqueueNotification({ user_ids, repo_id, type, severity, payload, link_url, dedup_key })` inserts one row per recipient; `dedup_key` skips users notified for the same `(repo, type, key)` in the last 30 days (prevents re-index spam). `recipientsForRepo(repoId)` = owner ∪ team members.
+- **Emission** (all best-effort, wrapped in try/catch): indexer → `index_ready` (owner+team) / `index_failed` (owner) / per newly-surfaced critical-or-high issue → `new_critical_issue` or `new_vulnerability`; PR review → `pr_review_ready`; tour fork → `tour_shared` (original author). The legacy `notificationEvents.js` EventEmitter remains for test observability.
+- **Endpoints** (`/api/notifications`, `requireAuth`, all user-scoped): `GET /` (`?limit&before` cursor), `GET /unread-count`, `POST /:id/read`, `POST /mark-all-read`.
+- **Frontend**: `NotificationBell` in the `Layout` sidebar footer (60s badge poll, 30s dropdown poll, grouped by day, mark-all-read, click-outside) + `/notifications` full feed page (paginated 50). Shared type/severity meta + `notificationText` are exported from `NotificationBell.jsx`.
 
 ---
 

--- a/backend/src/controllers/ciTokenController.js
+++ b/backend/src/controllers/ciTokenController.js
@@ -1,0 +1,87 @@
+/**
+ * US-076 — per-repo CI API token management.
+ *
+ * Tokens are shown once on creation and stored only as an HMAC-SHA256 hash
+ * (see middleware/ciTokenAuth.js). They are scoped to a single repo and used
+ * only by the CI status-check endpoint.
+ */
+const crypto = require('crypto');
+const { supabaseAdmin } = require('../db/supabase');
+const { canAccessRepo } = require('../lib/repoAccess');
+const { hashCiToken } = require('../middleware/ciTokenAuth');
+
+const TOKEN_PREFIX = 'codelens_pat_';
+
+// POST /api/repos/:repoId/ci-tokens  body: { name? }
+const createCiToken = async (req, res) => {
+  const { repoId } = req.params;
+  const name = String(req.body?.name || '').trim().slice(0, 100) || 'CI token';
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  if (!process.env.CI_TOKEN_HMAC_SECRET) {
+    return res.status(500).json({ error: 'CI token generation is not configured on this server' });
+  }
+
+  const token = TOKEN_PREFIX + crypto.randomBytes(24).toString('hex');
+  const tokenHash = hashCiToken(token);
+
+  const { data, error } = await supabaseAdmin
+    .from('repo_api_tokens')
+    .insert({ repo_id: repoId, token_hash: tokenHash, name, created_by: req.user.id })
+    .select('id, name, created_at')
+    .single();
+
+  if (error) {
+    console.error('[ci-tokens.create] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to generate CI token' });
+  }
+
+  // The plaintext token is returned exactly once and never persisted.
+  return res.status(201).json({ id: data.id, name: data.name, created_at: data.created_at, token });
+};
+
+// GET /api/repos/:repoId/ci-tokens — metadata only, never the hash or plaintext
+const listCiTokens = async (req, res) => {
+  const { repoId } = req.params;
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  const { data, error } = await supabaseAdmin
+    .from('repo_api_tokens')
+    .select('id, name, created_at, last_used_at, revoked_at')
+    .eq('repo_id', repoId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('[ci-tokens.list] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to list CI tokens' });
+  }
+  return res.json({ tokens: data || [] });
+};
+
+// DELETE /api/repos/:repoId/ci-tokens/:tokenId — revoke
+const revokeCiToken = async (req, res) => {
+  const { repoId, tokenId } = req.params;
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  const { data, error } = await supabaseAdmin
+    .from('repo_api_tokens')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', tokenId)
+    .eq('repo_id', repoId)
+    .is('revoked_at', null)
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    console.error('[ci-tokens.revoke] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to revoke CI token' });
+  }
+  if (!data) return res.status(404).json({ error: 'Token not found or already revoked' });
+  return res.json({ ok: true, id: data.id });
+};
+
+module.exports = { createCiToken, listCiTokens, revokeCiToken };

--- a/backend/src/controllers/notificationsController.js
+++ b/backend/src/controllers/notificationsController.js
@@ -1,0 +1,81 @@
+/**
+ * US-077 — in-app notification feed endpoints. All rows are user-scoped; the
+ * service-role client is used but every query filters on req.user.id so a user
+ * can only ever read/modify their own notifications.
+ */
+const { supabaseAdmin } = require('../db/supabase');
+
+// GET /api/notifications?limit&before
+const listNotifications = async (req, res) => {
+  const userId = req.user.id;
+  const limit = Math.min(100, Math.max(1, Number(req.query.limit) || 20));
+  const before = req.query.before;
+
+  let query = supabaseAdmin
+    .from('notifications')
+    .select('id, repo_id, type, severity, payload_json, link_url, read_at, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(limit + 1);
+  if (before) query = query.lt('created_at', before);
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('[notifications.list] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to load notifications' });
+  }
+
+  const rows = data || [];
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? page[page.length - 1]?.created_at : null;
+  return res.json({ notifications: page, next_cursor: nextCursor, has_more: hasMore });
+};
+
+// GET /api/notifications/unread-count
+const unreadCount = async (req, res) => {
+  const { count, error } = await supabaseAdmin
+    .from('notifications')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', req.user.id)
+    .is('read_at', null);
+  if (error) {
+    console.error('[notifications.unread-count] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to load unread count' });
+  }
+  return res.json({ unread: count || 0 });
+};
+
+// POST /api/notifications/:id/read
+const markRead = async (req, res) => {
+  const { id } = req.params;
+  const { data, error } = await supabaseAdmin
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('user_id', req.user.id)
+    .is('read_at', null)
+    .select('id')
+    .maybeSingle();
+  if (error) {
+    console.error('[notifications.read] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to mark notification read' });
+  }
+  return res.json({ ok: true, id: data?.id || id });
+};
+
+// POST /api/notifications/mark-all-read
+const markAllRead = async (req, res) => {
+  const { error } = await supabaseAdmin
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('user_id', req.user.id)
+    .is('read_at', null);
+  if (error) {
+    console.error('[notifications.mark-all-read] Failed:', error.message);
+    return res.status(500).json({ error: 'Failed to mark all read' });
+  }
+  return res.json({ ok: true });
+};
+
+module.exports = { listNotifications, unreadCount, markRead, markAllRead };

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -23,6 +23,7 @@ const { isManifestFile, parseManifest } = require('../services/manifestParser');
 const { scanDependencies } = require('../services/osvScanner');
 const { getBlastRadius } = require('../services/graphService');
 const { emitPrReviewReady } = require('../services/notificationEvents');
+const { enqueueNotification, recipientsForRepo } = require('../services/notifications');
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -1324,9 +1325,20 @@ async function runPrReviewBackground({ repoId, prNumber, owner, repo, githubToke
       }
     }
 
+    const { data: repoIndexState } = await supabaseAdmin
+      .from('repositories')
+      .select('latest_indexed_sha')
+      .eq('id', repoId)
+      .maybeSingle();
+    const indexedSha = repoIndexState?.latest_indexed_sha || null;
+    const stalenessNote = !indexedSha
+      ? 'Index staleness: unknown; this repository has no recorded indexed commit yet.'
+      : indexedSha === headSha
+        ? `Index is current with the PR head (${indexedSha.slice(0, 7)}).`
+        : `Index is at ${indexedSha.slice(0, 7)} while the PR head is ${headSha.slice(0, 7)}; blast-radius numbers may be slightly stale.`;
     const summary = [
       `PR review completed for #${prNumber} at ${headSha}.`,
-      'Index staleness: unknown; this repository does not currently store the latest indexed commit SHA.',
+      stalenessNote,
     ].join(' ');
 
     const updateRes = await supabaseAdmin.from('pr_reviews').update({
@@ -1341,6 +1353,23 @@ async function runPrReviewBackground({ repoId, prNumber, owner, repo, githubToke
     send({ type: 'summary', total_files: capped.length, total_findings: filtered.length, severity_counts: severityCounts, summary });
     send({ type: 'done', review_id: reviewRow.id });
     emitPrReviewReady({ review_id: reviewRow.id, repo_id: repoId, pr_number: prNumber, head_sha: headSha, total_findings: filtered.length, severity_counts: severityCounts });
+    // US-077: in-app notification for owner + team members.
+    try {
+      const recipients = await recipientsForRepo(repoId);
+      if (recipients.length > 0) {
+        await enqueueNotification({
+          user_ids: recipients,
+          repo_id: repoId,
+          type: 'pr_review_ready',
+          severity: (severityCounts.critical > 0 || severityCounts.high > 0) ? 'warning' : 'info',
+          payload: { review_id: reviewRow.id, pr_number: prNumber, total_findings: filtered.length, severity_counts: severityCounts },
+          link_url: `/repo/${repoId}?tab=pulls&pr=${prNumber}&review=${reviewRow.id}`,
+          dedup_key: `pr_review_ready::${prNumber}::${headSha}`,
+        });
+      }
+    } catch (notifyErr) {
+      console.warn('[pr-review] notification emission failed:', notifyErr?.message || notifyErr);
+    }
     try {
       const { data: repoSettings } = await supabaseAdmin
         .from('repositories')
@@ -1415,6 +1444,39 @@ async function cleanupPreviousPrReviewComments({ octokit, owner, repo, repoId, r
       }
     }
   }
+}
+
+// Idempotent re-publish of the SAME review (same head_sha keeps the same row):
+// delete the prior inline comments, mark the prior summary review outdated, and
+// clear the persisted rows so the upcoming publish does not duplicate them.
+async function resetCurrentReviewComments({ octokit, owner, repo, review }) {
+  const { data: rows } = await supabaseAdmin
+    .from('pr_review_comments')
+    .select('id, github_comment_id, kind')
+    .eq('review_id', review.id);
+  if (!rows || rows.length === 0) return;
+
+  for (const row of rows) {
+    if (!row.github_comment_id) continue;
+    try {
+      if (row.kind === 'inline') {
+        await octokit.rest.pulls.deleteReviewComment({ owner, repo, comment_id: row.github_comment_id });
+      } else if (row.kind === 'summary' && typeof octokit.rest.pulls.updateReview === 'function') {
+        await octokit.rest.pulls.updateReview({
+          owner,
+          repo,
+          pull_number: review.pr_number,
+          review_id: row.github_comment_id,
+          body: '[Outdated - see updated review below]',
+        });
+      }
+    } catch (err) {
+      if ((err?.status || err?.response?.status) !== 404) {
+        console.warn('[pr-review.publish] current review comment reset failed:', err?.message || err);
+      }
+    }
+  }
+  await supabaseAdmin.from('pr_review_comments').delete().eq('review_id', review.id);
 }
 
 async function fetchCreatedReviewInlineComments({ octokit, owner, repo, review, reviewData, inlineFindings }) {
@@ -1521,15 +1583,27 @@ async function publishPrReview({ repoId, reviewId, actorUserId = null, retry422 
   };
 
   await cleanupPreviousPrReviewComments({ octokit, owner, repo, repoId, review });
+  await resetCurrentReviewComments({ octokit, owner, repo, review });
 
   let response;
   try {
     response = await octokit.rest.pulls.createReview(payload);
   } catch (err) {
     if ((err?.status || err?.response?.status) === 422 && retry422) {
-      console.warn('[pr-review.publish] GitHub validation failed; retrying once:', err?.message || err);
+      console.warn('[pr-review.publish] GitHub validation failed; dropping out-of-diff comments and retrying once:', err?.message || err);
+      // A 422 usually means one or more inline comments target a line GitHub
+      // does not consider part of the diff. Rebuild the diff line index, keep
+      // only placeable comments, and retry once. Dropped findings remain in the
+      // summary table built by buildPrReviewBody, so nothing is lost.
+      let retryComments = payload.comments;
+      try {
+        const diffLineIndex = await fetchPrDiffLineIndex(octokit, owner, repo, review.pr_number);
+        retryComments = (payload.comments || []).filter((comment) => lineExistsInDiff(diffLineIndex, comment.path, comment.line));
+      } catch (diffErr) {
+        console.warn('[pr-review.publish] could not rebuild diff index for retry:', diffErr?.message || diffErr);
+      }
       await sleep(100);
-      response = await octokit.rest.pulls.createReview(payload);
+      response = await octokit.rest.pulls.createReview({ ...payload, comments: retryComments });
     } else {
       throw err;
     }
@@ -1562,6 +1636,118 @@ const publishPrReviewEndpoint = async (req, res) => {
     const mapped = mapPrPublishGithubError(err);
     console.error('[pr-review.publish] Failed:', err?.status || err?.response?.status, err?.message || err);
     return res.status(mapped.http).json({ error: mapped.message, code: mapped.code });
+  }
+};
+
+// ─── US-076: CI status check ──────────────────────────────────────────────────
+
+const CI_POLL_INTERVAL_MS = 3000;
+
+function parseFailOnSeverity(raw) {
+  const allowed = ['critical', 'high', 'medium', 'low'];
+  const parsed = String(raw || 'critical,high')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => allowed.includes(value));
+  return new Set(parsed.length ? parsed : ['critical', 'high']);
+}
+
+async function fetchLatestReviewForHead(repoId, prNumber, headSha) {
+  const { data } = await supabaseAdmin
+    .from('pr_reviews')
+    .select('id, status, findings_json, severity_counts, total_findings, summary, pr_number, pr_head_sha')
+    .eq('repo_id', repoId)
+    .eq('pr_number', prNumber)
+    .eq('pr_head_sha', headSha)
+    .order('created_at', { ascending: false })
+    .maybeSingle();
+  return data || null;
+}
+
+// POST /api/repos/:repoId/pulls/:number/reviews/ci-check  (authenticated by a CI token).
+// Blocks until the latest review for the PR head is ready (auto-triggering one if
+// none exists), then returns pass/fail based on fail_on_severity.
+const ciCheckReview = async (req, res) => {
+  const repoId = req.ciAuth?.repoId || req.params.repoId;
+  const prNumber = Number(req.params.number);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return res.status(400).json({ error: 'Valid pull request number is required' });
+  }
+
+  const failOn = parseFailOnSeverity(req.body?.fail_on_severity ?? req.query?.fail_on_severity);
+  const timeoutSeconds = Math.min(900, Math.max(30,
+    Number(req.body?.wait_timeout_seconds ?? req.query?.wait_timeout_seconds) || 300));
+  const deadline = Date.now() + timeoutSeconds * 1000;
+
+  try {
+    const { data: repoRow } = await supabaseAdmin
+      .from('repositories')
+      .select('id, user_id, full_name, name, source')
+      .eq('id', repoId)
+      .maybeSingle();
+    if (!repoRow) return res.status(404).json({ error: 'Repository not found' });
+    const fullName = repoRow.full_name || repoRow.name || '';
+    if (repoRow.source !== 'github' || !fullName.includes('/')) {
+      return res.status(400).json({ error: 'Only GitHub-connected repositories support CI checks' });
+    }
+
+    const githubToken = await getGithubTokenForUser(repoRow.user_id);
+    if (!githubToken) return res.status(401).json({ error: 'Repository owner GitHub token is unavailable' });
+
+    const [owner, repo] = fullName.split('/');
+    const octokit = getOctokit(githubToken);
+    const pr = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    const headSha = pr.data.head.sha;
+
+    let review = await fetchLatestReviewForHead(repoId, prNumber, headSha);
+
+    // Auto-trigger when no usable review exists for this head SHA (CI may run
+    // before the webhook fires, or webhooks may not be configured at all).
+    if (!review || review.status === 'failed') {
+      await runPrReviewBackground({ repoId, prNumber, owner, repo, githubToken, userId: repoRow.user_id, send: () => {} });
+      review = await fetchLatestReviewForHead(repoId, prNumber, headSha);
+    }
+
+    // Otherwise a webhook-triggered run may still be in flight — poll until terminal.
+    while (review && (review.status === 'analyzing' || review.status === 'pending')) {
+      if (Date.now() >= deadline) break;
+      await sleep(CI_POLL_INTERVAL_MS);
+      review = await fetchLatestReviewForHead(repoId, prNumber, headSha);
+    }
+
+    const reviewLink = review ? getCodeLensReviewLink(repoId, review.id) : getCodeLensReviewLink(repoId, '');
+
+    if (!review || review.status !== 'ready') {
+      // Fail closed: a guardrail check should block when it cannot confirm a clean review.
+      const summary = !review
+        ? 'CodeLens could not produce a review for this pull request.'
+        : review.status === 'failed'
+          ? 'CodeLens PR review failed to complete.'
+          : `CodeLens PR review did not finish within ${timeoutSeconds}s.`;
+      return res.status(200).json({
+        status: 'fail',
+        severity_counts: normalizeSeverityCounts(review?.severity_counts || {}),
+        summary_markdown: summary,
+        codelens_url: reviewLink,
+        timed_out: Boolean(review && review.status !== 'failed'),
+      });
+    }
+
+    const findings = Array.isArray(review.findings_json) ? review.findings_json : [];
+    const severityCounts = review.severity_counts && typeof review.severity_counts === 'object'
+      ? normalizeSeverityCounts(review.severity_counts)
+      : getSeverityCounts(findings);
+    const failed = [...failOn].some((severity) => Number(severityCounts[severity] || 0) > 0);
+
+    return res.status(200).json({
+      status: failed ? 'fail' : 'pass',
+      severity_counts: severityCounts,
+      summary_markdown: buildPrReviewBody({ review, findings, severityCounts, reviewLink }),
+      codelens_url: reviewLink,
+    });
+  } catch (err) {
+    console.error('[pr-review.ci-check] Failed:', err?.status || err?.response?.status, err?.message || err);
+    return res.status(502).json({ error: 'CI check failed to complete.' });
   }
 };
 
@@ -2979,6 +3165,7 @@ module.exports = {
   runPrReview,
   runPrReviewBackground,
   publishPrReviewEndpoint,
+  ciCheckReview,
   listPullRequests,
   listPullRequestReviews,
   getPrReviewDetail,
@@ -2986,6 +3173,8 @@ module.exports = {
   getSecurityAudit,
   duplicationRefactor,
   generatePrFindingProposal,
+  updatePrFindingProposalStatus,
+  applyPrFindingProposalAsPr,
   generateProposal,
   updateProposalStatus,
   applyProposalAsPr,

--- a/backend/src/controllers/toursController.js
+++ b/backend/src/controllers/toursController.js
@@ -7,6 +7,7 @@ const Anthropic         = require('@anthropic-ai/sdk');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage }   = require('../services/usageTracker');
 const { bindRequestAbort } = require('../lib/sseAbort');
+const { enqueueNotification } = require('../services/notifications'); // US-077
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -706,6 +707,22 @@ const forkTour = async (req, res) => {
     .select('id, tour_id, step_order, file_path, start_line, end_line, explanation')
     .eq('tour_id', newTourId)
     .order('step_order', { ascending: true });
+
+  // US-077: notify the original tour's author that their tour was forked.
+  if (sourceTour.created_by && sourceTour.created_by !== userId) {
+    try {
+      await enqueueNotification({
+        user_ids: [sourceTour.created_by],
+        repo_id: sourceTour.repo_id,
+        type: 'tour_shared',
+        severity: 'info',
+        payload: { source_tour_id: tourId, forked_tour_id: newTourId, forked_by: userId },
+        link_url: `/repo/${sourceTour.repo_id}?tab=tours&tour=${tourId}`,
+      });
+    } catch (notifyErr) {
+      console.warn('[forkTour] notification emission failed:', notifyErr.message || notifyErr);
+    }
+  }
 
   return res.status(201).json({ tour, steps: steps || [] });
 };

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -131,6 +131,13 @@ const handleGitHubPush = async (req, res) => {
     return res.status(200).json({ ok: true, skipped: 'push not to default branch' });
   }
 
+  // Auto-sync is opt-in per repo (US-028). Pushes only re-index when enabled.
+  // PR-review events above have their own opt-in (pr_review_enabled), which is
+  // why the repo lookup no longer filters on auto_sync_enabled.
+  if (!repo.auto_sync_enabled) {
+    return res.status(200).json({ ok: true, skipped: 'auto-sync disabled' });
+  }
+
   // Fire-and-forget re-index (US-028). For US-050, hand the payload's commit
   // SHAs to the indexer so the churn phase updates only changed files instead
   // of re-fetching the full 12-month history.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -19,6 +19,7 @@ const usageRoutes    = require('./routes/usage');
 const adminRoutes    = require('./routes/admin');
 const toursRoutes    = require('./routes/tours');
 const agentRoutes    = require('./routes/agent');
+const notificationRoutes = require('./routes/notifications');
 const errorHandler   = require('./middleware/errorHandler');
 const { requestTimingMiddleware } = require('./observability/requestStore');
 
@@ -84,6 +85,7 @@ app.use('/api/usage',     usageRoutes);
 app.use('/api/admin',     adminRoutes);
 app.use('/api/repos',    toursRoutes);
 app.use('/api',           agentRoutes);
+app.use('/api/notifications', notificationRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 

--- a/backend/src/middleware/ciTokenAuth.js
+++ b/backend/src/middleware/ciTokenAuth.js
@@ -1,0 +1,75 @@
+const crypto = require('crypto');
+const { supabaseAdmin } = require('../db/supabase');
+
+/**
+ * Hash a CI token the same way it is stored: HMAC-SHA256 with a server secret.
+ * Deterministic so the per-request lookup is a single indexed query on
+ * repo_api_tokens.token_hash. The plaintext token is never stored.
+ */
+function hashCiToken(token) {
+  const secret = process.env.CI_TOKEN_HMAC_SECRET || '';
+  return crypto.createHmac('sha256', secret).update(token).digest('hex');
+}
+
+/**
+ * Authenticates a per-repo CI token (US-076). Expects:
+ *   Authorization: Bearer codelens_pat_<token>
+ * Resolves the token to a single repo and enforces that it matches :repoId in
+ * the route. On success sets req.ciAuth = { repoId, tokenId, scope: 'ci_check' }.
+ * This is a parallel to requireAuth, but it resolves a repo rather than a user.
+ */
+const requireCiToken = async (req, res, next) => {
+  try {
+    if (!process.env.CI_TOKEN_HMAC_SECRET) {
+      console.error('[ciTokenAuth] CI_TOKEN_HMAC_SECRET is not configured');
+      return res.status(500).json({ error: 'CI token verification is not configured on this server' });
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    }
+
+    const token = authHeader.slice('Bearer '.length).trim();
+    if (!token.startsWith('codelens_pat_')) {
+      return res.status(401).json({ error: 'Invalid CI token' });
+    }
+
+    const tokenHash = hashCiToken(token);
+    const { data: row, error } = await supabaseAdmin
+      .from('repo_api_tokens')
+      .select('id, repo_id, revoked_at')
+      .eq('token_hash', tokenHash)
+      .is('revoked_at', null)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[ciTokenAuth] token lookup failed:', error.message);
+      return res.status(500).json({ error: 'Failed to verify CI token' });
+    }
+    if (!row) {
+      return res.status(401).json({ error: 'Invalid or revoked CI token' });
+    }
+
+    // Scope: a CI token may only act on the repo it was issued for.
+    if (req.params.repoId && row.repo_id !== req.params.repoId) {
+      return res.status(403).json({ error: 'CI token is not authorized for this repository' });
+    }
+
+    req.ciAuth = { repoId: row.repo_id, tokenId: row.id, scope: 'ci_check' };
+
+    // Fire-and-forget usage stamp; never blocks the request.
+    supabaseAdmin
+      .from('repo_api_tokens')
+      .update({ last_used_at: new Date().toISOString() })
+      .eq('id', row.id)
+      .then(() => {}, (err) => console.warn('[ciTokenAuth] failed to stamp last_used_at:', err?.message || err));
+
+    next();
+  } catch (err) {
+    console.error('[ciTokenAuth] unexpected error:', err);
+    return res.status(500).json({ error: 'Failed to verify CI token' });
+  }
+};
+
+module.exports = { requireCiToken, hashCiToken };

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const notificationsController = require('../controllers/notificationsController');
+const { requireAuth } = require('../middleware/auth');
+
+// US-077: in-app notification feed (all user-scoped)
+router.get('/', requireAuth, notificationsController.listNotifications);
+router.get('/unread-count', requireAuth, notificationsController.unreadCount);
+router.post('/mark-all-read', requireAuth, notificationsController.markAllRead);
+router.post('/:id/read', requireAuth, notificationsController.markRead);
+
+module.exports = router;

--- a/backend/src/routes/repo.js
+++ b/backend/src/routes/repo.js
@@ -63,4 +63,14 @@ router.get('/:repoId/pulls/:number/reviews', requireAuth, reviewController.listP
 router.post('/:repoId/pulls/:number/reviews', requireAuth, reviewController.runPrReview);
 router.post('/:repoId/reviews/:reviewId/publish', requireAuth, reviewController.publishPrReviewEndpoint);
 
+// CI status check (US-076) — authenticated by a per-repo CI token, NOT a user JWT
+const { requireCiToken } = require('../middleware/ciTokenAuth');
+router.post('/:repoId/pulls/:number/reviews/ci-check', requireCiToken, reviewController.ciCheckReview);
+
+// CI token management (US-076) — user-authenticated, gated by repo access
+const ciTokenController = require('../controllers/ciTokenController');
+router.post('/:repoId/ci-tokens', requireAuth, ciTokenController.createCiToken);
+router.get('/:repoId/ci-tokens', requireAuth, ciTokenController.listCiTokens);
+router.delete('/:repoId/ci-tokens/:tokenId', requireAuth, ciTokenController.revokeCiToken);
+
 module.exports = router;

--- a/backend/src/routes/review.js
+++ b/backend/src/routes/review.js
@@ -12,6 +12,8 @@ router.post('/:repoId/duplication-refactor', requireAuth, aiRateLimit, reviewCon
 
 // US-064: refactor proposal generation. Optional ?regenerate=true skips the cache.
 router.post('/:repoId/pr-findings/proposals', requireAuth, aiRateLimit, reviewController.generatePrFindingProposal);
+router.patch('/:repoId/pr-findings/proposals/:proposalId', requireAuth, reviewController.updatePrFindingProposalStatus);
+router.post('/:repoId/pr-findings/proposals/:proposalId/apply', requireAuth, reviewController.applyPrFindingProposalAsPr);
 router.post('/:repoId/issues/:issueId/proposals', requireAuth, aiRateLimit, reviewController.generateProposal);
 router.patch('/:repoId/issues/:issueId/proposals/:proposalId', requireAuth, reviewController.updateProposalStatus);
 

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -13,6 +13,7 @@ const { recordUsage } = require('./usageTracker'); // US-042
 const { isManifestFile, parseManifest } = require('./manifestParser'); // US-045
 const { scanDependencies } = require('./osvScanner'); // US-045
 const { generateStartHereTour } = require('./startHereTourService'); // US-059
+const { enqueueNotification, recipientsForRepo } = require('./notifications'); // US-077
 const { OpenAI } = require('openai');
 const { supabaseAdmin } = require('../db/supabase');
 const { SAFE_FETCH_CEILING, warnIfCeilingHit, withSupabaseRetry } = require('../lib/dbHelpers');
@@ -707,6 +708,45 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     // chunking, duplicate detection, or churn work finishes.
     await markRepoReady({ repoId, fileCount, hasCoverageFiles, finalNodes, latestIndexedSha });
 
+    // US-077: notify recipients that the index is ready and surface newly-introduced
+    // critical/high issues + vulnerabilities. Best-effort — never blocks the pipeline.
+    // The 30-day dedup_key prevents re-notifying for issues seen on a prior index.
+    try {
+      const recipients = await recipientsForRepo(repoId);
+      if (recipients.length > 0) {
+        await enqueueNotification({
+          user_ids: recipients,
+          repo_id: repoId,
+          type: 'index_ready',
+          severity: 'info',
+          payload: { file_count: fileCount },
+          link_url: `/repo/${repoId}`,
+        });
+
+        const { data: importantIssues } = await supabaseAdmin
+          .from('analysis_issues')
+          .select('id, type, severity, file_paths, description')
+          .eq('repo_id', repoId)
+          .in('severity', ['critical', 'high']);
+
+        for (const issue of importantIssues || []) {
+          const filePath = Array.isArray(issue.file_paths) ? issue.file_paths[0] : null;
+          const isVuln = issue.type === 'vulnerable_dependency';
+          await enqueueNotification({
+            user_ids: recipients,
+            repo_id: repoId,
+            type: isVuln ? 'new_vulnerability' : 'new_critical_issue',
+            severity: issue.severity === 'critical' ? 'critical' : 'warning',
+            payload: { issue_id: issue.id, file_path: filePath, rule_id: issue.type, message: issue.description },
+            link_url: `/repo/${repoId}/issues?issue=${issue.id}`,
+            dedup_key: `${issue.type}::${filePath || ''}::${(issue.description || '').slice(0, 80)}`,
+          });
+        }
+      }
+    } catch (notifyErr) {
+      console.warn('[indexer] notification emission failed:', notifyErr.message || notifyErr);
+    }
+
     // 10. Store full file contents (US-043) — only for changed/new files
     // Unchanged files already have their content rows in the DB.
     const FILE_SIZE_CAP = 1024 * 1024; // 1 MB
@@ -1056,6 +1096,27 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
           status: 'failed'
         })
         .eq('id', repoId);
+
+      // US-077: notify the repo owner that indexing failed (owner only).
+      try {
+        const { data: repoRow } = await supabaseAdmin
+          .from('repositories')
+          .select('user_id')
+          .eq('id', repoId)
+          .maybeSingle();
+        if (repoRow?.user_id) {
+          await enqueueNotification({
+            user_ids: [repoRow.user_id],
+            repo_id: repoId,
+            type: 'index_failed',
+            severity: 'warning',
+            payload: { message: error.message || 'Indexing failed' },
+            link_url: `/repo/${repoId}`,
+          });
+        }
+      } catch (notifyErr) {
+        console.warn('[indexer] index_failed notification emission failed:', notifyErr.message || notifyErr);
+      }
     }
 
     console.error(`[indexer] Failed pipeline for repoId ${repoId}:`, error.message);

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -1,0 +1,108 @@
+/**
+ * US-077 — in-app notification dispatch.
+ *
+ * enqueueNotification() writes one row per recipient. For repeatable events
+ * (new_critical_issue / new_vulnerability) pass a `dedup_key` so re-indexing a
+ * repo with pre-existing issues does not spam duplicate notifications — any
+ * (user, repo, type, dedup_key) seen in the last 30 days is skipped.
+ *
+ * All emission is best-effort: callers wrap in try/catch and never block their
+ * pipeline on a notification failure.
+ */
+const { supabaseAdmin } = require('../db/supabase');
+const { withSupabaseRetry } = require('../lib/dbHelpers');
+
+const DEDUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the set of user ids who can see a repo: the owner plus members of any
+ * team the repo is shared with.
+ */
+async function recipientsForRepo(repoId) {
+  const ids = new Set();
+  try {
+    const { data: repo } = await supabaseAdmin
+      .from('repositories')
+      .select('user_id')
+      .eq('id', repoId)
+      .maybeSingle();
+    if (repo?.user_id) ids.add(repo.user_id);
+
+    const { data: teamRepos } = await supabaseAdmin
+      .from('team_repositories')
+      .select('team_id')
+      .eq('repo_id', repoId);
+    const teamIds = (teamRepos || []).map((row) => row.team_id).filter(Boolean);
+    if (teamIds.length > 0) {
+      const { data: members } = await supabaseAdmin
+        .from('team_members')
+        .select('user_id')
+        .in('team_id', teamIds);
+      for (const member of members || []) {
+        if (member.user_id) ids.add(member.user_id);
+      }
+    }
+  } catch (err) {
+    console.warn('[notifications] recipientsForRepo failed:', err.message || err);
+  }
+  return [...ids];
+}
+
+/**
+ * Insert a notification for each recipient.
+ * @param {Object} opts
+ * @param {string[]} opts.user_ids - recipient user ids
+ * @param {string} [opts.repo_id]
+ * @param {string} opts.type - notification_type enum value
+ * @param {string} [opts.severity] - 'info' | 'warning' | 'critical'
+ * @param {Object} [opts.payload] - type-specific data (stored in payload_json)
+ * @param {string} [opts.link_url] - deep link into the app
+ * @param {string} [opts.dedup_key] - if set, skip users notified for the same
+ *   (repo, type, dedup_key) within the last 30 days
+ * @returns {Promise<number>} number of rows inserted
+ */
+async function enqueueNotification({ user_ids, repo_id = null, type, severity = 'info', payload = {}, link_url = null, dedup_key = null }) {
+  try {
+    let recipients = [...new Set((user_ids || []).filter(Boolean))];
+    if (recipients.length === 0 || !type) return 0;
+
+    if (dedup_key) {
+      const since = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
+      const { data: existing } = await supabaseAdmin
+        .from('notifications')
+        .select('user_id, payload_json')
+        .eq('repo_id', repo_id)
+        .eq('type', type)
+        .gte('created_at', since)
+        .in('user_id', recipients);
+      const seen = new Set(
+        (existing || [])
+          .filter((row) => row.payload_json?.dedup_key === dedup_key)
+          .map((row) => row.user_id),
+      );
+      recipients = recipients.filter((id) => !seen.has(id));
+      if (recipients.length === 0) return 0;
+    }
+
+    const payloadJson = dedup_key ? { ...payload, dedup_key } : payload;
+    const rows = recipients.map((userId) => ({
+      user_id: userId,
+      repo_id,
+      type,
+      severity,
+      payload_json: payloadJson,
+      link_url,
+    }));
+
+    await withSupabaseRetry(
+      () => supabaseAdmin.from('notifications').insert(rows),
+      { label: 'notifications.insert' },
+    );
+    return rows.length;
+  } catch (err) {
+    console.warn('[notifications] enqueueNotification failed:', err.message || err);
+    return 0;
+  }
+}
+
+module.exports = { enqueueNotification, recipientsForRepo };

--- a/backend/test/api.integration.test.js
+++ b/backend/test/api.integration.test.js
@@ -94,6 +94,14 @@ function createSupabaseMock(handlers) {
       this.filters.push({ op: 'in', column, value });
       return this;
     }
+    is(column, value) {
+      this.filters.push({ op: 'is', column, value });
+      return this;
+    }
+    lt(column, value) {
+      this.filters.push({ op: 'lt', column, value });
+      return this;
+    }
     order(column, opts) {
       this.orderBy = { column, opts };
       return this;
@@ -1512,6 +1520,7 @@ describe('Backend API integration (mocked)', () => {
             full_name: 'owner/repo',
             name: 'repo',
             source: 'github',
+            auto_sync_enabled: true,
             pr_review_enabled: false,
           },
           error: null,
@@ -1539,8 +1548,58 @@ describe('Backend API integration (mocked)', () => {
     queueSpy.mockRestore();
   });
 
+  it('GitHub push webhook skips re-index when auto-sync is disabled', async () => {
+    const { queue } = require('../src/services/queue');
+    const queueSpy = vi.spyOn(queue, 'add').mockImplementation(() => {});
+    const secret = 'webhook-secret';
+    const payload = {
+      ref: 'refs/heads/main',
+      repository: { full_name: 'owner/repo', name: 'repo', owner: { login: 'owner' } },
+      commits: [{ id: 'commit-1' }],
+    };
+    const raw = JSON.stringify(payload);
+    const signature = `sha256=${crypto.createHmac('sha256', secret).update(Buffer.from(raw)).digest('hex')}`;
+
+    supabaseAdminMock = createSupabaseMock({
+      'repositories.select.maybeSingle': async () => ({
+        data: {
+          id: 'repo-1',
+          user_id: 'user-1',
+          webhook_secret: secret,
+          default_branch: 'main',
+          full_name: 'owner/repo',
+          name: 'repo',
+          source: 'github',
+          auto_sync_enabled: false,
+          pr_review_enabled: false,
+        },
+        error: null,
+      }),
+      'profiles.select.single': async () => ({ data: { github_token_secret_id: 'secret-1' }, error: null }),
+      'rpc.get_github_token_secret': async () => ({ data: 'gh-token', error: null }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const webhookController = (await import('../src/controllers/webhookController.js')).default || await import('../src/controllers/webhookController.js');
+    const app = express();
+    app.post('/api/webhooks/github', express.raw({ type: '*/*' }), webhookController.handleGitHubPush);
+
+    const res = await request(app)
+      .post('/api/webhooks/github')
+      .set('content-type', 'application/json')
+      .set('x-github-event', 'push')
+      .set('x-hub-signature-256', signature)
+      .send(raw)
+      .expect(200);
+
+    expect(res.body).toEqual(expect.objectContaining({ skipped: 'auto-sync disabled' }));
+    expect(queueSpy).not.toHaveBeenCalled();
+    queueSpy.mockRestore();
+  });
+
   it('US-072 schema keeps PR review persistence aligned with acceptance criteria', () => {
-    const schema = readFileSync(new URL('../../scripts/schema.sql', import.meta.url), 'utf8');
+    // Normalize CRLF so the multi-line assertions below match on Windows checkouts.
+    const schema = readFileSync(new URL('../../scripts/schema.sql', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
     expect(schema).toContain("findings_json  JSONB NOT NULL DEFAULT '[]'::jsonb");
     expect(schema).toContain("CREATE TYPE pr_review_status AS ENUM ('pending', 'analyzing', 'ready', 'failed', 'stale')");
@@ -1556,5 +1615,183 @@ describe('Backend API integration (mocked)', () => {
     expect(schema).toContain('ON pr_review_comments FOR ALL');
     expect(schema).toContain('AND can_access_repo(pr.repo_id, auth.uid())');
     expect(schema).toContain('WITH CHECK (\n    EXISTS (\n      SELECT 1 FROM pr_reviews pr');
+  });
+
+  // ─── US-076: CI tokens + CI check ──────────────────────────────────────────
+
+  it('US-076 generates a CI token once and never returns the hash', async () => {
+    process.env.CI_TOKEN_HMAC_SECRET = 'test-secret';
+    supabaseAdminMock = createSupabaseMock({
+      'rpc.can_access_repo': async () => ({ data: true, error: null }),
+      'repo_api_tokens.insert.single': async (state) => ({
+        data: { id: 'tok-1', name: state.payload.name, created_at: '2026-01-01T00:00:00Z' },
+        error: null,
+      }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const ciTokenController = (await import('../src/controllers/ciTokenController.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.post('/api/repos/:repoId/ci-tokens', (req, _res, next) => { req.user = { id: 'user-1' }; next(); }, wrap(ciTokenController.createCiToken));
+    app.use((err, _req, res, _next) => res.status(500).json({ error: err.message || 'error' }));
+
+    const res = await request(app).post('/api/repos/repo-1/ci-tokens').send({ name: 'CI token' }).expect(201);
+    expect(res.body.token).toMatch(/^codelens_pat_/);
+    expect(res.body).not.toHaveProperty('token_hash');
+    expect(res.body.id).toBe('tok-1');
+  });
+
+  it('US-076 CI token middleware rejects a token scoped to a different repo', async () => {
+    process.env.CI_TOKEN_HMAC_SECRET = 'test-secret';
+    supabaseAdminMock = createSupabaseMock({
+      'repo_api_tokens.select.maybeSingle': async () => ({ data: { id: 'tok-1', repo_id: 'repo-OTHER', revoked_at: null }, error: null }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const { requireCiToken } = (await import('../src/middleware/ciTokenAuth.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.post('/api/repos/:repoId/x', requireCiToken, (req, res) => res.json({ ok: true }));
+
+    await request(app)
+      .post('/api/repos/repo-1/x')
+      .set('Authorization', 'Bearer codelens_pat_abc')
+      .expect(403);
+  });
+
+  it('US-076 ci-check returns fail when blocking findings exist for the head SHA', async () => {
+    process.env.CI_TOKEN_HMAC_SECRET = 'test-secret';
+    globalThis.__CODELENS_GITHUB_TOKEN__ = 'owner-token';
+    globalThis.__CODELENS_OCTOKIT__ = {
+      Octokit: class {
+        get rest() {
+          return { pulls: { get: async () => ({ data: { head: { sha: 'headsha123' }, base: { sha: 'base' } } }) } };
+        }
+      },
+    };
+    supabaseAdminMock = createSupabaseMock({
+      'repo_api_tokens.select.maybeSingle': async () => ({ data: { id: 'tok-1', repo_id: 'repo-1', revoked_at: null }, error: null }),
+      'repositories.select.maybeSingle': async () => ({ data: { id: 'repo-1', user_id: 'owner-user', full_name: 'owner/repo', source: 'github' }, error: null }),
+      'pr_reviews.select.maybeSingle': async () => ({
+        data: { id: 'review-1', status: 'ready', pr_number: 42, pr_head_sha: 'headsha123', findings_json: [], severity_counts: { critical: 1, high: 0, medium: 0, low: 0 } },
+        error: null,
+      }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const reviewController = await import('../src/controllers/reviewController.js');
+    const { requireCiToken } = (await import('../src/middleware/ciTokenAuth.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.post('/api/repos/:repoId/pulls/:number/reviews/ci-check', requireCiToken, wrap(reviewController.default.ciCheckReview));
+    app.use((err, _req, res, _next) => res.status(500).json({ error: err.message || 'error' }));
+
+    const res = await request(app)
+      .post('/api/repos/repo-1/pulls/42/reviews/ci-check')
+      .set('Authorization', 'Bearer codelens_pat_abc')
+      .send({ fail_on_severity: 'critical,high' })
+      .expect(200);
+    expect(res.body.status).toBe('fail');
+    expect(res.body.severity_counts.critical).toBe(1);
+    expect(res.body.codelens_url).toContain('review-1');
+  });
+
+  it('US-076 ci-check passes when no severity matches fail_on_severity', async () => {
+    process.env.CI_TOKEN_HMAC_SECRET = 'test-secret';
+    globalThis.__CODELENS_GITHUB_TOKEN__ = 'owner-token';
+    globalThis.__CODELENS_OCTOKIT__ = {
+      Octokit: class {
+        get rest() {
+          return { pulls: { get: async () => ({ data: { head: { sha: 'headsha123' }, base: { sha: 'base' } } }) } };
+        }
+      },
+    };
+    supabaseAdminMock = createSupabaseMock({
+      'repo_api_tokens.select.maybeSingle': async () => ({ data: { id: 'tok-1', repo_id: 'repo-1', revoked_at: null }, error: null }),
+      'repositories.select.maybeSingle': async () => ({ data: { id: 'repo-1', user_id: 'owner-user', full_name: 'owner/repo', source: 'github' }, error: null }),
+      'pr_reviews.select.maybeSingle': async () => ({
+        data: { id: 'review-2', status: 'ready', pr_number: 7, pr_head_sha: 'headsha123', findings_json: [], severity_counts: { critical: 0, high: 0, medium: 2, low: 1 } },
+        error: null,
+      }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const reviewController = await import('../src/controllers/reviewController.js');
+    const { requireCiToken } = (await import('../src/middleware/ciTokenAuth.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.post('/api/repos/:repoId/pulls/:number/reviews/ci-check', requireCiToken, wrap(reviewController.default.ciCheckReview));
+
+    const res = await request(app)
+      .post('/api/repos/repo-1/pulls/7/reviews/ci-check')
+      .set('Authorization', 'Bearer codelens_pat_abc')
+      .send({ fail_on_severity: 'critical,high' })
+      .expect(200);
+    expect(res.body.status).toBe('pass');
+  });
+
+  // ─── US-077: notifications ─────────────────────────────────────────────────
+
+  it('US-077 enqueueNotification skips users already notified for the same dedup_key', async () => {
+    let inserted = null;
+    supabaseAdminMock = createSupabaseMock({
+      'notifications.select.many': async () => ({
+        data: [{ user_id: 'user-1', payload_json: { dedup_key: 'k1' } }],
+        error: null,
+      }),
+      'notifications.insert.many': async (state) => { inserted = state.payload; return { data: state.payload, error: null }; },
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const { enqueueNotification } = await import('../src/services/notifications.js');
+
+    const skipped = await enqueueNotification({
+      user_ids: ['user-1'], repo_id: 'repo-1', type: 'new_critical_issue', dedup_key: 'k1', payload: {},
+    });
+    expect(skipped).toBe(0);
+    expect(inserted).toBeNull();
+
+    const wrote = await enqueueNotification({
+      user_ids: ['user-1'], repo_id: 'repo-1', type: 'new_critical_issue', dedup_key: 'k2', payload: {},
+    });
+    expect(wrote).toBe(1);
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].payload_json.dedup_key).toBe('k2');
+  });
+
+  it('US-077 notification feed endpoints are user-scoped', async () => {
+    const updates = [];
+    supabaseAdminMock = createSupabaseMock({
+      'notifications.select.many': async (state) => {
+        // unread-count uses head/count; list returns rows
+        if (state.columns === 'id') return { count: 3, data: null, error: null };
+        return { data: [
+          { id: 'n1', type: 'index_ready', severity: 'info', payload_json: {}, link_url: '/repo/r', read_at: null, created_at: '2026-01-02T00:00:00Z' },
+          { id: 'n2', type: 'pr_review_ready', severity: 'warning', payload_json: {}, link_url: '/repo/r', read_at: null, created_at: '2026-01-01T00:00:00Z' },
+        ], error: null };
+      },
+      'notifications.update.many': async (state) => { updates.push(state); return { data: null, error: null }; },
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+
+    const notificationsController = (await import('../src/controllers/notificationsController.js')).default;
+    const app = express();
+    app.use(express.json());
+    const inject = (req, _res, next) => { req.user = { id: 'user-1' }; next(); };
+    app.get('/api/notifications', inject, wrap(notificationsController.listNotifications));
+    app.get('/api/notifications/unread-count', inject, wrap(notificationsController.unreadCount));
+    app.post('/api/notifications/mark-all-read', inject, wrap(notificationsController.markAllRead));
+    app.use((err, _req, res, _next) => res.status(500).json({ error: err.message || 'error' }));
+
+    const list = await request(app).get('/api/notifications?limit=20').expect(200);
+    expect(list.body.notifications).toHaveLength(2);
+    expect(list.body.has_more).toBe(false);
+
+    const count = await request(app).get('/api/notifications/unread-count').expect(200);
+    expect(count.body.unread).toBe(3);
+
+    await request(app).post('/api/notifications/mark-all-read').expect(200);
+    expect(updates.length).toBe(1);
   });
 });

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -1,0 +1,76 @@
+# CodeLens CI Integration (US-076)
+
+Run CodeLens's deterministic PR review from inside CI and surface the result as a
+GitHub status check. PRs with `critical`/`high` findings can then be blocked via a
+required check + branch protection.
+
+## 1. Generate a CI token
+
+In CodeLens: **Repo → Settings → CI Integration → Generate token**. The token
+(`codelens_pat_…`) is shown **once** — copy it immediately. It is scoped to that one
+repository and can only call the CI-check endpoint.
+
+Store it as a repository **Actions secret**, e.g. `CODELENS_API_TOKEN`.
+
+You'll also need your **CodeLens repo UUID** (shown in the same settings page / repo URL).
+
+## 2. Add the workflow
+
+For v1 the action ships inside this repo at `.github/actions/codelens-review/`, so
+reference it with a local path. (Once published to `codelens/codelens-action`, switch
+to `uses: codelens/codelens-action@v1`.)
+
+```yaml
+name: CodeLens Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  checks: write          # required to publish the status check
+  pull-requests: read
+
+jobs:
+  codelens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/codelens-review
+        with:
+          repo_id: 00000000-0000-0000-0000-000000000000   # your CodeLens repo UUID
+          codelens_api_token: ${{ secrets.CODELENS_API_TOKEN }}
+          fail_on_severity: 'critical,high'                # optional (default)
+          wait_timeout_seconds: '300'                      # optional (default)
+          # codelens_api_url: 'https://app.codelens.dev'   # optional override
+```
+
+## 3. Make it required (optional)
+
+Add **CodeLens Review** as a required status check under
+**Settings → Branches → Branch protection** to block merges when it fails.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `repo_id` | yes | — | CodeLens repository UUID |
+| `codelens_api_token` | yes | — | Per-repo CI token (`codelens_pat_…`) |
+| `fail_on_severity` | no | `critical,high` | Comma-separated severities that fail the check |
+| `wait_timeout_seconds` | no | `300` | Max seconds to wait for the review |
+| `codelens_api_url` | no | `https://app.codelens.dev` | CodeLens API base URL |
+| `github_token` | no | `${{ github.token }}` | Token used to create the check run (`checks:write`) |
+
+## How it works
+
+1. The action POSTs to `POST /api/repos/:repoId/pulls/:number/reviews/ci-check` with the
+   CI token. The endpoint resolves the PR's head SHA, reuses an existing `ready` review
+   for that SHA if present, otherwise **triggers a review and blocks** until it's ready
+   (or the timeout elapses).
+2. The endpoint returns `{ status: 'pass' | 'fail', severity_counts, summary_markdown, codelens_url }`.
+   `fail` means at least one finding's severity is in `fail_on_severity`.
+3. The action writes a GitHub check run (`conclusion: success | failure`) with the summary
+   and fails the step on `fail`.
+
+The token is never stored in plaintext server-side — only an HMAC-SHA256 hash is kept and
+matched on each request.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ const Login        = lazy(() => import('./pages/Login'));
 const AuthCallback = lazy(() => import('./pages/AuthCallback'));
 const Dashboard    = lazy(() => import('./pages/Dashboard'));
 const RepoView     = lazy(() => import('./pages/RepoView'));
+const NotificationsPage = lazy(() => import('./pages/NotificationsPage'));
 
 function AnimatedRoutes() {
   const location = useLocation();
@@ -27,6 +28,7 @@ function AnimatedRoutes() {
             <Route path="/"            element={<Dashboard />} />
             <Route path="/dashboard"   element={<Dashboard />} />
             <Route path="/repo/:repoId" element={<RepoView />} />
+            <Route path="/notifications" element={<NotificationsPage />} />
           </Route>
         </Routes>
       </Suspense>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,6 +4,7 @@ import { useAuth }  from '../context/AuthContext';
 import { useRepo }  from '../context/RepoContext';
 import { apiUrl }   from '../lib/api';
 import OnboardingModal from './OnboardingModal';
+import NotificationBell from './NotificationBell';
 import Tooltip from './ui/Tooltip';
 import { Badge, IconButton } from './ui/Primitives';
 
@@ -245,6 +246,9 @@ export default function Layout() {
               </div>
             </div>
           )}
+
+          {/* Notifications (US-077) */}
+          <NotificationBell collapsed={collapsed} />
 
           {/* Show introduction */}
           <NavItem

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { apiUrl } from '../lib/api';
+import { formatDate } from '../lib/constants';
+import {
+  Bell, CheckCheck, X, ShieldAlert, Package, CheckCircle2, XCircle, GitBranch, Star, Sparkles,
+} from './ui/Icons';
+
+export const TYPE_META = {
+  new_critical_issue: { icon: ShieldAlert, label: 'New critical issue' },
+  new_vulnerability:  { icon: Package,     label: 'New vulnerability' },
+  index_ready:        { icon: CheckCircle2, label: 'Index ready' },
+  index_failed:       { icon: XCircle,     label: 'Index failed' },
+  pr_review_ready:    { icon: GitBranch,   label: 'PR review ready' },
+  proposal_shared:    { icon: Sparkles,    label: 'Proposal shared' },
+  tour_shared:        { icon: Star,        label: 'Tour forked' },
+  webhook_paused:     { icon: XCircle,     label: 'Webhook paused' },
+};
+
+export const SEVERITY_DOT = {
+  critical: 'bg-red-500',
+  warning: 'bg-yellow-500',
+  info: 'bg-sky-500',
+};
+
+export function notificationText(n) {
+  const p = n.payload_json || {};
+  switch (n.type) {
+    case 'new_critical_issue': return p.message || `Critical issue in ${p.file_path || 'a file'}`;
+    case 'new_vulnerability':  return p.message || `Vulnerable dependency detected`;
+    case 'index_ready':        return `Indexing finished${p.file_count ? ` (${p.file_count} files)` : ''}`;
+    case 'index_failed':       return p.message || 'Indexing failed';
+    case 'pr_review_ready':    return `PR #${p.pr_number} review ready — ${p.total_findings || 0} findings`;
+    case 'tour_shared':        return 'Someone forked your tour';
+    default:                   return TYPE_META[n.type]?.label || 'Notification';
+  }
+}
+
+function groupByDay(notifications) {
+  const groups = new Map();
+  for (const n of notifications) {
+    const day = new Date(n.created_at).toDateString();
+    if (!groups.has(day)) groups.set(day, []);
+    groups.get(day).push(n);
+  }
+  return [...groups.entries()];
+}
+
+export default function NotificationBell({ collapsed }) {
+  const { session } = useAuth();
+  const navigate = useNavigate();
+  const token = session?.access_token;
+  const [unread, setUnread] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const wrapRef = useRef(null);
+
+  const fetchUnread = useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetch(apiUrl('/api/notifications/unread-count'), {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setUnread(data.unread || 0);
+    } catch { /* ignore */ }
+  }, [token]);
+
+  const fetchItems = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const res = await fetch(apiUrl('/api/notifications?limit=20'), {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setItems(data.notifications || []);
+    } catch { /* ignore */ } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  // Badge poll: every 60s while the app is in the foreground.
+  useEffect(() => {
+    if (!token) return undefined;
+    fetchUnread();
+    const id = setInterval(() => { if (!document.hidden) fetchUnread(); }, 60_000);
+    return () => clearInterval(id);
+  }, [token, fetchUnread]);
+
+  // Dropdown poll: every 30s while open.
+  useEffect(() => {
+    if (!open) return undefined;
+    fetchItems();
+    const id = setInterval(fetchItems, 30_000);
+    return () => clearInterval(id);
+  }, [open, fetchItems]);
+
+  // Click-outside to close.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handler = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const markRead = useCallback(async (id) => {
+    if (!token) return;
+    try {
+      await fetch(apiUrl(`/api/notifications/${id}/read`), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch { /* ignore */ }
+  }, [token]);
+
+  const handleRowClick = async (n) => {
+    if (!n.read_at) {
+      setItems((prev) => prev.map((x) => (x.id === n.id ? { ...x, read_at: new Date().toISOString() } : x)));
+      setUnread((u) => Math.max(0, u - 1));
+      await markRead(n.id);
+    }
+    setOpen(false);
+    if (n.link_url) navigate(n.link_url);
+  };
+
+  const markAllRead = async () => {
+    if (!token) return;
+    setItems((prev) => prev.map((x) => ({ ...x, read_at: x.read_at || new Date().toISOString() })));
+    setUnread(0);
+    try {
+      await fetch(apiUrl('/api/notifications/mark-all-read'), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch { /* ignore */ }
+  };
+
+  const groups = useMemo(() => groupByDay(items), [items]);
+  const badge = unread > 99 ? '99+' : String(unread);
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Notifications"
+        className={`flex w-full items-center rounded-lg px-3 py-2 text-sm text-gray-400 transition-colors hover:bg-surface-800 hover:text-white ${collapsed ? 'justify-center' : 'gap-3'}`}
+      >
+        <span className="relative">
+          <Bell className="h-5 w-5" />
+          {unread > 0 && (
+            <span className="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+              {badge}
+            </span>
+          )}
+        </span>
+        {!collapsed && <span className="hidden lg:inline">Notifications</span>}
+      </button>
+
+      {open && (
+        <div
+          className="fixed bottom-4 left-20 z-50 flex max-h-[70vh] w-80 flex-col overflow-hidden rounded-xl border border-surface-700 bg-surface-900 shadow-2xl"
+          style={{ animation: 'slideUp 150ms ease both' }}
+        >
+          <div className="flex items-center justify-between border-b border-surface-800 px-4 py-3">
+            <span className="text-sm font-semibold text-white">Notifications</span>
+            <div className="flex items-center gap-2">
+              <button type="button" onClick={markAllRead} className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-white" title="Mark all as read">
+                <CheckCheck className="h-3.5 w-3.5" /> Mark all
+              </button>
+              <button type="button" onClick={() => setOpen(false)} className="text-gray-500 hover:text-white" aria-label="Close">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {loading && items.length === 0 ? (
+              <p className="px-4 py-6 text-center text-sm text-gray-500">Loading...</p>
+            ) : items.length === 0 ? (
+              <p className="px-4 py-6 text-center text-sm text-gray-500">No notifications yet.</p>
+            ) : (
+              groups.map(([day, dayItems]) => (
+                <div key={day}>
+                  <p className="sticky top-0 bg-surface-900/95 px-4 py-1.5 text-[11px] uppercase tracking-wider text-gray-500">{day}</p>
+                  {dayItems.map((n) => {
+                    const Icon = TYPE_META[n.type]?.icon || Bell;
+                    return (
+                      <button
+                        key={n.id}
+                        type="button"
+                        onClick={() => handleRowClick(n)}
+                        className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-800 ${n.read_at ? 'opacity-60' : ''}`}
+                      >
+                        <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${SEVERITY_DOT[n.severity] || 'bg-gray-500'}`} />
+                        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm text-gray-200">{notificationText(n)}</span>
+                          <span className="text-xs text-gray-500">{TYPE_META[n.type]?.label || n.type} · {formatDate(n.created_at)}</span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+
+          <Link
+            to="/notifications"
+            onClick={() => setOpen(false)}
+            className="border-t border-surface-800 px-4 py-2.5 text-center text-xs text-indigo-300 hover:bg-surface-800 hover:text-indigo-200"
+          >
+            View all notifications
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsPanel.jsx
+++ b/frontend/src/components/SettingsPanel.jsx
@@ -4,10 +4,11 @@
  * Extracted from inline SettingsPanel in RepoView.jsx.
  * Handles auto-sync toggle and webhook URL generation.
  */
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { apiUrl } from '../lib/api';
+import { formatDate } from '../lib/constants';
 import { useToast } from './Toast';
-import { RefreshCw, Copy, Check, Zap, Webhook, MessageSquare } from './ui/Icons';
+import { RefreshCw, Copy, Check, Zap, Webhook, MessageSquare, Terminal, Trash2 } from './ui/Icons';
 import { Banner, Button, EmptyState, Panel, Select, Switch } from './ui/Primitives';
 
 export default function SettingsPanel({ repo, session, onRepoUpdated }) {
@@ -18,9 +19,60 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
   const [webhookInfo,  setWebhookInfo]  = useState(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [copied,       setCopied]       = useState('');
+  const [ciTokens,     setCiTokens]     = useState([]);
+  const [newCiToken,   setNewCiToken]   = useState(null);
+  const [isGeneratingToken, setIsGeneratingToken] = useState(false);
   const toast = useToast();
 
   const isGitHub = repo?.source === 'github';
+
+  const fetchCiTokens = useCallback(async () => {
+    if (!repo?.id || !session?.access_token) return;
+    try {
+      const res = await fetch(apiUrl(`/api/repos/${repo.id}/ci-tokens`), {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setCiTokens(data.tokens || []);
+    } catch { /* ignore */ }
+  }, [repo?.id, session?.access_token]);
+
+  useEffect(() => { fetchCiTokens(); }, [fetchCiTokens]);
+
+  const handleGenerateCiToken = async () => {
+    setIsGeneratingToken(true);
+    setNewCiToken(null);
+    try {
+      const res = await fetch(apiUrl(`/api/repos/${repo.id}/ci-tokens`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ name: 'CI token' }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to generate CI token');
+      setNewCiToken(data.token);
+      await fetchCiTokens();
+    } catch (err) {
+      toast.error(err.message || 'Failed to generate CI token');
+    } finally {
+      setIsGeneratingToken(false);
+    }
+  };
+
+  const handleRevokeCiToken = async (tokenId) => {
+    try {
+      const res = await fetch(apiUrl(`/api/repos/${repo.id}/ci-tokens/${tokenId}`), {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to revoke token');
+      setCiTokens((prev) => prev.map((t) => (t.id === tokenId ? { ...t, revoked_at: new Date().toISOString() } : t)));
+      toast.success('CI token revoked');
+    } catch (err) {
+      toast.error(err.message || 'Failed to revoke token');
+    }
+  };
 
   useEffect(() => {
     setAutoSync(repo?.auto_sync_enabled ?? false);
@@ -214,6 +266,64 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
                     {copied === key ? 'Copied' : 'Copy'}
                   </Button>
                 </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Panel>
+
+      {/* CI Integration — per-repo API tokens (US-076) */}
+      <Panel>
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 border border-violet-500/20">
+            <Terminal className="h-4 w-4 text-violet-400" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-white">CI Integration</h3>
+            <p className="mt-1 text-sm text-gray-400 leading-relaxed">
+              Generate a per-repo API token for the CodeLens GitHub Action so CI can run a PR
+              review and report a status check. The token is scoped to this repository and shown once.
+              See <code className="rounded bg-gray-800 px-1 py-0.5 text-xs text-gray-200">docs/ci-integration.md</code>.
+            </p>
+          </div>
+        </div>
+
+        <Button onClick={handleGenerateCiToken} disabled={isGeneratingToken} loading={isGeneratingToken} icon={Terminal}>
+          {isGeneratingToken ? 'Generating...' : 'Generate token'}
+        </Button>
+
+        {newCiToken && (
+          <div className="mt-4 space-y-2" style={{ animation: 'slideUp 200ms ease both' }}>
+            <Banner tone="warning">Copy this token now — it will not be shown again.</Banner>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <code className="flex-1 overflow-auto rounded-lg border border-gray-700 bg-gray-950 px-3 py-2.5 font-mono text-xs text-gray-200 break-all">
+                {newCiToken}
+              </code>
+              <Button onClick={() => handleCopy(newCiToken, 'ci-token')} size="sm" variant="outline" icon={copied === 'ci-token' ? Check : Copy}>
+                {copied === 'ci-token' ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {ciTokens.length > 0 && (
+          <div className="mt-5 space-y-2">
+            <p className="text-xs uppercase tracking-widest text-gray-500">Existing tokens</p>
+            {ciTokens.map((token) => (
+              <div key={token.id} className="flex items-center justify-between gap-3 rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm">
+                <div className="min-w-0">
+                  <span className={`block truncate ${token.revoked_at ? 'text-gray-500 line-through' : 'text-gray-200'}`}>{token.name || 'CI token'}</span>
+                  <span className="text-xs text-gray-500">
+                    Created {formatDate(token.created_at)}
+                    {token.last_used_at ? ` · last used ${formatDate(token.last_used_at)}` : ' · never used'}
+                    {token.revoked_at ? ' · revoked' : ''}
+                  </span>
+                </div>
+                {!token.revoked_at && (
+                  <Button onClick={() => handleRevokeCiToken(token.id)} size="sm" variant="outline" icon={Trash2}>
+                    Revoke
+                  </Button>
+                )}
               </div>
             ))}
           </div>

--- a/frontend/src/components/ui/Icons.jsx
+++ b/frontend/src/components/ui/Icons.jsx
@@ -54,6 +54,8 @@ export {
   AlertCircle,
   XCircle,
   Info,
+  Bell,
+  CheckCheck,
 
   // Actions
   Search,

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { apiUrl } from '../lib/api';
+import { formatDate } from '../lib/constants';
+import { Button, EmptyState, Banner } from '../components/ui/Primitives';
+import { Bell, CheckCheck } from '../components/ui/Icons';
+import { TYPE_META, SEVERITY_DOT, notificationText } from '../components/NotificationBell';
+
+const PAGE_SIZE = 50;
+
+export default function NotificationsPage() {
+  const { session } = useAuth();
+  const navigate = useNavigate();
+  const token = session?.access_token;
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadPage = useCallback(async (before) => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const qs = new URLSearchParams({ limit: String(PAGE_SIZE) });
+      if (before) qs.set('before', before);
+      const res = await fetch(apiUrl(`/api/notifications?${qs.toString()}`), {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Failed to load notifications');
+      setItems((prev) => (before ? [...prev, ...(data.notifications || [])] : data.notifications || []));
+      setCursor(data.next_cursor || null);
+      setHasMore(Boolean(data.has_more));
+    } catch (err) {
+      setError(err.message || 'Failed to load notifications');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => { loadPage(null); }, [loadPage]);
+
+  const markRead = async (n) => {
+    if (!n.read_at) {
+      setItems((prev) => prev.map((x) => (x.id === n.id ? { ...x, read_at: new Date().toISOString() } : x)));
+      try {
+        await fetch(apiUrl(`/api/notifications/${n.id}/read`), {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      } catch { /* ignore */ }
+    }
+    if (n.link_url) navigate(n.link_url);
+  };
+
+  const markAllRead = async () => {
+    setItems((prev) => prev.map((x) => ({ ...x, read_at: x.read_at || new Date().toISOString() })));
+    try {
+      await fetch(apiUrl('/api/notifications/mark-all-read'), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-white">Notifications</h1>
+        <Button variant="outline" size="sm" icon={CheckCheck} onClick={markAllRead}>Mark all as read</Button>
+      </div>
+
+      {error && <Banner tone="danger" className="mb-4">{error}</Banner>}
+
+      {!loading && items.length === 0 ? (
+        <EmptyState icon={Bell} title="No notifications yet" description="New issues, completed indexes, and team activity will show up here." className="py-24" />
+      ) : (
+        <div className="divide-y divide-surface-800 overflow-hidden rounded-xl border border-surface-800 bg-surface-900">
+          {items.map((n) => {
+            const Icon = TYPE_META[n.type]?.icon || Bell;
+            return (
+              <button
+                key={n.id}
+                type="button"
+                onClick={() => markRead(n)}
+                className={`flex w-full items-start gap-3 px-4 py-3.5 text-left transition-colors hover:bg-surface-800 ${n.read_at ? 'opacity-60' : ''}`}
+              >
+                <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${SEVERITY_DOT[n.severity] || 'bg-gray-500'}`} />
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm text-gray-200">{notificationText(n)}</span>
+                  <span className="text-xs text-gray-500">{TYPE_META[n.type]?.label || n.type} · {formatDate(n.created_at)}</span>
+                </span>
+                {!n.read_at && <span className="mt-1 rounded-full bg-indigo-500/15 px-2 py-0.5 text-[10px] font-medium text-indigo-300">New</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {hasMore && (
+        <div className="mt-4 text-center">
+          <Button variant="outline" loading={loading} onClick={() => loadPage(cursor)}>Load more</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -62,15 +62,19 @@ $$;
 REVOKE ALL ON FUNCTION get_github_token_secret FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION get_github_token_secret TO authenticated, service_role;
 
+-- plpgsql (not sql) so the body is validated at first call, not at creation —
+-- this function is defined before the repositories/teams tables it references,
+-- which a LANGUAGE sql body would reject on a fresh database.
 CREATE OR REPLACE FUNCTION can_access_repo(
   p_repo_id UUID,
   p_user_id UUID
 )
 RETURNS BOOLEAN
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
-  SELECT EXISTS (
+BEGIN
+  RETURN EXISTS (
     SELECT 1
     FROM repositories r
     WHERE r.id = p_repo_id
@@ -85,6 +89,7 @@ AS $$
         )
       )
   );
+END;
 $$;
 
 GRANT EXECUTE ON FUNCTION can_access_repo(UUID, UUID) TO authenticated, service_role;
@@ -177,6 +182,41 @@ ALTER TABLE repositories ADD COLUMN IF NOT EXISTS has_coverage_files BOOLEAN NOT
 ALTER TABLE repositories ADD COLUMN IF NOT EXISTS language_stats JSONB DEFAULT '[]';
 ALTER TABLE repositories ADD COLUMN IF NOT EXISTS sast_disabled_rules TEXT[] DEFAULT '{}';
 ALTER TABLE repositories ADD COLUMN IF NOT EXISTS latest_indexed_sha TEXT;
+
+-- Team tables are created here (immediately after repositories) because the
+-- repositories and graph_nodes RLS policies below reference team_repositories /
+-- team_members in inline subqueries, which Postgres validates at policy-creation
+-- time. Their RLS policies are defined later in the TEAMS / ORGANIZATIONS section.
+CREATE TABLE IF NOT EXISTS teams (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       TEXT        NOT NULL,
+  created_by UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS team_members (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id         UUID        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  user_id         UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  github_username TEXT        NOT NULL,
+  role            TEXT        NOT NULL DEFAULT 'member'
+                              CHECK (role IN ('owner', 'member')),
+  joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (team_id, github_username)
+);
+
+CREATE INDEX IF NOT EXISTS team_members_user_id_idx ON team_members (user_id);
+CREATE INDEX IF NOT EXISTS team_members_team_id_idx ON team_members (team_id);
+
+CREATE TABLE IF NOT EXISTS team_repositories (
+  id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  repo_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  UNIQUE (team_id, repo_id)
+);
+
+CREATE INDEX IF NOT EXISTS team_repositories_team_id_idx ON team_repositories (team_id);
+CREATE INDEX IF NOT EXISTS team_repositories_repo_id_idx ON team_repositories (repo_id);
 
 ALTER TABLE repositories ENABLE ROW LEVEL SECURITY;
 
@@ -450,38 +490,9 @@ CREATE POLICY "Users can only access suppressions for their repos"
 
 -- =============================================================================
 -- TEAMS / ORGANIZATIONS
+-- Tables are created earlier (right after repositories) so the repositories /
+-- graph_nodes RLS policies can reference them. Only RLS wiring lives here.
 -- =============================================================================
-
-CREATE TABLE IF NOT EXISTS teams (
-  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  name       TEXT        NOT NULL,
-  created_by UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS team_members (
-  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  team_id         UUID        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
-  user_id         UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
-  github_username TEXT        NOT NULL,
-  role            TEXT        NOT NULL DEFAULT 'member'
-                              CHECK (role IN ('owner', 'member')),
-  joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (team_id, github_username)
-);
-
-CREATE INDEX IF NOT EXISTS team_members_user_id_idx ON team_members (user_id);
-CREATE INDEX IF NOT EXISTS team_members_team_id_idx ON team_members (team_id);
-
-CREATE TABLE IF NOT EXISTS team_repositories (
-  id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
-  repo_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-  UNIQUE (team_id, repo_id)
-);
-
-CREATE INDEX IF NOT EXISTS team_repositories_team_id_idx ON team_repositories (team_id);
-CREATE INDEX IF NOT EXISTS team_repositories_repo_id_idx ON team_repositories (repo_id);
 
 ALTER TABLE teams             ENABLE ROW LEVEL SECURITY;
 ALTER TABLE team_members      ENABLE ROW LEVEL SECURITY;
@@ -1445,6 +1456,79 @@ CREATE POLICY "Users access messages of their conversations"
   WITH CHECK (EXISTS (SELECT 1 FROM agent_conversations c
                        WHERE c.id = agent_messages.conversation_id
                          AND c.user_id = auth.uid()));
+
+-- =============================================================================
+-- US-076: per-repo CI API tokens. Hashed (HMAC-SHA256 with CI_TOKEN_HMAC_SECRET),
+-- never stored or returned in plaintext after creation. Scoped to a single repo
+-- and used only by the CI status-check endpoint.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS repo_api_tokens (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  repo_id      UUID        NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  token_hash   TEXT        NOT NULL,
+  name         TEXT,
+  created_by   UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at   TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS repo_api_tokens_token_hash_idx ON repo_api_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS repo_api_tokens_repo_idx ON repo_api_tokens (repo_id);
+
+ALTER TABLE repo_api_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Management (list/revoke/generate) is gated by repo access. The CI middleware
+-- reads tokens via service_role, bypassing RLS for the per-request hash lookup.
+DROP POLICY IF EXISTS "Users manage CI tokens for their repos" ON repo_api_tokens;
+CREATE POLICY "Users manage CI tokens for their repos"
+  ON repo_api_tokens FOR ALL
+  USING (can_access_repo(repo_id, auth.uid()))
+  WITH CHECK (can_access_repo(repo_id, auth.uid()));
+
+-- =============================================================================
+-- US-077: in-app notifications. One row per recipient user. payload_json is
+-- type-specific so the UI can render rich cards; link_url deep-links into the app.
+-- =============================================================================
+
+DO $$ BEGIN
+  CREATE TYPE notification_type AS ENUM (
+    'new_critical_issue', 'new_vulnerability', 'index_ready', 'index_failed',
+    'pr_review_ready', 'proposal_shared', 'tour_shared', 'webhook_paused'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE notification_severity AS ENUM ('info', 'warning', 'critical');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id           UUID                  PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID                  NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  repo_id      UUID                  REFERENCES repositories(id) ON DELETE CASCADE,
+  type         notification_type     NOT NULL,
+  severity     notification_severity NOT NULL DEFAULT 'info',
+  payload_json JSONB                 NOT NULL DEFAULT '{}'::jsonb,
+  link_url     TEXT,
+  read_at      TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ           NOT NULL DEFAULT NOW()
+);
+
+-- Unread-count badge + ordered feed.
+CREATE INDEX IF NOT EXISTS notifications_user_read_created_idx
+  ON notifications (user_id, read_at, created_at DESC);
+-- De-duplication queries (per user, repo, type).
+CREATE INDEX IF NOT EXISTS notifications_user_repo_type_created_idx
+  ON notifications (user_id, repo_id, type, created_at DESC);
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users access their own notifications" ON notifications;
+CREATE POLICY "Users access their own notifications"
+  ON notifications FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
 
 -- =============================================================================
 -- END OF SCHEMA


### PR DESCRIPTION
US-076 — GitHub Action & PR status check:
- repo_api_tokens table (HMAC-SHA256 hashed, repo-scoped, RLS) + ciTokenAuth
  middleware resolving Bearer codelens_pat_* to a single repo
- ciTokenController: generate (shown once) / list (no hash) / revoke
- ciCheckReview endpoint: resolves head SHA, reuses a ready review or
  auto-triggers runPrReviewBackground and polls until ready/timeout (fail-closed),
  returns pass/fail by fail_on_severity
- zero-dependency Node 20 GitHub Action at .github/actions/codelens-review/
  + docs/ci-integration.md; CI Integration UI in SettingsPanel
- CI_TOKEN_HMAC_SECRET env

US-077 — Notifications (schema + emission + in-app feed):
- notifications table + type/severity enums + dedup/feed indexes (RLS)
- notifications service: enqueueNotification (30-day dedup_key) + recipientsForRepo
- emission wired into indexer (index_ready/failed, new_critical_issue/vulnerability),
  PR review (pr_review_ready), tour fork (tour_shared)
- feed endpoints (list/unread-count/read/mark-all-read), user-scoped
- NotificationBell in Layout sidebar footer + /notifications page

Tests: +6 integration tests (CI token gen/scope, ci-check pass/fail, notification
dedup, feed endpoints); 39/39 pass. Backend + frontend lint clean. CLAUDE.md updated.

Closes #138 
Closes #139 