### PR TITLE
US-082 + US-083 + US-084 completed

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.20.0",
+        "@npmcli/arborist": "^9.7.0",
         "@supabase/supabase-js": "^2.39.0",
+        "@yarnpkg/lockfile": "^1.1.0",
         "adm-zip": "^0.5.16",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -550,6 +552,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -584,6 +595,24 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+      "license": "ISC"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -953,6 +982,450 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+      "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.7.0.tgz",
+      "integrity": "sha512-vmGB7um0yvzZlBi0GzmSRJ/oW2KzjiBdgD5AGbMdiqxg/xemfCsDMyD/DtkXPhZrWsPNtGByiBF1kx//gi/5xA==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "semver": "^7.3.7",
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/installed-package-contents": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@octokit/app": {
@@ -1681,6 +2154,80 @@
         "win32"
       ]
     },
+    "node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
@@ -1758,6 +2305,64 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@tufjs/models/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@tufjs/models/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@tufjs/models/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@types/aws-lambda": {
@@ -1945,6 +2550,21 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1996,6 +2616,15 @@
       "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -2137,6 +2766,22 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/bin-links": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
+      "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2255,6 +2900,89 @@
         "node": ">=8"
       }
     },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2368,12 +3096,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/color-convert": {
@@ -2403,6 +3149,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/component-emitter": {
@@ -2556,11 +3311,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2683,6 +3449,15 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/es-define-property": {
@@ -2967,6 +3742,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -3266,6 +4047,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3388,6 +4181,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3447,6 +4246,33 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3464,6 +4290,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -3507,6 +4359,54 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/ignore-walk": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3556,6 +4456,24 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3646,6 +4564,15 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3657,6 +4584,24 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -3678,6 +4623,18 @@
         "node": ">=12",
         "npm": ">=6"
       }
+    },
+    "node_modules/just-diff": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+      "license": "MIT"
+    },
+    "node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -3809,6 +4766,38 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3881,6 +4870,145 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/morgan": {
@@ -4023,6 +5151,30 @@
         }
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -4031,6 +5183,30 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nodemon": {
@@ -4118,6 +5294,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4125,6 +5316,101 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-bundled": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-assign": {
@@ -4282,6 +5568,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pacote": {
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
+      "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4292,6 +5621,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-conflict-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/parseurl": {
@@ -4342,6 +5685,31 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/path-to-regexp": {
@@ -4419,6 +5787,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4426,6 +5807,42 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/proggy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/proxy-addr": {
@@ -4509,6 +5926,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/readable-stream": {
@@ -4823,6 +6249,35 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sigstore": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -4835,6 +6290,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4842,6 +6335,40 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/stackback": {
@@ -4995,6 +6522,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5017,7 +6560,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -5033,7 +6575,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -5050,7 +6591,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -5285,10 +6825,33 @@
         }
       }
     },
+    "node_modules/treeverse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tuf-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5336,6 +6899,15 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
@@ -5396,6 +6968,15 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/vary": {
@@ -5617,6 +7198,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5684,6 +7274,18 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -5702,6 +7304,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yocto-queue": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",
+    "@npmcli/arborist": "^9.7.0",
     "@supabase/supabase-js": "^2.39.0",
+    "@yarnpkg/lockfile": "^1.1.0",
     "adm-zip": "^0.5.16",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -337,7 +337,16 @@ const getAnalysisData = async (req, res) => {
  */
 const updateRepo = async (req, res) => {
   const { repoId } = req.params;
-  const { auto_sync_enabled, sast_disabled_rules, pr_review_enabled, pr_review_auto_publish, pr_review_block_on_severity } = req.body;
+  const {
+    auto_sync_enabled,
+    sast_disabled_rules,
+    pr_review_enabled,
+    pr_review_auto_publish,
+    pr_review_block_on_severity,
+    dependency_update_strategy,
+    dependency_batch_threshold,
+    dependency_auto_pr_enabled,
+  } = req.body;
 
   const updates = {};
   if (typeof auto_sync_enabled === 'boolean') updates.auto_sync_enabled = auto_sync_enabled;
@@ -354,6 +363,25 @@ const updateRepo = async (req, res) => {
     return res.status(400).json({ error: 'pr_review_block_on_severity must be critical or high' });
   }
   if (['critical', 'high'].includes(pr_review_block_on_severity)) updates.pr_review_block_on_severity = pr_review_block_on_severity;
+
+  // Dependency auto-PR settings (US-084)
+  if (dependency_update_strategy !== undefined) {
+    if (!['minimum_safe', 'latest_safe'].includes(dependency_update_strategy)) {
+      return res.status(400).json({ error: 'dependency_update_strategy must be minimum_safe or latest_safe' });
+    }
+    updates.dependency_update_strategy = dependency_update_strategy;
+  }
+  if (dependency_batch_threshold !== undefined) {
+    const t = parseInt(dependency_batch_threshold, 10);
+    if (isNaN(t) || t < 1 || t > 20) {
+      return res.status(400).json({ error: 'dependency_batch_threshold must be an integer between 1 and 20' });
+    }
+    updates.dependency_batch_threshold = t;
+  }
+  if (typeof dependency_auto_pr_enabled === 'boolean') updates.dependency_auto_pr_enabled = dependency_auto_pr_enabled;
+  if (dependency_auto_pr_enabled !== undefined && typeof dependency_auto_pr_enabled !== 'boolean') {
+    return res.status(400).json({ error: 'dependency_auto_pr_enabled must be a boolean' });
+  }
 
   if (Object.keys(updates).length === 0) {
     return res.status(400).json({ error: 'No valid fields to update' });
@@ -994,4 +1022,89 @@ const getDiff = async (req, res) => {
   }
 };
 
-module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData, updateRepo, generateWebhook, getFileContent, getDependencies, getChurn, getDuplication, getBranches, getDiff, getStoredDependenciesWithIssues };
+/** GET /api/repos/:repoId/trends?range=30d — daily metrics snapshots for trend charts (US-082) */
+const getTrends = async (req, res) => {
+  const { repoId } = req.params;
+  const { range = '30d' } = req.query;
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  try {
+    let cutoffDate = null;
+    if (range === '7d')  cutoffDate = new Date(Date.now() - 7  * 24 * 60 * 60 * 1000);
+    else if (range === '30d') cutoffDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    else if (range === '90d') cutoffDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    // 'all' → no cutoff
+
+    let query = supabaseAdmin
+      .from('repo_metrics_daily')
+      .select('snapshot_date, file_count, total_loc, avg_complexity, max_complexity, issue_counts_json, vulnerability_counts_json, dependency_counts_json, top_risks_json')
+      .eq('repo_id', repoId)
+      .order('snapshot_date', { ascending: true });
+
+    if (cutoffDate) {
+      query = query.gte('snapshot_date', cutoffDate.toISOString().split('T')[0]);
+    }
+
+    const { data: snapshots, error } = await query;
+    if (error) throw error;
+
+    const rows = snapshots || [];
+
+    // Compute summary: current value + delta vs period start
+    const current = rows.length > 0 ? rows[rows.length - 1] : null;
+    const periodStart = rows.length > 0 ? rows[0] : null;
+
+    const safeDelta = (a, b) => (a != null && b != null) ? (a - b) : null;
+
+    const summary = {
+      current: current ? {
+        snapshot_date: current.snapshot_date,
+        file_count: current.file_count,
+        total_loc: current.total_loc,
+        avg_complexity: current.avg_complexity,
+        max_complexity: current.max_complexity,
+        critical_issues: current.issue_counts_json?.by_severity?.critical ?? 0,
+        high_issues: current.issue_counts_json?.by_severity?.high ?? 0,
+        medium_issues: current.issue_counts_json?.by_severity?.medium ?? 0,
+        low_issues: current.issue_counts_json?.by_severity?.low ?? 0,
+        total_vulnerabilities:
+          (current.vulnerability_counts_json?.by_severity?.critical ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.high ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.medium ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.low ?? 0),
+        vulnerable_deps: current.dependency_counts_json?.vulnerable ?? 0,
+      } : null,
+      period_start: periodStart ? { snapshot_date: periodStart.snapshot_date } : null,
+      delta: (current && periodStart && current !== periodStart) ? {
+        file_count: safeDelta(current.file_count, periodStart.file_count),
+        total_loc: safeDelta(current.total_loc, periodStart.total_loc),
+        avg_complexity: current.avg_complexity != null && periodStart.avg_complexity != null
+          ? parseFloat((current.avg_complexity - periodStart.avg_complexity).toFixed(2))
+          : null,
+        critical_issues: safeDelta(
+          current.issue_counts_json?.by_severity?.critical ?? 0,
+          periodStart.issue_counts_json?.by_severity?.critical ?? 0
+        ),
+        total_vulnerabilities: safeDelta(
+          (current.vulnerability_counts_json?.by_severity?.critical ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.high ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.medium ?? 0) +
+          (current.vulnerability_counts_json?.by_severity?.low ?? 0),
+          (periodStart.vulnerability_counts_json?.by_severity?.critical ?? 0) +
+          (periodStart.vulnerability_counts_json?.by_severity?.high ?? 0) +
+          (periodStart.vulnerability_counts_json?.by_severity?.medium ?? 0) +
+          (periodStart.vulnerability_counts_json?.by_severity?.low ?? 0)
+        ),
+      } : null,
+    };
+
+    res.json({ snapshots: rows, summary });
+  } catch (err) {
+    console.error('[getTrends] Error:', err);
+    res.status(500).json({ error: err.message || 'Failed to fetch trends data' });
+  }
+};
+
+module.exports = { connectRepo, uploadRepo, listRepos, getStatus, reindexRepo, deleteRepo, getAnalysisData, updateRepo, generateWebhook, getFileContent, getDependencies, getChurn, getDuplication, getBranches, getDiff, getStoredDependenciesWithIssues, getTrends };

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -25,6 +25,7 @@ const { getBlastRadius } = require('../services/graphService');
 const { emitPrReviewReady } = require('../services/notificationEvents');
 const { enqueueNotification, recipientsForRepo } = require('../services/notifications');
 const { scoreIssuesForRepo } = require('../services/riskScoring');
+const { fixNpmDependency }  = require('../services/dependencyFixer');
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
@@ -2744,6 +2745,34 @@ const generateProposal = async (req, res) => {
       }
     }
 
