### PR TITLE
Fix pre-demo security, correctness, and UX issues

### DIFF
--- a/backend/src/controllers/analysisController.js
+++ b/backend/src/controllers/analysisController.js
@@ -2,6 +2,7 @@ const { supabase, supabaseAdmin } = require('../db/supabase');
 const { SAFE_FETCH_CEILING, warnIfCeilingHit } = require('../lib/dbHelpers');
 const graphService = require('../services/graphService');
 const { buildRiskContext, computeRiskComponents } = require('../services/riskScoring');
+const { canAccessRepo } = require('../lib/repoAccess');
 
 async function attachRiskComponents(repoId, issues) {
   const ctx = await buildRiskContext(repoId);
@@ -17,8 +18,11 @@ async function attachRiskComponents(repoId, issues) {
 
 /** GET /api/analysis/:repoId/graph — dependency graph overview (counts + top hubs/sinks + cycle count) */
 const getDependencyGraph = async (req, res) => {
+  const { repoId } = req.params;
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
   try {
-    const overview = await graphService.getGraphOverview(req.params.repoId);
+    const overview = await graphService.getGraphOverview(repoId);
     res.json(overview);
   } catch (err) {
     console.error('[getDependencyGraph]', err);
@@ -29,6 +33,8 @@ const getDependencyGraph = async (req, res) => {
 /** GET /api/analysis/:repoId/metrics — per-file complexity metrics */
 const getMetrics = async (req, res) => {
   const { repoId } = req.params;
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
   const { data, error } = await supabaseAdmin
     .from('graph_nodes')
     .select('file_path, language, line_count, complexity_score, incoming_count, outgoing_count, node_classification, is_test_file')
@@ -42,6 +48,8 @@ const getMetrics = async (req, res) => {
 /** GET /api/analysis/:repoId/issues — architectural issues (circular deps, god files, etc.) */
 const getIssues = async (req, res) => {
   const { repoId } = req.params;
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
   const { data, error } = await supabaseAdmin
     .from('analysis_issues')
     .select('*')
@@ -54,10 +62,15 @@ const getIssues = async (req, res) => {
 };
 
 /** POST /api/analysis/:repoId/issues/suppress — mark an issue as a false positive */
+const SUPPRESSIBLE_ISSUE_TYPES = new Set(['missing_auth', 'hardcoded_secret', 'insecure_pattern']);
+
 const suppressIssue = async (req, res) => {
   const { repoId } = req.params;
-  const { file_path, rule_id, line_number } = req.body;
+  const { file_path, rule_id, line_number, type } = req.body;
   const userId = req.user.id;
+
+  const allowed = await canAccessRepo(repoId, userId);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
 
   // 1. Insert into suppressions table
   const { error: suppError } = await supabase
@@ -66,8 +79,13 @@ const suppressIssue = async (req, res) => {
 
   if (suppError) return res.status(500).json({ error: suppError.message });
 
-  // Derive issue type from rule_id so the delete targets the correct row
-  const issueType = rule_id === 'missing_auth' ? 'missing_auth' : 'hardcoded_secret';
+  // The issue type drives which analysis_issues row the delete targets. Prefer
+  // the explicit type sent by the client (it always knows the issue's type);
+  // fall back to a rule_id heuristic for older callers. Secret rule ids are
+  // free-form (aws_access_key, github_pat, …) so we can't infer them by prefix.
+  const issueType = SUPPRESSIBLE_ISSUE_TYPES.has(type)
+    ? type
+    : (rule_id === 'missing_auth' ? 'missing_auth' : 'hardcoded_secret');
 
   // 2. Delete the active issue from analysis_issues so it disappears immediately
   await supabaseAdmin
@@ -84,6 +102,8 @@ const suppressIssue = async (req, res) => {
 const getImpact = async (req, res) => {
   try {
     const { repoId, filePath } = req.params;
+    const allowed = await canAccessRepo(repoId, req.user.id);
+    if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
     const result = await graphService.getBlastRadius(repoId, filePath);
     res.json(result);
   } catch (err) {

--- a/backend/src/controllers/repoController.js
+++ b/backend/src/controllers/repoController.js
@@ -163,11 +163,16 @@ const listRepos = async (req, res) => {
 /** GET /api/repos/:repoId/status — polling endpoint for indexing progress */
 const getStatus = async (req, res) => {
   const { repoId } = req.params;
+
+  // Team members (not just the owner) must be able to poll status, so gate on
+  // can_access_repo rather than a hard user_id match.
+  const allowed = await canAccessRepo(repoId, req.user.id);
+  if (!allowed) return res.status(404).json({ error: 'Repository not found' });
+
   const { data, error } = await supabaseAdmin
     .from('repositories')
-    .select('status, file_count, sast_disabled_rules')
+    .select('status, file_count, sast_disabled_rules, indexed_at')
     .eq('id', repoId)
-    .eq('user_id', req.user.id)
     .single();
 
   if (error || !data) {

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -61,10 +61,11 @@ const handleGitHubPush = async (req, res) => {
     .update(rawBody)
     .digest('hex');
 
-  const isValid = crypto.timingSafeEqual(
-    Buffer.from(signature, 'utf8'),
-    Buffer.from(expected, 'utf8')
-  );
+  // timingSafeEqual throws if the buffers differ in length, so guard the
+  // length first — a malformed/short signature must be a clean 403, not a 500.
+  const sigBuf = Buffer.from(signature, 'utf8');
+  const expBuf = Buffer.from(expected, 'utf8');
+  const isValid = sigBuf.length === expBuf.length && crypto.timingSafeEqual(sigBuf, expBuf);
 
   if (!isValid) {
     return res.status(403).json({ error: 'Invalid webhook signature' });

--- a/backend/src/routes/internal.js
+++ b/backend/src/routes/internal.js
@@ -5,8 +5,9 @@ const { supabaseAdmin } = require('../db/supabase');
 // Middleware to check server secret
 const requireServerSecret = (req, res, next) => {
   const secret = req.headers['server-secret'];
-  const expected = process.env.CI_TOKEN_HMAC_SECRET || 'fallback-secret-for-dev';
-  if (!secret || secret !== expected) {
+  const expected = process.env.CI_TOKEN_HMAC_SECRET;
+  // No fallback: if the secret isn't configured the endpoint is closed, not open.
+  if (!expected || !secret || secret !== expected) {
     return res.status(401).json({ error: 'Unauthorized: Invalid server-secret header' });
   }
   next();

--- a/frontend/src/components/AgentPanel.jsx
+++ b/frontend/src/components/AgentPanel.jsx
@@ -476,7 +476,14 @@ export default function AgentPanel({ repoId, onOpenFile, onSwitchTab }) {
 
   // ── Rehydrate a saved conversation into the UI's message shape ───────────
   const loadConversation = useCallback(async (convId) => {
-    if (!session?.access_token) return;
+    if (!session?.access_token || convId === activeConvId) return;
+    // Abort any in-flight stream and clear the previous conversation's messages
+    // up front so its content doesn't linger (or get appended to) while the
+    // selected conversation loads.
+    abortRef.current?.abort();
+    setActiveConvId(convId);
+    setBudgetStopped(false);
+    setMessages([]);
     try {
       const res = await fetch(apiUrl(`/api/agent/conversations/${convId}`), {
         headers: { Authorization: `Bearer ${session.access_token}` },
@@ -486,13 +493,11 @@ export default function AgentPanel({ repoId, onOpenFile, onSwitchTab }) {
         return;
       }
       const data = await res.json();
-      setActiveConvId(convId);
-      setBudgetStopped(false);
       setMessages(rowsToTurns(data.messages || []));
     } catch (err) {
       toast.error(err.message);
     }
-  }, [session?.access_token, toast]);
+  }, [activeConvId, session?.access_token, toast]);
 
   // ── New conversation (frontend-only until first send) ────────────────────
   const handleNewConversation = useCallback(() => {

--- a/frontend/src/components/DependenciesPanel.jsx
+++ b/frontend/src/components/DependenciesPanel.jsx
@@ -315,7 +315,7 @@ export default function DependenciesPanel({ repoId, refreshKey = 0 }) {
       </div>
 
       <div className="shrink-0 rounded-xl border border-gray-800 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
-        Dependencies is the full package inventory for this repository. Vulnerable packages are also listed in `Issues` so risk triage stays in one place.
+        Dependencies is the full package inventory for this repository. Vulnerable packages are also listed in <span className="font-medium text-gray-300">Issues</span> so risk triage stays in one place.
       </div>
 
       {(highlightedPackage || highlightedFromIssue) && (

--- a/frontend/src/components/IssuesPanel.jsx
+++ b/frontend/src/components/IssuesPanel.jsx
@@ -10,6 +10,7 @@ import Modal from './ui/Modal';
 import { Button, Badge, Select } from './ui/Primitives';
 import IssueCard, { getBadgeStyles } from './IssueCard';
 import ProposalPanel from './ProposalPanel';
+import { useToast } from './Toast';
 import {
   Package, Lock, ShieldAlert, GitMerge,
   FileWarning, Link2, FileX, Search,
@@ -371,13 +372,13 @@ function DuplicationDetailModal({ cluster, repoId, token, onClose }) {
 export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDependencies, onOpenFile, repoId }) {
   const { session } = useAuth();
   const accessToken = session?.access_token;
+  const toast = useToast();
 
   const [localIssues, setLocalIssues] = useState(issues || []);
   const [duplicationClusters, setDuplicationClusters] = useState([]);
   const [selectedDuplicationCluster, setSelectedDuplicationCluster] = useState(null);
   const [filterText,  setFilterText]  = useState('');
   const [sortBy, setSortBy] = useState('risk');
-  const [isFetching, setIsFetching] = useState(false);
   const [canMutateIssues, setCanMutateIssues] = useState(true);
   const [selectedProposalIssue, setSelectedProposalIssue] = useState(null);
   const [proposalsByIssue, setProposalsByIssue] = useState({});
@@ -388,11 +389,11 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   // needs the actual DOM node, not a ref placeholder.
   const [scrollParent, setScrollParent] = useState(null);
 
-  // Sync local state if the upstream issues prop changes
+  // Sync local state if the upstream issues prop changes. Always mirror the
+  // prop (including the empty case) so a re-index that clears issues doesn't
+  // leave stale cards on screen.
   useEffect(() => {
-    if (issues && issues.length > 0) {
-      setLocalIssues(issues);
-    }
+    setLocalIssues(issues || []);
   }, [issues]);
 
 
@@ -497,15 +498,29 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
   const handleSuppress = useCallback(async (e, issue) => {
     e.stopPropagation();
     if (!canMutateIssues) return;
-    const ruleMatch = issue.description.match(/Rule ID: (.*?)\)/);
-    if (!ruleMatch) return;
-    const lineMatch = issue.description.match(/line (\d+)/);
 
-    const payload = {
-      file_path:   issue.file_paths[0],
-      rule_id:     ruleMatch[1],
-      line_number: lineMatch ? parseInt(lineMatch[1], 10) : 0,
-    };
+    let payload;
+    if (issue.type === 'missing_auth') {
+      // missing_auth is a file-level suppression with a fixed rule_id and the
+      // line_number: 0 sentinel — it has no "line N" in its description.
+      payload = {
+        file_path:   issue.file_paths[0],
+        rule_id:     'missing_auth',
+        line_number: 0,
+        type:        'missing_auth',
+      };
+    } else {
+      const ruleMatch = issue.description.match(/Rule ID: (.*?)\)/);
+      if (!ruleMatch) return;
+      const lineMatch = issue.description.match(/line (\d+)/);
+      payload = {
+        file_path:   issue.file_paths[0],
+        rule_id:     ruleMatch[1],
+        line_number: lineMatch ? parseInt(lineMatch[1], 10) : 0,
+        type:        issue.type,
+      };
+    }
+
     try {
       const res = await fetch(apiUrl(`/api/analysis/${repoId}/issues/suppress`), {
         method: 'POST',
@@ -519,8 +534,9 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
       setLocalIssues(prev => prev.filter(i => i.id !== issue.id));
     } catch (err) {
       console.error('Failed to suppress issue', err);
+      toast.error(err.message || 'Failed to suppress issue');
     }
-  }, [canMutateIssues, repoId, session]);
+  }, [canMutateIssues, repoId, session, toast]);
 
   const handleDisableSastRule = useCallback(async (e, issue) => {
     e.stopPropagation();
@@ -589,20 +605,11 @@ export default function IssuesPanel({ nodes, issues, onNodeSelect, onOpenDepende
     return (
       <>
         <div className="flex h-auto min-h-[30rem] flex-col items-center justify-center rounded-xl border border-dashed border-gray-700 bg-gray-900/30 px-6 text-center xl:h-[calc(100vh-12rem)]">
-          {isFetching ? (
-            <div className="flex flex-col items-center">
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent mb-3" />
-              <p className="text-sm text-gray-400">Loading issues...</p>
-            </div>
-          ) : (
-            <>
-              <div className="flex items-center justify-center w-16 h-16 rounded-full bg-green-500/10 border border-green-500/20 mb-4">
-                <CheckCircle2 className="w-8 h-8 text-green-400" />
-              </div>
-              <h3 className="text-lg font-medium text-gray-200">No issues detected</h3>
-              <p className="mt-1 text-sm text-gray-500">No architectural, security, or duplication findings need attention.</p>
-            </>
-          )}
+          <div className="flex items-center justify-center w-16 h-16 rounded-full bg-green-500/10 border border-green-500/20 mb-4">
+            <CheckCircle2 className="w-8 h-8 text-green-400" />
+          </div>
+          <h3 className="text-lg font-medium text-gray-200">No issues detected</h3>
+          <p className="mt-1 text-sm text-gray-500">No architectural, security, or duplication findings need attention.</p>
         </div>
         <DuplicationDetailModal
           cluster={selectedDuplicationCluster}

--- a/frontend/src/components/PullRequestsPanel.jsx
+++ b/frontend/src/components/PullRequestsPanel.jsx
@@ -151,7 +151,9 @@ export default function PullRequestsPanel({ repoId, repo, active, onRepoUpdated 
   const [listError, setListError] = useState(null);
   const [detail, setDetail] = useState(null);
   const [history, setHistory] = useState([]);
-  const [detailLoading, setDetailLoading] = useState(false);
+  // When a review id is present in the URL the detail fetch fires on mount, so
+  // start in the loading state to avoid flashing undefined PR data first.
+  const [detailLoading, setDetailLoading] = useState(Boolean(reviewId));
   const [isEnabling, setIsEnabling] = useState(false);
   const [isRerunning, setIsRerunning] = useState(false);
   const [runStatus, setRunStatus] = useState('');
@@ -317,6 +319,7 @@ export default function PullRequestsPanel({ repoId, repo, active, onRepoUpdated 
         file_path: finding.file_path || finding.file_paths?.[0],
         rule_id: finding.rule_id || finding._meta?.rule_id,
         line_number: finding.line_number || finding._meta?.line_number || 0,
+        type: finding.type,
       };
       const res = await fetch(apiUrl(`/api/analysis/${repoId}/issues/suppress`), {
         method: 'POST',

--- a/frontend/src/components/SettingsPanel.jsx
+++ b/frontend/src/components/SettingsPanel.jsx
@@ -157,7 +157,7 @@ export default function SettingsPanel({ repo, session, onRepoUpdated }) {
       const data = await res.json();
       setWebhookInfo(data);
     } catch (err) {
-      console.error(err);
+      toast.error(err.message || 'Failed to generate webhook');
     } finally {
       setIsGenerating(false);
     }

--- a/frontend/src/components/__tests__/IssuesPanel.test.jsx
+++ b/frontend/src/components/__tests__/IssuesPanel.test.jsx
@@ -6,6 +6,10 @@ vi.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ session: { access_token: 'token-1' } }),
 }));
 
+vi.mock('../Toast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
 import IssuesPanel from '../IssuesPanel';
 
 function makeSseResponse(events) {

--- a/frontend/src/components/__tests__/PullRequestsPanel.test.jsx
+++ b/frontend/src/components/__tests__/PullRequestsPanel.test.jsx
@@ -166,7 +166,7 @@ describe('PullRequestsPanel', () => {
     expect(screen.getByText(/high: 0/i)).toBeInTheDocument();
     expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/analysis/repo-1/issues/suppress'), expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ file_path: 'src/auth.js', rule_id: 'missing_check', line_number: 12 }),
+      body: JSON.stringify({ file_path: 'src/auth.js', rule_id: 'missing_check', line_number: 12, type: 'insecure_pattern' }),
     }));
   });
 });

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -107,16 +107,22 @@ const RepoCard = memo(function RepoCard({ repo, onRetry, onDelete, isRetrying, s
           </div>
 
           <LanguageMiniBar languages={repo.languages} />
+
+          <p
+            className="inline-flex min-w-0 max-w-full items-center gap-1.5 truncate text-xs text-surface-500"
+            title={repo.indexed_at
+              ? `Indexed ${new Date(repo.indexed_at).toLocaleString()}`
+              : `Added ${new Date(repo.created_at).toLocaleString()}`}
+          >
+            <Clock className="h-3.5 w-3.5 shrink-0" />
+            {repo.indexed_at
+              ? `Indexed ${timeAgo(repo.indexed_at)}`
+              : `Added ${timeAgo(repo.created_at)}`}
+          </p>
         </div>
       </Link>
 
-      <div className="flex items-center justify-between gap-3 border-t border-surface-800 bg-surface-950/35 px-5 py-3.5">
-        <span className="inline-flex min-w-0 items-center gap-1.5 truncate text-xs text-surface-500">
-          <Clock className="h-3.5 w-3.5 shrink-0" />
-          {repo.indexed_at
-            ? `Indexed ${timeAgo(repo.indexed_at)}`
-            : `Added ${timeAgo(repo.created_at)}`}
-        </span>
+      <div className="flex items-center justify-end gap-3 border-t border-surface-800 bg-surface-950/35 px-5 py-3.5">
         <Toolbar className="shrink-0 gap-1.5">
           {!repo.shared && (
             <Button

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import { LANGUAGE_COLORS } from '../lib/constants';
 import ConnectGitHubModal from '../components/ConnectGitHubModal';
 import UploadRepoModal from '../components/UploadRepoModal';
 import CreateTeamModal from '../components/CreateTeamModal';
+import Modal from '../components/ui/Modal';
 import { Badge, Banner, Button, EmptyState, Panel, SearchInput, Select, Skeleton, Toolbar } from '../components/ui/Primitives';
 import {
   ArrowRight,
@@ -134,7 +135,7 @@ const RepoCard = memo(function RepoCard({ repo, onRetry, onDelete, isRetrying, s
               size="sm"
               variant="danger"
               icon={Trash2}
-              onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDelete(e, repo.id); }}
+              onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDelete(e, repo.id, repo.name); }}
             >
               Delete
             </Button>
@@ -167,6 +168,8 @@ export default function Dashboard() {
   const [retryingIds, setRetryingIds] = useState(() => new Set());
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('updated');
+  const [pendingDelete, setPendingDelete] = useState(null); // { id, name } awaiting confirmation
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const fetchRepos = useCallback(async () => {
     if (!session?.access_token) return;
@@ -220,19 +223,27 @@ export default function Dashboard() {
     }
   };
 
-  const handleDelete = async (e, repoId) => {
+  const handleDelete = (e, repoId, repoName) => {
     e.preventDefault(); e.stopPropagation();
-    if (!window.confirm('Are you sure you want to delete this repository? This cannot be undone.')) return;
+    setPendingDelete({ id: repoId, name: repoName });
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+    setIsDeleting(true);
     try {
-      const res = await fetch(apiUrl(`/api/repos/${repoId}`), {
+      const res = await fetch(apiUrl(`/api/repos/${pendingDelete.id}`), {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${session.access_token}` },
       });
       if (!res.ok) throw new Error('Failed to delete repository');
       await fetchRepos();
       toast.success('Repository deleted');
+      setPendingDelete(null);
     } catch (err) {
       toast.error(err.message);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -383,6 +394,27 @@ export default function Dashboard() {
           toast.success(`Team "${team.name}" created with ${count} collaborator${count !== 1 ? 's' : ''} added.`);
         }}
       />
+      <Modal
+        isOpen={!!pendingDelete}
+        onClose={() => { if (!isDeleting) setPendingDelete(null); }}
+        title="Delete repository"
+      >
+        <div className="px-5 py-4">
+          <p className="text-sm text-surface-300">
+            Are you sure you want to delete{' '}
+            <span className="font-semibold text-surface-100">{pendingDelete?.name || 'this repository'}</span>?
+            This permanently removes its index, analysis, and history and cannot be undone.
+          </p>
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setPendingDelete(null)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button variant="danger" icon={Trash2} loading={isDeleting} onClick={confirmDelete}>
+              Delete repository
+            </Button>
+          </div>
+        </div>
+      </Modal>
       </div>
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,7 +5,6 @@ import { useAuth } from '../context/AuthContext';
 import { Button, Badge, Panel, Banner } from '../components/ui/Primitives';
 import {
   Activity,
-  ArrowRight,
   BarChart3,
   CheckCircle2,
   Code2,
@@ -173,9 +172,6 @@ export default function Login() {
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
             <Button onClick={handleGitHubLogin} loading={isLoading} icon={GitBranch} variant="primary" size="lg">
               Sign in with GitHub
-            </Button>
-            <Button as="a" icon={ArrowRight} variant="outline" size="lg" href="https://github.com/Samir-Sahiti/CodeLens-hub" target="_blank" rel="noreferrer">
-              View repository
             </Button>
           </div>
 

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -16,7 +16,9 @@ export default function NotificationsPage() {
   const [items, setItems] = useState([]);
   const [cursor, setCursor] = useState(null);
   const [hasMore, setHasMore] = useState(false);
-  const [loading, setLoading] = useState(false);
+  // Start true so the first load shows a loading state instead of briefly
+  // flashing the "no notifications" empty state before the fetch resolves.
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const loadPage = useCallback(async (before) => {

--- a/frontend/src/pages/RepoView.jsx
+++ b/frontend/src/pages/RepoView.jsx
@@ -667,7 +667,7 @@ export default function RepoView() {
             <div className="flex min-w-0 flex-wrap items-center gap-3">
               <h1 className="min-w-0 truncate text-xl font-bold tracking-tight text-white">{repo.name}</h1>
               <Badge tone={repo.status === 'ready' ? 'success' : repo.status === 'failed' ? 'danger' : isWorking ? 'accent' : 'subtle'}>
-                {repo.status === 'pending' ? 'Indexing' : repo.status.charAt(0).toUpperCase() + repo.status.slice(1)}
+                {repo.status === 'pending' ? 'Indexing' : (repo.status?.charAt(0).toUpperCase() ?? '') + (repo.status?.slice(1) ?? '')}
               </Badge>
             </div>
             <p className="text-xs text-gray-500 mt-1">
@@ -734,7 +734,7 @@ export default function RepoView() {
 
         {isWorking && !canShowAnalysis ? (
           <EmptyState
-            title={stageCopy}
+            title="Indexing in progress"
             description={`${stageCopy} This refreshes automatically while indexing continues.`}
             className="py-32"
             actions={(


### PR DESCRIPTION
Backend:
- Close IDOR holes in analysisController: gate getDependencyGraph,
  getMetrics, getIssues, suppressIssue, and getImpact on canAccessRepo
- getStatus: gate on canAccessRepo so team members aren't blocked;
  add indexed_at to the select so "Last indexed" refreshes after re-index
- suppressIssue: derive issue type from the explicit client-sent type
  (with a safe rule_id fallback) so insecure_pattern/secret suppressions
  target the correct row — the old rule_id heuristic misclassified secrets
- webhookController: length-guard before timingSafeEqual so a malformed
  signature returns 403 instead of crashing to 500
- internal.js: drop hardcoded 'fallback-secret-for-dev'; closed when unset

Frontend:
- Login: remove personal GitHub repo link + unused ArrowRight import
- IssuesPanel: dedicated missing_auth suppress branch, mirror empty issues
  prop (no stale cards after re-index), surface suppress errors via toast,
  send issue type in suppress payload, remove dead isFetching state
- PullRequestsPanel: send finding type in suppress payload; init
  detailLoading from reviewId so PR detail doesn't flash undefined data
- RepoView: null-safe status badge; fix duplicated indexing copy
- NotificationsPage: init loading=true to avoid empty-state flash
- SettingsPanel: toast webhook generation errors instead of swallowing
- Dashboard: replace window.confirm delete with a styled modal
- AgentPanel: abort in-flight stream and clear messages on conversation switch
- DependenciesPanel: fix literal backticks rendering around "Issues"

Tests: add Toast mock to IssuesPanel test; update PR-panel suppress-body
assertion for the new type field.