+    // Fast path: for vulnerable_dependency issues we can produce a deterministic
+    // proposal using dependencyFixer without spending Claude tokens.
+    if (issue.type === 'vulnerable_dependency') {
+      const parsed = await tryBuildVulnFixProposal(issue, repoId);
+      if (parsed) {
+        emitProposalEvents(send, parsed);
+        const { data: inserted, error: insErr } = await supabaseAdmin
+          .from('issue_proposals')
+          .insert({
+            issue_id: issueId,
+            user_id: req.user.id,
+            status: 'pending',
+            proposal_json: parsed,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+          })
+          .select('id')
+          .single();
+        if (insErr) {
+          send({ type: 'error', message: 'Could not save the generated proposal.' });
+        } else {
+          send({ type: 'done', proposal_id: inserted.id, prompt_tokens: 0, completion_tokens: 0 });
+        }
+        return res.end();
+      }
+      // Fall through to Claude if the fixer couldn't handle it
+    }
+
     const { system, user } = await buildContextForIssue(issue, repoId);
     const { signal, cleanup } = bindRequestAbort(req);
 
@@ -2849,6 +2878,94 @@ const generateProposal = async (req, res) => {
   }
 };
 
+// ── US-083/084: Deterministic vulnerable-dep fixer ───────────────────────────
+
+/**
+ * Attempt to build a proposal for a vulnerable_dependency issue using
+ * dependencyFixer (no Claude). Returns a proposal_json object or null.
+ */
+async function tryBuildVulnFixProposal(issue, repoId) {
+  const desc = issue.description || '';
+  const manifestPath = Array.isArray(issue.file_paths) ? issue.file_paths[0] : null;
+  if (!manifestPath) return null;
+
+  const lockfileInfo = inferLockfileInfo(manifestPath);
+  if (!lockfileInfo) return null; // non-npm/yarn manifest (e.g. Cargo.toml)
+
+  // Parse package name + target version from description
+  const pkgMatch = desc.match(/^[^:]+:\s(@?[^@\s]+)@([^\s(]+)\s+has a known vulnerability/);
+  if (!pkgMatch) return null;
+  const package_name = pkgMatch[1];
+
+  const fixedVersionMatch = desc.match(/— upgrade to ([^\s.,;)]+)/);
+  if (!fixedVersionMatch) return null;
+  const target_version = fixedVersionMatch[1];
+
+  const effectiveManifestPath = lockfileInfo.manifest_path_override || manifestPath;
+
+  // Load manifest + lockfile from indexed file_contents
+  const [manifestContent, lockfileContent] = await Promise.all([
+    fetchFileSource(repoId, effectiveManifestPath),
+    fetchFileSource(repoId, lockfileInfo.lockfile_path),
+  ]);
+  if (!manifestContent) return null;
+
+  const result = await fixNpmDependency({
+    manifest_content:  manifestContent,
+    lockfile_content:  lockfileContent,
+    lockfile_format:   lockfileInfo.lockfile_format,
+    package_name,
+    target_version,
+    strategy:          'minimum_safe',
+  });
+
+  if (!result.ok) return null;
+
+  const changes = [
+    {
+      file_path: effectiveManifestPath,
+      action:    'modify',
+      diff:      `Update ${package_name} to ${target_version}`,
+      full_content: result.new_manifest,
+    },
+  ];
+  if (result.new_lockfile && lockfileInfo.lockfile_path !== effectiveManifestPath) {
+    changes.push({
+      file_path: lockfileInfo.lockfile_path,
+      action:    'modify',
+      diff:      `Re-locked after upgrading ${package_name}`,
+      full_content: result.new_lockfile,
+    });
+  }
+
+  const applied = result.applied_changes || [];
+  const changesText = applied.map(c => `- \`${c.package}\`: ${c.from || '(transitive)'} → ${c.to} (${c.kind})`).join('\n');
+
+  return {
+    summary:   `Upgrade ${package_name} to ${target_version} (deterministic fix)`,
+    rationale: `Bumps \`${package_name}\` to \`${target_version}\` to resolve the known vulnerability.\n\nChanges applied:\n${changesText}`,
+    changes,
+    risks:     [],
+  };
+}
+
+/**
+ * Compute per-package blast radius: files that import a given npm package.
+ * Returns top-3 file paths + total count.
+ */
+async function getPackageBlastRadius(repoId, packageName) {
+  const pattern = `%/node_modules/${packageName}/%`;
+  const { data } = await supabaseAdmin
+    .from('graph_edges')
+    .select('from_path')
+    .eq('repo_id', repoId)
+    .ilike('to_path', pattern)
+    .limit(50);
+
+  const unique = [...new Set((data || []).map(r => r.from_path))];
+  return { total: unique.length, top3: unique.slice(0, 3) };
+}
+
 // ── US-066: Apply proposal as a GitHub draft PR ─────────────────────────────
 
 function buildBranchSlug(issueType, filePath) {
@@ -2885,6 +3002,21 @@ function buildPrBody({ rationale, risks, repoId, issueId, proposalId, issueType 
   }
   sections.push(`## Source\nOpened from a [CodeLens proposal](${issueLink}) for issue type \`${issueType || 'unknown'}\`.`);
   return sections.join('\n\n');
+}
+
+/** Detect lockfile format + expected lockfile path from a manifest path. */
+function inferLockfileInfo(manifestPath = '') {
+  const dir  = path.posix.dirname(manifestPath);
+  const base = path.basename(manifestPath).toLowerCase();
+  if (base === 'package.json' || base === 'package-lock.json') {
+    return { lockfile_format: 'npm', lockfile_path: dir === '.' ? 'package-lock.json' : `${dir}/package-lock.json` };
+  }
+  if (base === 'yarn.lock') {
+    // yarn.lock is both the manifest root and the lockfile
+    const pkgJson = dir === '.' ? 'package.json' : `${dir}/package.json`;
+    return { lockfile_format: 'yarn', lockfile_path: manifestPath, manifest_path_override: pkgJson };
+  }
+  return null;
 }
 
 async function findExistingOpenPr(octokit, owner, repo, branchName) {
@@ -3096,6 +3228,323 @@ const applyProposalAsPr = async (req, res) => {
   }
 };
 
+// ── US-084: Batch vulnerable-dependency auto-PR ──────────────────────────────
+
+const batchDependencyProposal = async (req, res) => {
+  const { repoId } = req.params;
+  const { vulnerability_ids } = req.body || {};
+
+  if (!Array.isArray(vulnerability_ids) || vulnerability_ids.length === 0) {
+    return res.status(400).json({ error: 'vulnerability_ids must be a non-empty array' });
+  }
+
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
+
+  // Idempotency: hash the sorted IDs and look for an existing applied batch proposal
+  const batchKey = crypto
+    .createHash('sha256')
+    .update([...vulnerability_ids].sort().join(','))
+    .digest('hex')
+    .slice(0, 16);
+
+  const { data: existing } = await supabaseAdmin
+    .from('issue_proposals')
+    .select('id, pr_url, branch_name, proposal_json')
+    .eq('user_id', req.user.id)
+    .eq('status', 'applied')
+    .contains('proposal_json', { batch_key: batchKey })
+    .maybeSingle();
+
+  if (existing?.pr_url) {
+    return res.json({ ok: true, pr_url: existing.pr_url, branch_name: existing.branch_name, reused: true });
+  }
+
+  // Fetch all vulnerability issues
+  const { data: issues, error: issErr } = await supabaseAdmin
+    .from('analysis_issues')
+    .select('id, type, severity, description, file_paths')
+    .in('id', vulnerability_ids)
+    .eq('repo_id', repoId)
+    .eq('type', 'vulnerable_dependency');
+
+  if (issErr) return res.status(500).json({ error: 'Failed to load vulnerability issues' });
+  if (!issues || issues.length === 0) {
+    return res.status(404).json({ error: 'No vulnerable_dependency issues found for the given IDs' });
+  }
+
+  const { data: repoRow } = await supabaseAdmin
+    .from('repositories')
+    .select('id, full_name, default_branch, source, dependency_update_strategy')
+    .eq('id', repoId)
+    .single();
+
+  if (!repoRow?.full_name || repoRow.source !== 'github') {
+    return res.status(400).json({ error: 'Only GitHub-connected repositories support batch fix PR.' });
+  }
+
+  const githubToken = await getGithubTokenForUser(req.user.id);
+  if (!githubToken) {
+    return res.status(401).json({ error: 'Your GitHub token has expired. Reconnect GitHub from Settings.' });
+  }
+
+  // Group issues by manifest file
+  const byManifest = new Map();
+  for (const issue of issues) {
+    const manifest = Array.isArray(issue.file_paths) ? issue.file_paths[0] : null;
+    if (!manifest) continue;
+    if (!byManifest.has(manifest)) byManifest.set(manifest, []);
+    byManifest.get(manifest).push(issue);
+  }
+
+  // For each manifest group: chain dependencyFixer calls
+  const allChanges = [];
+  const failedFixes = [];
+  const appliedPackages = [];
+
+  for (const [manifestPath, manifestIssues] of byManifest) {
+    const lockfileInfo = inferLockfileInfo(manifestPath);
+    if (!lockfileInfo) {
+      manifestIssues.forEach(i => failedFixes.push({ issue_id: i.id, reason: 'unsupported_manifest_type' }));
+      continue;
+    }
+
+    const effectiveManifestPath = lockfileInfo.manifest_path_override || manifestPath;
+    let currentManifest = await fetchFileSource(repoId, effectiveManifestPath);
+    let currentLockfile = await fetchFileSource(repoId, lockfileInfo.lockfile_path);
+
+    if (!currentManifest) {
+      manifestIssues.forEach(i => failedFixes.push({ issue_id: i.id, reason: 'manifest_not_found' }));
+      continue;
+    }
+
+    for (const issue of manifestIssues) {
+      const desc = issue.description || '';
+      const pkgMatch = desc.match(/^[^:]+:\s(@?[^@\s]+)@([^\s(]+)\s+has a known vulnerability/);
+      const fixedVersionMatch = desc.match(/— upgrade to ([^\s.,;)]+)/);
+      if (!pkgMatch || !fixedVersionMatch) {
+        failedFixes.push({ issue_id: issue.id, reason: 'cannot_parse_issue_description' });
+        continue;
+      }
+      const package_name  = pkgMatch[1];
+      const target_version = fixedVersionMatch[1];
+
+      const result = await fixNpmDependency({
+        manifest_content: currentManifest,
+        lockfile_content: currentLockfile,
+        lockfile_format:  lockfileInfo.lockfile_format,
+        package_name,
+        target_version,
+        strategy: repoRow.dependency_update_strategy || 'minimum_safe',
+      });
+
+      if (result.ok) {
+        currentManifest = result.new_manifest;
+        if (result.new_lockfile) currentLockfile = result.new_lockfile;
+        appliedPackages.push({ package_name, target_version, issue_id: issue.id, applied_changes: result.applied_changes });
+      } else {
+        failedFixes.push({ issue_id: issue.id, package: package_name, reason: result.reason });
+      }
+    }
+
+    if (appliedPackages.length === 0) continue;
+
+    allChanges.push({ file_path: effectiveManifestPath, full_content: currentManifest });
+    if (currentLockfile && lockfileInfo.lockfile_path !== effectiveManifestPath) {
+      allChanges.push({ file_path: lockfileInfo.lockfile_path, full_content: currentLockfile });
+    }
+  }
+
+  if (allChanges.length === 0) {
+    return res.status(422).json({
+      error: 'No dependency fixes could be applied.',
+      failed_fixes: failedFixes,
+    });
+  }
+
+  // Compute blast radius per package for the PR body
+  const frontendUrl = (process.env.FRONTEND_URL || '').replace(/\/+$/, '');
+  const pkgDetails = await Promise.all(
+    appliedPackages.map(async (p) => {
+      const br = await getPackageBlastRadius(repoId, p.package_name);
+      return { ...p, blast_radius: br };
+    })
+  );
+
+  // Build PR body
+  const countBySev = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const issue of issues) { if (countBySev[issue.severity] !== undefined) countBySev[issue.severity]++; }
+  const total = appliedPackages.length;
+  const sevParts = Object.entries(countBySev).filter(([, v]) => v > 0).map(([k, v]) => `${v} ${k}`).join(', ');
+
+  const pkgTable = [
+    '| Package | Old → New | Kind | Used by |',
+    '|---|---|---|---|',
+    ...pkgDetails.map(p => {
+      const ac = (p.applied_changes || [])[0] || {};
+      const usedBy = p.blast_radius.total > 0
+        ? `${p.blast_radius.total} file${p.blast_radius.total !== 1 ? 's' : ''} (${p.blast_radius.top3.map(f => `\`${path.basename(f)}\``).join(', ')}${p.blast_radius.total > 3 ? '…' : ''})`
+        : 'not directly imported';
+      return `| \`${p.package_name}\` | ${ac.from || '(transitive)'} → ${ac.to || p.target_version} | ${ac.kind || 'direct'} | ${usedBy} |`;
+    }),
+  ].join('\n');
+
+  const prBody = [
+    `## Summary\nFixes ${total} vulnerabilit${total !== 1 ? 'ies' : 'y'} (${sevParts}) across ${appliedPackages.length} package${appliedPackages.length !== 1 ? 's' : ''}.`,
+    `## Packages Updated\n${pkgTable}`,
+    failedFixes.length ? `## Not Applied\n${failedFixes.map(f => `- Issue \`${f.issue_id}\`: ${f.reason}${f.package ? ` (\`${f.package}\`)` : ''}`).join('\n')}` : '',
+    frontendUrl ? `## Source\nGenerated by [CodeLens](${frontendUrl}/repos/${repoId}?tab=dependencies).` : '',
+  ].filter(Boolean).join('\n\n');
+
+  const prTitle = `Fix ${total} vulnerable ${total !== 1 ? 'dependencies' : 'dependency'}`;
+  const branchName = `codelens/fix-deps-${batchKey.slice(0, 8)}`;
+  const [owner, repoName] = repoRow.full_name.split('/');
+  const octokit = getOctokit(githubToken);
+
+  try {
+    let defaultBranch = repoRow.default_branch;
+    if (!defaultBranch) {
+      const { data: repoMeta } = await octokit.rest.repos.get({ owner, repo: repoName });
+      defaultBranch = repoMeta.default_branch;
+    }
+
+    const { data: baseRef } = await octokit.rest.git.getRef({ owner, repo: repoName, ref: `heads/${defaultBranch}` });
+    const baseSha = baseRef.object.sha;
+    const { data: baseCommit } = await octokit.rest.git.getCommit({ owner, repo: repoName, commit_sha: baseSha });
+    const baseTreeSha = baseCommit.tree.sha;
+
+    const treeEntries = [];
+    for (const change of allChanges) {
+      const { data: blob } = await octokit.rest.git.createBlob({ owner, repo: repoName, content: change.full_content, encoding: 'utf-8' });
+      treeEntries.push({ path: change.file_path, mode: '100644', type: 'blob', sha: blob.sha });
+    }
+
+    const { data: newTree } = await octokit.rest.git.createTree({ owner, repo: repoName, base_tree: baseTreeSha, tree: treeEntries });
+    const { data: commit } = await octokit.rest.git.createCommit({
+      owner,
+      repo: repoName,
+      message: `${prTitle}\n\nAutomatically generated by CodeLens.`,
+      tree: newTree.sha,
+      parents: [baseSha],
+    });
+
+    let prUrl;
+    try {
+      await octokit.rest.git.createRef({ owner, repo: repoName, ref: `refs/heads/${branchName}`, sha: commit.sha });
+    } catch (refErr) {
+      if (refErr?.status === 422) {
+        const existingPr = await findExistingOpenPr(octokit, owner, repoName, branchName);
+        if (existingPr) { prUrl = existingPr.html_url; }
+        else {
+          await octokit.rest.git.updateRef({ owner, repo: repoName, ref: `heads/${branchName}`, sha: commit.sha, force: true });
+        }
+      } else { throw refErr; }
+    }
+
+    if (!prUrl) {
+      const { data: pr } = await octokit.rest.pulls.create({ owner, repo: repoName, draft: true, head: branchName, base: defaultBranch, title: prTitle, body: prBody });
+      prUrl = pr.html_url;
+      // Label the PR
+      try {
+        await octokit.rest.issues.addLabels({ owner, repo: repoName, issue_number: pr.number, labels: ['dependencies', 'security'] });
+      } catch { /* labels might not exist — non-fatal */ }
+    }
+
+    // Persist to issue_proposals for the first issue in the batch (for badge tracking)
+    const proposalJson = {
+      summary:   prTitle,
+      rationale: prBody,
+      changes:   allChanges.map(c => ({ file_path: c.file_path, action: 'modify', diff: '', full_content: c.full_content })),
+      risks:     failedFixes.map(f => `${f.package || f.issue_id}: ${f.reason}`),
+      batch_key: batchKey,
+      batch_ids: vulnerability_ids,
+    };
+
+    await withSupabaseRetry(
+      () => supabaseAdmin.from('issue_proposals').insert({
+        issue_id: issues[0].id,
+        user_id: req.user.id,
+        status: 'applied',
+        proposal_json: proposalJson,
+        branch_name: branchName,
+        pr_url: prUrl,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+      }),
+      { label: 'batch_proposal.insert' },
+    );
+
+    return res.json({
+      ok: true,
+      pr_url: prUrl,
+      branch_name: branchName,
+      applied_count: appliedPackages.length,
+      failed_fixes: failedFixes,
+    });
+  } catch (err) {
+    const { http, message } = mapGithubError(err);
+    console.error('[batchDependencyProposal] Failed:', err?.status, err?.message);
+    return res.status(http).json({ error: message });
+  }
+};
+
+/**
+ * Internal (non-HTTP) version of batchDependencyProposal for use by the indexer
+ * auto-PR trigger. Returns { ok, pr_url } or throws.
+ */
+async function batchDependencyProposalInternal({ repoId, userId, vulnerabilityIds }) {
+  const { data: issues } = await supabaseAdmin
+    .from('analysis_issues')
+    .select('id, type, severity, description, file_paths')
+    .in('id', vulnerabilityIds)
+    .eq('repo_id', repoId)
+    .eq('type', 'vulnerable_dependency');
+
+  if (!issues || issues.length === 0) return { ok: false, reason: 'no_issues' };
+
+  const batchKey = crypto
+    .createHash('sha256')
+    .update([...vulnerabilityIds].sort().join(','))
+    .digest('hex')
+    .slice(0, 16);
+
+  // Check idempotency
+  const { data: existing } = await supabaseAdmin
+    .from('issue_proposals')
+    .select('pr_url')
+    .eq('user_id', userId)
+    .eq('status', 'applied')
+    .contains('proposal_json', { batch_key: batchKey })
+    .maybeSingle();
+  if (existing?.pr_url) return { ok: true, pr_url: existing.pr_url, reused: true };
+
+  const { data: repoRow } = await supabaseAdmin
+    .from('repositories')
+    .select('id, full_name, default_branch, source, dependency_update_strategy')
+    .eq('id', repoId)
+    .single();
+
+  if (!repoRow?.full_name || repoRow.source !== 'github') return { ok: false, reason: 'not_github' };
+
+  const githubToken = await getGithubTokenForUser(userId);
+  if (!githubToken) return { ok: false, reason: 'no_github_token' };
+
+  // Delegate to the shared implementation
+  const fakeReq = {
+    params: { repoId },
+    body: { vulnerability_ids: vulnerabilityIds },
+    user: { id: userId },
+  };
+
+  return new Promise((resolve) => {
+    const fakeRes = {
+      status(code) { return { json: (data) => resolve({ ...data, http_status: code }) }; },
+      json(data) { resolve(data); },
+    };
+    batchDependencyProposal(fakeReq, fakeRes).catch((err) => resolve({ ok: false, reason: err.message }));
+  });
+}
+
 // ── Lightweight summary for IssueCard badges ────────────────────────────────
 
 const listProposalSummaries = async (req, res) => {
@@ -3185,6 +3634,8 @@ module.exports = {
   updateProposalStatus,
   applyProposalAsPr,
   listProposalSummaries,
+  batchDependencyProposal,
+  batchDependencyProposalInternal,
   _private: {
     parseFindingsFromText,
     rerankSecurityChunks,

--- a/backend/src/routes/repo.js
+++ b/backend/src/routes/repo.js
@@ -56,6 +56,12 @@ router.get('/:repoId/branches', requireAuth, repoController.getBranches);
 // Compute or retrieve cached architectural diff between two refs (US-051)
 router.get('/:repoId/diff', requireAuth, repoController.getDiff);
 
+// Daily metrics trend data for trend charts (US-082)
+router.get('/:repoId/trends', requireAuth, repoController.getTrends);
+
+// Batch vulnerable-dependency fix PR (US-084)
+router.post('/:repoId/dependencies/batch-proposal', requireAuth, reviewController.batchDependencyProposal);
+
 // PR review run (deterministic-only pipeline) — US-073
 const reviewController = require('../controllers/reviewController');
 router.get('/:repoId/pulls', requireAuth, reviewController.listPullRequests);

--- a/backend/src/services/dependencyFixer.js
+++ b/backend/src/services/dependencyFixer.js
@@ -1,0 +1,235 @@
+/**
+ * backend/src/services/dependencyFixer.js
+ *
+ * Deterministic dependency-update service (US-083).
+ * Updates a package manifest + lockfile in memory, returning the patched files.
+ * No shell-out; uses @npmcli/arborist for npm and @yarnpkg/lockfile for yarn.
+ *
+ * Exported function:
+ *   fixNpmDependency({ manifest_content, lockfile_content, lockfile_format,
+ *                       package_name, target_version, strategy })
+ *   → Promise<{ ok: true, new_manifest, new_lockfile, applied_changes }
+ *           | { ok: false, reason }>
+ */
+
+const os   = require('os');
+const fs   = require('fs').promises;
+const path = require('path');
+const crypto = require('crypto');
+
+const TIMEOUT_MS = 30_000;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function safeJson(content) {
+  try { return { ok: true, data: JSON.parse(content) }; }
+  catch { return { ok: false }; }
+}
+
+/** Compute a diff of changed dependency versions between old and new manifests. */
+function computeAppliedChanges(oldManifest, newManifest) {
+  const changes = [];
+  const depFields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies', 'overrides'];
+  for (const field of depFields) {
+    const oldDeps = oldManifest[field] || {};
+    const newDeps = newManifest[field] || {};
+    const allKeys = new Set([...Object.keys(oldDeps), ...Object.keys(newDeps)]);
+    for (const pkg of allKeys) {
+      const from = oldDeps[pkg];
+      const to   = newDeps[pkg];
+      if (from !== to) {
+        changes.push({
+          package: pkg,
+          from: from || null,
+          to:   to   || null,
+          kind: field === 'overrides' ? 'override' : (oldManifest.dependencies?.[pkg] || oldManifest.devDependencies?.[pkg] ? 'direct' : 'transitive'),
+        });
+      }
+    }
+  }
+  return changes;
+}
+
+// ── npm path ─────────────────────────────────────────────────────────────────
+
+async function fixWithArborist({ manifest_content, lockfile_content, package_name, target_version }) {
+  const Arborist = require('@npmcli/arborist');
+
+  const { ok, data: manifest } = safeJson(manifest_content);
+  if (!ok) return { ok: false, reason: 'malformed_manifest_json' };
+
+  const updatedManifest = JSON.parse(JSON.stringify(manifest));
+
+  // Determine if it's a direct dep or transitive
+  const isDirectDep = Boolean(
+    updatedManifest.dependencies?.[package_name] ||
+    updatedManifest.devDependencies?.[package_name] ||
+    updatedManifest.peerDependencies?.[package_name] ||
+    updatedManifest.optionalDependencies?.[package_name]
+  );
+
+  if (isDirectDep) {
+    // Update the version range in whichever field it lives in
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+      if (updatedManifest[field]?.[package_name] !== undefined) {
+        updatedManifest[field][package_name] = target_version;
+      }
+    }
+  } else {
+    // Transitive: use npm overrides
+    if (!updatedManifest.overrides) updatedManifest.overrides = {};
+    updatedManifest.overrides[package_name] = target_version;
+  }
+
+  // Write to a tmpdir so Arborist can reify
+  const tmpDir = path.join(os.tmpdir(), `codelens-fix-${crypto.randomUUID()}`);
+  try {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(path.join(tmpDir, 'package.json'), JSON.stringify(updatedManifest, null, 2), 'utf8');
+    if (lockfile_content) {
+      await fs.writeFile(path.join(tmpDir, 'package-lock.json'), lockfile_content, 'utf8');
+    }
+
+    const arborist = new Arborist({ path: tmpDir });
+
+    await Promise.race([
+      arborist.reify({ save: true, audit: false }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('arborist_timeout')), TIMEOUT_MS)
+      ),
+    ]);
+
+    const newManifestStr  = await fs.readFile(path.join(tmpDir, 'package.json'), 'utf8');
+    let   newLockfileStr  = null;
+    try {
+      newLockfileStr = await fs.readFile(path.join(tmpDir, 'package-lock.json'), 'utf8');
+    } catch { /* lock may not exist for zip-only repos */ }
+
+    const { ok: parsedOk, data: newManifest } = safeJson(newManifestStr);
+    if (!parsedOk) return { ok: false, reason: 'arborist_produced_invalid_manifest' };
+
+    return {
+      ok: true,
+      new_manifest:  newManifestStr,
+      new_lockfile:  newLockfileStr,
+      applied_changes: computeAppliedChanges(manifest, newManifest),
+    };
+  } catch (err) {
+    if (err.message === 'arborist_timeout') return { ok: false, reason: 'timeout' };
+    // Peer dep conflict, major version break, etc.
+    return { ok: false, reason: err.message || 'arborist_reify_failed' };
+  } finally {
+    fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// ── yarn path ─────────────────────────────────────────────────────────────────
+
+async function fixWithYarn({ manifest_content, lockfile_content, package_name, target_version }) {
+  const yarnLockfile = require('@yarnpkg/lockfile');
+
+  const { ok, data: manifest } = safeJson(manifest_content);
+  if (!ok) return { ok: false, reason: 'malformed_manifest_json' };
+
+  const updatedManifest = JSON.parse(JSON.stringify(manifest));
+
+  // Update direct dep in manifest (same logic as npm)
+  const isDirectDep = Boolean(
+    updatedManifest.dependencies?.[package_name] ||
+    updatedManifest.devDependencies?.[package_name]
+  );
+  if (isDirectDep) {
+    for (const field of ['dependencies', 'devDependencies']) {
+      if (updatedManifest[field]?.[package_name] !== undefined) {
+        updatedManifest[field][package_name] = target_version;
+      }
+    }
+  }
+
+  if (!lockfile_content) {
+    // No lockfile — just return the updated manifest
+    return {
+      ok: true,
+      new_manifest:  JSON.stringify(updatedManifest, null, 2),
+      new_lockfile:  null,
+      applied_changes: computeAppliedChanges(manifest, updatedManifest),
+    };
+  }
+
+  // Parse the lockfile
+  const parsed = yarnLockfile.parse(lockfile_content);
+  if (parsed.type !== 'success') {
+    return { ok: false, reason: 'yarn_lockfile_parse_failed' };
+  }
+
+  const lockfileObj = parsed.object;
+
+  // Count distinct resolution versions for the package to detect complex graphs
+  const matchingEntries = Object.keys(lockfileObj).filter(key =>
+    key.startsWith(`${package_name}@`)
+  );
+  const distinctResolutions = new Set(matchingEntries.map(k => lockfileObj[k]?.version)).size;
+  if (distinctResolutions > 1) {
+    return { ok: false, reason: 'yarn_complex_resolution' };
+  }
+
+  // Update version for all entries matching the package
+  let changed = false;
+  for (const key of matchingEntries) {
+    if (lockfileObj[key]) {
+      lockfileObj[key].version   = target_version;
+      lockfileObj[key].resolved  = lockfileObj[key].resolved
+        ? lockfileObj[key].resolved.replace(/[^/]+\.tgz$/, `${package_name}-${target_version}.tgz`)
+        : lockfileObj[key].resolved;
+      changed = true;
+    }
+  }
+
+  if (!changed && !isDirectDep) {
+    return { ok: false, reason: 'package_not_found_in_lockfile' };
+  }
+
+  const newLockfileStr = yarnLockfile.stringify(lockfileObj);
+
+  return {
+    ok: true,
+    new_manifest:  JSON.stringify(updatedManifest, null, 2),
+    new_lockfile:  newLockfileStr,
+    applied_changes: computeAppliedChanges(manifest, updatedManifest),
+  };
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @param {object} opts
+ * @param {string} opts.manifest_content  - Raw package.json / pyproject.toml etc.
+ * @param {string|null} opts.lockfile_content - Raw lockfile (package-lock.json / yarn.lock) or null
+ * @param {'npm'|'yarn'|'pnpm'} opts.lockfile_format
+ * @param {string} opts.package_name      - Package to upgrade
+ * @param {string} opts.target_version    - Target version spec (e.g. "^4.17.21" or "4.17.21")
+ * @param {'minimum_safe'|'latest_safe'} opts.strategy - Informational; affects caller context
+ * @returns {Promise<{ok:true, new_manifest:string, new_lockfile:string|null, applied_changes:Array}
+ *                  |{ok:false, reason:string}>}
+ */
+async function fixNpmDependency({ manifest_content, lockfile_content, lockfile_format, package_name, target_version }) {
+  if (!manifest_content) return { ok: false, reason: 'missing_manifest_content' };
+  if (!package_name)      return { ok: false, reason: 'missing_package_name' };
+  if (!target_version)    return { ok: false, reason: 'missing_target_version' };
+
+  if (lockfile_format === 'npm') {
+    return fixWithArborist({ manifest_content, lockfile_content, package_name, target_version });
+  }
+
+  if (lockfile_format === 'yarn') {
+    return fixWithYarn({ manifest_content, lockfile_content, package_name, target_version });
+  }
+
+  if (lockfile_format === 'pnpm') {
+    return { ok: false, reason: 'pnpm_not_yet_supported' };
+  }
+
+  return { ok: false, reason: `unsupported_lockfile_format:${lockfile_format}` };
+}
+
+module.exports = { fixNpmDependency };

--- a/backend/src/services/indexerService.js
+++ b/backend/src/services/indexerService.js
@@ -149,7 +149,7 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
     // user_id here and sast_disabled_rules later in the parsing phase.
     const { data: repoMeta } = await supabaseAdmin
       .from('repositories')
-      .select('user_id, sast_disabled_rules')
+      .select('user_id, sast_disabled_rules, dependency_auto_pr_enabled, dependency_batch_threshold, dependency_update_strategy')
       .eq('id', repoId)
       .single();
     const repoUserId = repoMeta?.user_id || null;
@@ -763,6 +763,32 @@ const indexRepository = async ({ repoId, owner, name, token, extractPath, source
       console.log(`[indexer] Generated daily snapshot post-index for ${repoId}`);
     } catch (snapCatchErr) {
       console.warn(`[indexer] Post-index snapshot generation threw: ${snapCatchErr.message}`);
+    }
+
+    // US-084: auto-open a batch fix PR when dependency_auto_pr_enabled and enough vulns found
+    if (repoMeta?.dependency_auto_pr_enabled && repoUserId && token && source === 'github') {
+      const threshold = repoMeta.dependency_batch_threshold ?? 3;
+      try {
+        const { data: vulnIssues } = await supabaseAdmin
+          .from('analysis_issues')
+          .select('id')
+          .eq('repo_id', repoId)
+          .eq('type', 'vulnerable_dependency');
+        const vulnCount = (vulnIssues || []).length;
+        if (vulnCount >= threshold) {
+          const vulnIds = (vulnIssues || []).map(i => i.id);
+          console.log(`[indexer] Auto-PR: ${vulnCount} vuln(s) >= threshold ${threshold}, triggering batch-proposal.`);
+          // Fire-and-forget — never blocks the pipeline
+          const { batchDependencyProposalInternal } = require('../controllers/reviewController');
+          if (typeof batchDependencyProposalInternal === 'function') {
+            batchDependencyProposalInternal({ repoId, userId: repoUserId, vulnerabilityIds: vulnIds }).catch((autoErr) => {
+              console.warn('[indexer] Auto-PR batch proposal failed:', autoErr.message);
+            });
+          }
+        }
+      } catch (autoErr) {
+        console.warn('[indexer] Auto-PR trigger failed (best-effort):', autoErr.message);
+      }
     }
 
     // US-077: notify recipients that the index is ready and surface newly-introduced

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.21.1",
         "react-syntax-highlighter": "^16.1.1",
         "react-virtuoso": "^4.18.7",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1396,6 +1397,42 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1763,8 +1800,13 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.101.1",
@@ -2039,8 +2081,7 @@
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "dev": true
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
     },
     "node_modules/@types/d3-axis": {
       "version": "3.0.6",
@@ -2069,8 +2110,7 @@
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "node_modules/@types/d3-contour": {
       "version": "3.0.6",
@@ -2112,8 +2152,7 @@
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "dev": true
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "node_modules/@types/d3-fetch": {
       "version": "3.0.7",
@@ -2155,7 +2194,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -2163,8 +2201,7 @@
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "dev": true
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
     },
     "node_modules/@types/d3-polygon": {
       "version": "3.0.2",
@@ -2188,7 +2225,6 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dev": true,
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -2209,7 +2245,6 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "dev": true,
       "dependencies": {
         "@types/d3-path": "*"
       }
@@ -2217,8 +2252,7 @@
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "dev": true
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
     "node_modules/@types/d3-time-format": {
       "version": "4.0.3",
@@ -2229,8 +2263,7 @@
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "dev": true
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
@@ -2338,6 +2371,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -2970,6 +3009,15 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3495,6 +3543,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -3716,6 +3770,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3942,6 +4006,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4537,6 +4607,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -6619,8 +6699,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6647,6 +6727,30 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -6748,6 +6852,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6760,6 +6894,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/refractor": {
@@ -6849,6 +6999,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -7394,6 +7550,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7727,6 +7889,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7759,6 +7930,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-router-dom": "^6.21.1",
     "react-syntax-highlighter": "^16.1.1",
     "react-virtuoso": "^4.18.7",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -43,32 +43,48 @@ const GROUP_ORDER = [
 ];
 
 // ── IssueGroup ────────────────────────────────────────────────────────────────
-const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled, scrollParent, proposalsByIssue }) {
+const IssueGroup = memo(function IssueGroup({ type, label, Icon, issues, nodeMap, onIssueClick, onSuppress, onDisableRule, onProposeFix, actionsDisabled, scrollParent, proposalsByIssue, onBatchFix, batchFixing }) {
   const [isOpen, setIsOpen] = useState(true);
+  const showBatchFix = type === 'vulnerable_dependency' && issues.length >= 2 && typeof onBatchFix === 'function';
 
   return (
     <div className="mb-6 last:mb-0">
       {/* Sticky header */}
-      <button
-        onClick={() => setIsOpen(v => !v)}
-        className="sticky top-0 z-10 w-full flex items-center justify-between bg-gray-950 border-b border-gray-800 shadow-sm pb-2 mb-3 pt-1 group"
-      >
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gray-800 border border-gray-700">
-            <Icon className="h-3.5 w-3.5 text-gray-400 group-hover:text-white transition-colors" />
-          </div>
-          <h2 className="text-base font-semibold text-gray-200 group-hover:text-white transition-colors">
-            {label}
-          </h2>
-          <span className="rounded-full bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500">
-            {issues.length}
-          </span>
+      <div className="sticky top-0 z-10 bg-gray-950 border-b border-gray-800 shadow-sm pb-2 mb-3 pt-1">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setIsOpen(v => !v)}
+            className="flex items-center gap-2.5 group"
+          >
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-gray-800 border border-gray-700">
+              <Icon className="h-3.5 w-3.5 text-gray-400 group-hover:text-white transition-colors" />
+            </div>
+            <h2 className="text-base font-semibold text-gray-200 group-hover:text-white transition-colors">
+              {label}
+            </h2>
+            <span className="rounded-full bg-gray-800 px-2 py-0.5 text-xs font-medium text-gray-500">
+              {issues.length}
+            </span>
+            {isOpen
+              ? <ChevronUp className="h-4 w-4 text-gray-600 ml-1" />
+              : <ChevronDown className="h-4 w-4 text-gray-600 ml-1" />
+            }
+          </button>
+          {showBatchFix && (
+            <button
+              onClick={() => onBatchFix(issues.map(i => i.id))}
+              disabled={actionsDisabled || batchFixing}
+              className="flex items-center gap-1.5 rounded-lg border border-indigo-700/50 bg-indigo-900/30 px-3 py-1 text-xs font-medium text-indigo-300 hover:bg-indigo-900/60 hover:text-indigo-200 transition disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {batchFixing ? (
+                <><div className="h-3 w-3 animate-spin rounded-full border-2 border-indigo-400 border-t-transparent" /> Opening PR…</>
+              ) : (
+                <><Sparkles className="h-3 w-3" /> Batch fix PR</>
+              )}
+            </button>
+          )}
         </div>
-        {isOpen
-          ? <ChevronUp className="h-4 w-4 text-gray-600" />
-          : <ChevronDown className="h-4 w-4 text-gray-600" />
-        }
-      </button>
+      </div>
 
       {/* Collapsible body */}
       {isOpen && (
@@ -365,6 +381,8 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   const [canMutateIssues, setCanMutateIssues] = useState(true);
   const [selectedProposalIssue, setSelectedProposalIssue] = useState(null);
   const [proposalsByIssue, setProposalsByIssue] = useState({});
+  const [batchFixing, setBatchFixing] = useState(false);
+  const [batchFixError, setBatchFixError] = useState(null);
   // Phase 4.1: callback ref so the scroll-parent element propagates through
   // state and triggers a re-render — IssueGroup's customScrollParent prop
   // needs the actual DOM node, not a ref placeholder.
@@ -546,6 +564,27 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
     }));
   }, []);
 
+  const handleBatchFix = useCallback(async (issueIds) => {
+    if (!accessToken || batchFixing) return;
+    setBatchFixing(true);
+    setBatchFixError(null);
+    try {
+      const res = await fetch(apiUrl(`/api/repos/${repoId}/dependencies/batch-proposal`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ vulnerability_ids: issueIds }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Batch fix failed');
+      // Open the PR in a new tab
+      if (data.pr_url) window.open(data.pr_url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setBatchFixError(err.message);
+    } finally {
+      setBatchFixing(false);
+    }
+  }, [accessToken, batchFixing, repoId]);
+
   if ((!localIssues || localIssues.length === 0) && duplicationClusters.length === 0) {
     return (
       <>
@@ -655,6 +694,8 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
               actionsDisabled={!canMutateIssues}
               scrollParent={scrollParent}
               proposalsByIssue={proposalsByIssue}
+              onBatchFix={type === 'vulnerable_dependency' ? handleBatchFix : undefined}
+              batchFixing={batchFixing}
             />
           );
         })}
@@ -663,6 +704,12 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
           clusters={duplicationClusters}
           onOpen={setSelectedDuplicationCluster}
         />
+
+        {batchFixError && (
+          <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-400">
+            Batch fix failed: {batchFixError}
+          </div>
+        )}
 
         {/* No filter results */}
         {filterText && filteredIssues.length === 0 && duplicationClusters.length === 0 && (

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -11,7 +11,7 @@ import {
   LayoutDashboard, GitGraph, BarChart3, FolderTree,
   Package, ShieldAlert, Sparkles, Code2, Settings, GitBranch,
   LogOut, HelpCircle, ChevronLeft, ChevronRight, ArrowLeft,
-  Star,
+  Star, TrendingUp,
 } from './ui/Icons';
 
 const OnboardingGuide = lazy(() => import('./OnboardingGuide'));
@@ -160,6 +160,7 @@ export default function Layout() {
   const repoNavItems = [
     { label: 'Graph',        tab: 'graph',        Icon: GitGraph     },
     { label: 'Metrics',      tab: 'metrics',      Icon: BarChart3    },
+    { label: 'Trends',       tab: 'trends',       Icon: TrendingUp   },
     { label: 'Files',        tab: 'files',        Icon: FolderTree   },
     { label: 'Dependencies', tab: 'dependencies', Icon: Package      },
     { label: 'Pull Requests', tab: 'pulls',       Icon: GitBranch    },

--- a/frontend/src/components/SettingsPanel.jsx
+++ b/frontend/src/components/SettingsPanel.jsx
@@ -15,6 +15,9 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
   const [autoSync,     setAutoSync]     = useState(repo?.auto_sync_enabled ?? false);
   const [autoPublish,  setAutoPublish]  = useState(repo?.pr_review_auto_publish ?? true);
   const [blockSeverity, setBlockSeverity] = useState(repo?.pr_review_block_on_severity || 'critical');
+  const [depStrategy,  setDepStrategy]  = useState(repo?.dependency_update_strategy || 'minimum_safe');
+  const [depThreshold, setDepThreshold] = useState(repo?.dependency_batch_threshold ?? 3);
+  const [depAutoPr,    setDepAutoPr]    = useState(repo?.dependency_auto_pr_enabled ?? false);
   const [isSaving,     setIsSaving]     = useState(false);
   const [webhookInfo,  setWebhookInfo]  = useState(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -78,7 +81,11 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
     setAutoSync(repo?.auto_sync_enabled ?? false);
     setAutoPublish(repo?.pr_review_auto_publish ?? true);
     setBlockSeverity(repo?.pr_review_block_on_severity || 'critical');
-  }, [repo?.auto_sync_enabled, repo?.pr_review_auto_publish, repo?.pr_review_block_on_severity]);
+    setDepStrategy(repo?.dependency_update_strategy || 'minimum_safe');
+    setDepThreshold(repo?.dependency_batch_threshold ?? 3);
+    setDepAutoPr(repo?.dependency_auto_pr_enabled ?? false);
+  }, [repo?.auto_sync_enabled, repo?.pr_review_auto_publish, repo?.pr_review_block_on_severity,
+      repo?.dependency_update_strategy, repo?.dependency_batch_threshold, repo?.dependency_auto_pr_enabled]);
 
   const saveRepoSettings = async (updates) => {
     setIsSaving(true);
@@ -118,6 +125,25 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
     const next = event.target.value;
     setBlockSeverity(next);
     await saveRepoSettings({ pr_review_block_on_severity: next });
+  };
+
+  const handleDepStrategyChange = async (event) => {
+    const next = event.target.value;
+    setDepStrategy(next);
+    await saveRepoSettings({ dependency_update_strategy: next });
+  };
+
+  const handleDepThresholdChange = async (event) => {
+    const raw = parseInt(event.target.value, 10);
+    const next = isNaN(raw) ? 3 : Math.max(1, Math.min(20, raw));
+    setDepThreshold(next);
+    await saveRepoSettings({ dependency_batch_threshold: next });
+  };
+
+  const handleDepAutoPrToggle = async () => {
+    const next = !depAutoPr;
+    setDepAutoPr(next);
+    await saveRepoSettings({ dependency_auto_pr_enabled: next });
   };
 
   const handleGenerateWebhook = async () => {
@@ -328,6 +354,68 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
             ))}
           </div>
         )}
+      </Panel>
+
+      {/* Dependency Updates — US-084 */}
+      <Panel>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-white">Dependency Updates</h3>
+            <p className="mt-1 text-sm text-gray-400">
+              Configure automatic batch fix PRs for vulnerable npm/yarn dependencies.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 space-y-5">
+          {/* Update strategy */}
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-gray-300">Update strategy</p>
+              <p className="text-xs text-gray-500 mt-0.5">Whether to target the minimum CVE-fixing version or the latest non-breaking version.</p>
+            </div>
+            <Select
+              value={depStrategy}
+              onChange={handleDepStrategyChange}
+              disabled={isSaving}
+              inputClassName="w-44"
+            >
+              <option value="minimum_safe">Minimum safe</option>
+              <option value="latest_safe">Latest safe</option>
+            </Select>
+          </div>
+
+          {/* Batch threshold */}
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-gray-300">Batch threshold</p>
+              <p className="text-xs text-gray-500 mt-0.5">Open a single batched PR when this many vulnerabilities are open (1–20).</p>
+            </div>
+            <input
+              type="number"
+              min={1}
+              max={20}
+              value={depThreshold}
+              onChange={handleDepThresholdChange}
+              disabled={isSaving}
+              className="w-20 rounded-lg border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm text-white text-center outline-none focus:border-indigo-500 disabled:opacity-50"
+            />
+          </div>
+
+          {/* Auto-PR toggle */}
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-gray-300">Auto-PR on index</p>
+              <p className="text-xs text-gray-500 mt-0.5">Automatically open a batch fix PR after each index when the threshold is met.</p>
+            </div>
+            <Switch
+              checked={depAutoPr}
+              onChange={handleDepAutoPrToggle}
+              disabled={isSaving}
+              label=""
+            />
+          </div>
+        </div>
       </Panel>
     </div>
   );

--- a/frontend/src/components/TrendsPanel.jsx
+++ b/frontend/src/components/TrendsPanel.jsx
@@ -1,0 +1,337 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  AreaChart, Area, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip,
+  ResponsiveContainer, Legend,
+} from 'recharts';
+import { useAuth } from '../context/AuthContext';
+import { apiUrl } from '../lib/api';
+import { TrendingUp, TrendingDown, Download } from './ui/Icons';
+
+const RANGES = [
+  { label: '7d',  value: '7d'  },
+  { label: '30d', value: '30d' },
+  { label: '90d', value: '90d' },
+  { label: 'All', value: 'all' },
+];
+
+const SEVERITY_COLORS = {
+  critical: '#ef4444',
+  high:     '#f97316',
+  medium:   '#eab308',
+  low:      '#22c55e',
+};
+
+function KpiCard({ label, value, delta, lowerIsBetter = true }) {
+  const isNeutral = delta == null || delta === 0;
+  const isWorse = lowerIsBetter ? delta > 0 : delta < 0;
+  const color = isNeutral ? 'text-gray-400' : isWorse ? 'text-red-400' : 'text-green-400';
+  const Icon = delta > 0 ? TrendingUp : TrendingDown;
+
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-4">
+      <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500">{label}</p>
+      <p className="text-2xl font-bold text-white tabular-nums">
+        {value != null ? value.toLocaleString() : '—'}
+      </p>
+      {!isNeutral && (
+        <span className={`flex items-center gap-1 text-xs font-medium ${color}`}>
+          <Icon className="h-3 w-3" />
+          {delta > 0 ? '+' : ''}{typeof delta === 'number' && !Number.isInteger(delta) ? delta.toFixed(2) : delta} vs period start
+        </span>
+      )}
+    </div>
+  );
+}
+
+function NoDataBanner({ snapshotCount }) {
+  return (
+    <div className="rounded-xl border border-dashed border-gray-700 bg-gray-900/30 px-6 py-4 text-sm text-gray-400">
+      {snapshotCount < 7
+        ? 'Trends fill in as your repo is re-indexed daily. Come back in a week for a full picture.'
+        : 'No snapshot data available for this period.'}
+    </div>
+  );
+}
+
+function ChartCard({ title, children }) {
+  return (
+    <div className="rounded-xl border border-gray-800 bg-gray-900/60 px-5 py-4">
+      <p className="mb-3 text-xs uppercase tracking-[0.2em] text-gray-500">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const [, m, d] = dateStr.split('-');
+  return `${m}/${d}`;
+}
+
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-xs shadow-xl">
+      <p className="mb-1 font-medium text-gray-300">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full" style={{ background: entry.color }} />
+          <span className="text-gray-400">{entry.name}:</span>
+          <span className="font-semibold text-white">
+            {typeof entry.value === 'number' && !Number.isInteger(entry.value)
+              ? entry.value.toFixed(2)
+              : entry.value?.toLocaleString()}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function exportCsv(snapshots) {
+  if (!snapshots?.length) return;
+  const headers = [
+    'date', 'file_count', 'total_loc', 'avg_complexity',
+    'critical_issues', 'high_issues', 'medium_issues', 'low_issues',
+    'vuln_critical', 'vuln_high', 'vuln_medium', 'vuln_low',
+  ];
+  const rows = snapshots.map(s => [
+    s.snapshot_date,
+    s.file_count,
+    s.total_loc,
+    s.avg_complexity != null ? s.avg_complexity.toFixed(2) : '',
+    s.issue_counts_json?.by_severity?.critical ?? 0,
+    s.issue_counts_json?.by_severity?.high ?? 0,
+    s.issue_counts_json?.by_severity?.medium ?? 0,
+    s.issue_counts_json?.by_severity?.low ?? 0,
+    s.vulnerability_counts_json?.by_severity?.critical ?? 0,
+    s.vulnerability_counts_json?.by_severity?.high ?? 0,
+    s.vulnerability_counts_json?.by_severity?.medium ?? 0,
+    s.vulnerability_counts_json?.by_severity?.low ?? 0,
+  ].join(','));
+  const csv = [headers.join(','), ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'codelens-trends.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function TrendsPanel({ repoId }) {
+  const { session } = useAuth();
+  const [range, setRange] = useState('30d');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchTrends = useCallback(async () => {
+    if (!session?.access_token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(apiUrl(`/api/repos/${repoId}/trends?range=${range}`), {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) throw new Error('Failed to load trends');
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [repoId, range, session?.access_token]);
+
+  useEffect(() => { fetchTrends(); }, [fetchTrends]);
+
+  const snapshots = data?.snapshots ?? [];
+  const summary = data?.summary ?? null;
+
+  // Flatten snapshot data for Recharts
+  const chartData = snapshots.map(s => ({
+    date:     formatDate(s.snapshot_date),
+    fullDate: s.snapshot_date,
+    file_count:     s.file_count ?? 0,
+    total_loc:      s.total_loc ?? 0,
+    avg_complexity: s.avg_complexity != null ? parseFloat(s.avg_complexity.toFixed(2)) : 0,
+    critical: s.issue_counts_json?.by_severity?.critical ?? 0,
+    high:     s.issue_counts_json?.by_severity?.high ?? 0,
+    medium:   s.issue_counts_json?.by_severity?.medium ?? 0,
+    low:      s.issue_counts_json?.by_severity?.low ?? 0,
+    vuln_critical: s.vulnerability_counts_json?.by_severity?.critical ?? 0,
+    vuln_high:     s.vulnerability_counts_json?.by_severity?.high ?? 0,
+    vuln_medium:   s.vulnerability_counts_json?.by_severity?.medium ?? 0,
+    vuln_low:      s.vulnerability_counts_json?.by_severity?.low ?? 0,
+  }));
+
+  const cur  = summary?.current;
+  const delta = summary?.delta;
+
+  const totalVulnsCur   = cur ? ((cur.total_vulnerabilities) ?? 0) : null;
+  const deltaVulns       = delta?.total_vulnerabilities ?? null;
+  const deltaCritical    = delta?.critical_issues ?? null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-white">Trends</h2>
+        <div className="flex items-center gap-2">
+          {/* Range selector */}
+          <div className="flex rounded-lg border border-gray-700 bg-gray-900 overflow-hidden">
+            {RANGES.map(r => (
+              <button
+                key={r.value}
+                onClick={() => setRange(r.value)}
+                className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                  range === r.value
+                    ? 'bg-indigo-600 text-white'
+                    : 'text-gray-400 hover:text-white'
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+          {/* CSV export */}
+          <button
+            onClick={() => exportCsv(snapshots)}
+            disabled={!snapshots.length}
+            title="Export as CSV"
+            className="flex items-center gap-1.5 rounded-lg border border-gray-700 bg-gray-900 px-3 py-1.5 text-xs text-gray-400 hover:text-white hover:border-gray-500 transition disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Download className="h-3.5 w-3.5" />
+            CSV
+          </button>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-xl border border-gray-800 bg-gray-900/60" />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-400">{error}</div>
+      )}
+
+      {!loading && !error && (
+        <>
+          {/* KPI strip */}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <KpiCard
+              label="Critical Issues"
+              value={cur?.critical_issues ?? null}
+              delta={deltaCritical}
+              lowerIsBetter
+            />
+            <KpiCard
+              label="Vulnerabilities"
+              value={totalVulnsCur}
+              delta={deltaVulns}
+              lowerIsBetter
+            />
+            <KpiCard
+              label="Avg Complexity"
+              value={cur?.avg_complexity != null ? parseFloat(cur.avg_complexity.toFixed(2)) : null}
+              delta={delta?.avg_complexity ?? null}
+              lowerIsBetter
+            />
+            <KpiCard
+              label="File Count"
+              value={cur?.file_count ?? null}
+              delta={delta?.file_count ?? null}
+              lowerIsBetter={false}
+            />
+          </div>
+
+          {/* "Too little data" helper */}
+          {snapshots.length < 7 && <NoDataBanner snapshotCount={snapshots.length} />}
+
+          {snapshots.length === 0 ? null : (
+            <div className="space-y-4">
+              {/* Issues by severity */}
+              <ChartCard title="Total Issues by Severity">
+                <ResponsiveContainer width="100%" height={200}>
+                  <AreaChart data={chartData} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                    <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} allowDecimals={false} width={32} />
+                    <RechartsTooltip content={<CustomTooltip />} />
+                    <Legend wrapperStyle={{ fontSize: 11, color: '#9ca3af' }} />
+                    <Area type="monotone" dataKey="critical" name="Critical" stackId="1" stroke={SEVERITY_COLORS.critical} fill={SEVERITY_COLORS.critical} fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="high"     name="High"     stackId="1" stroke={SEVERITY_COLORS.high}     fill={SEVERITY_COLORS.high}     fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="medium"   name="Medium"   stackId="1" stroke={SEVERITY_COLORS.medium}   fill={SEVERITY_COLORS.medium}   fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="low"      name="Low"      stackId="1" stroke={SEVERITY_COLORS.low}      fill={SEVERITY_COLORS.low}      fillOpacity={0.3} />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </ChartCard>
+
+              {/* Vulnerabilities by severity */}
+              <ChartCard title="Vulnerability Count by Severity">
+                <ResponsiveContainer width="100%" height={200}>
+                  <AreaChart data={chartData} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                    <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} allowDecimals={false} width={32} />
+                    <RechartsTooltip content={<CustomTooltip />} />
+                    <Legend wrapperStyle={{ fontSize: 11, color: '#9ca3af' }} />
+                    <Area type="monotone" dataKey="vuln_critical" name="Critical" stackId="1" stroke={SEVERITY_COLORS.critical} fill={SEVERITY_COLORS.critical} fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="vuln_high"     name="High"     stackId="1" stroke={SEVERITY_COLORS.high}     fill={SEVERITY_COLORS.high}     fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="vuln_medium"   name="Medium"   stackId="1" stroke={SEVERITY_COLORS.medium}   fill={SEVERITY_COLORS.medium}   fillOpacity={0.3} />
+                    <Area type="monotone" dataKey="vuln_low"      name="Low"      stackId="1" stroke={SEVERITY_COLORS.low}      fill={SEVERITY_COLORS.low}      fillOpacity={0.3} />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </ChartCard>
+
+              {/* Average complexity */}
+              <ChartCard title="Average Complexity">
+                <ResponsiveContainer width="100%" height={180}>
+                  <LineChart data={chartData} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                    <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} width={40} />
+                    <RechartsTooltip content={<CustomTooltip />} />
+                    <Line type="monotone" dataKey="avg_complexity" name="Avg Complexity" stroke="#818cf8" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </ChartCard>
+
+              {/* File count */}
+              <ChartCard title="File Count">
+                <ResponsiveContainer width="100%" height={180}>
+                  <LineChart data={chartData} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                    <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} allowDecimals={false} width={40} />
+                    <RechartsTooltip content={<CustomTooltip />} />
+                    <Line type="monotone" dataKey="file_count" name="Files" stroke="#34d399" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </ChartCard>
+
+              {/* Total LOC */}
+              <ChartCard title="Total Lines of Code">
+                <ResponsiveContainer width="100%" height={180}>
+                  <LineChart data={chartData} margin={{ top: 4, right: 12, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                    <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} width={52} tickFormatter={v => v >= 1000 ? `${(v/1000).toFixed(0)}k` : v} />
+                    <RechartsTooltip content={<CustomTooltip />} />
+                    <Line type="monotone" dataKey="total_loc" name="LOC" stroke="#60a5fa" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </ChartCard>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -17,6 +17,7 @@ const FileChatPanel        = lazy(() => import('../components/FileChatPanel'));
 const FileBrowser          = lazy(() => import('../components/FileBrowser'));
 const DependenciesPanel    = lazy(() => import('../components/DependenciesPanel'));
 const PullRequestsPanel    = lazy(() => import('../components/PullRequestsPanel'));
+const TrendsPanel          = lazy(() => import('../components/TrendsPanel'));
 const MetricsPanel         = lazy(() => import('../components/MetricsPanel'));
 const IssuesPanel          = lazy(() => import('../components/IssuesPanel'));
 const SettingsPanel        = lazy(() => import('../components/SettingsPanel'));
@@ -859,6 +860,11 @@ export default function RepoView() {
                   active={activeTab === 'pulls'}
                   onRepoUpdated={fetchRepo}
                 />
+              </div>
+
+              {/* Trends tab — daily metrics over time (US-082) */}
+              <div className={activeTab === 'trends' ? 'tab-panel-active h-full' : 'tab-panel-hidden h-full'}>
+                {activeTab === 'trends' && <TrendsPanel repoId={repoId} />}
               </div>
             </div>
           </Suspense>

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1857,5 +1857,17 @@ EXCEPTION WHEN OTHERS THEN
 END $$;
 
 -- =============================================================================
+-- US-084: Vulnerable dependency auto-PR + batching settings on repositories
+-- =============================================================================
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS dependency_update_strategy TEXT NOT NULL DEFAULT 'minimum_safe';
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_dependency_update_strategy_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_dependency_update_strategy_check
+  CHECK (dependency_update_strategy IN ('minimum_safe', 'latest_safe'));
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS dependency_batch_threshold INT NOT NULL DEFAULT 3;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS dependency_auto_pr_enabled BOOLEAN NOT NULL DEFAULT false;
+
+-- =============================================================================
 -- END OF SCHEMA
 -- =============================================================================


### PR DESCRIPTION
US-082: Trends tab — GET /api/repos/:id/trends endpoint querying repo_metrics_daily, TrendsPanel with Recharts (stacked area + line charts), KPI strip with deltas, CSV export, range selector, and "< 7 days" banner. Trends tab added to sidebar nav.

US-083: dependencyFixer service — deterministic npm/yarn dep upgrades using @npmcli/arborist (tmpdir reify) and @yarnpkg/lockfile; pnpm stub; 30s timeout; full error taxonomy. No shell-out.

US-084: Batch vulnerable-dep auto-PR — fast path in generateProposal skips Claude for simple npm/yarn bumps using dependencyFixer; POST /api/repos/:id/dependencies/ batch-proposal endpoint groups vulns by manifest, chains fixer calls, opens a draft GitHub PR with CVE table + per-package blast-radius callout, idempotent via SHA256 batch key. Auto-PR trigger in indexer fires when dependency_auto_pr_enabled and threshold met. Schema adds dependency_update_strategy/batch_threshold/auto_pr_enabled columns. Frontend: Batch fix PR button in IssuesPanel vuln deps header, dependency settings section in SettingsPanel.