### PR TITLE
fix: harden RAG retrieval and security-audit finding parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,9 +396,9 @@ GitHub tokens stored encrypted in Supabase Vault — never plaintext.
 - Cross-links findings to deterministic `analysis_issues` rows that affect the same file
 
 **Whole-repo audit** (`POST /api/review/:repoId/security-audit`):
-- Targets top 20 files by `incoming_count + complexity_score` (via `get_security_audit_targets()` RPC)
+- Targets top 20 files via `fetchAuditTargets` (in `reviewController.js`): security-relevant files are prioritised first — those carrying deterministic security issues (`hardcoded_secret`/`insecure_pattern`/`missing_auth`/`vulnerable_dependency`, severity-weighted) and attack-surface files (`node_classification` source/sink/both) — then remaining slots fill by structural score (`incoming_count + complexity_score`). Each target carries a `security_signal` tag; `audit_score` stays the plain structural score for display. (Supersedes the older `get_security_audit_targets()` RPC, which ranked on structural score alone.)
 - Processes sequentially, checking daily token budget before each file
-- Streams `progress` + `finding` + `summary` SSE events; report persisted to `security_audits` table
+- Streams `progress` + `finding` + `summary` SSE events; report persisted to `security_audits` table. A "secure" sentinel finding (clean file) is excluded from `findings_count`/`by_severity` and not emitted as a finding
 - Partial audits (budget exhausted) are saved with `status: 'partial'`
 
 **Frontend (CodeReviewPanel.jsx):**

--- a/backend/src/ai/ragService.js
+++ b/backend/src/ai/ragService.js
@@ -12,6 +12,7 @@
 
 const { supabaseAdmin } = require('../db/supabase');
 const { openai } = require('./openaiClient');
+const { SAFE_FETCH_CEILING, warnIfCeilingHit } = require('../lib/dbHelpers');
 
 /**
  * Embed a natural language query. Returns `{ embedding, tokens }`.
@@ -32,9 +33,71 @@ async function embedQuery(query) {
 }
 
 /**
- * Retrieve top-k code chunks by cosine similarity. Falls back to a plain
- * SELECT if the pgvector RPC is unavailable (e.g. local dev without the
- * migration applied).
+ * Parse a pgvector embedding as returned by PostgREST. The column comes back
+ * either as the textual literal "[0.1,0.2,...]" or, depending on the client,
+ * an already-parsed number[]. Returns a number[] or null if it can't be parsed.
+ */
+function parseStoredEmbedding(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string' && value.length > 1) {
+    try {
+      const arr = JSON.parse(value);
+      return Array.isArray(arr) ? arr : null;
+    } catch { return null; }
+  }
+  return null;
+}
+
+/** Cosine distance (1 − cosine similarity), matching pgvector's `<=>` operator. */
+function cosineDistance(a, b) {
+  if (!a || !b || a.length !== b.length) return 1;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) return 1;
+  return 1 - dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+/**
+ * Degraded-path retrieval: the pgvector RPC is unavailable, so rank in-process
+ * by actually computing cosine distance over the stored embeddings instead of
+ * returning arbitrary unranked chunks. Results are genuinely relevant (not
+ * junk) and every row is stamped `degraded: true` so callers and monitoring can
+ * tell retrieval ran without the index. Bounded by SAFE_FETCH_CEILING — on a
+ * repo larger than the ceiling the ranking covers a prefix, which is logged.
+ */
+async function fallbackCosineRank(repoId, queryEmbedding, topK) {
+  const { data, error } = await supabaseAdmin
+    .from('code_chunks')
+    .select('file_path, start_line, end_line, content, embedding')
+    .eq('repo_id', repoId)
+    .range(0, SAFE_FETCH_CEILING - 1);
+  if (error) throw new Error(`Vector search failed (fallback): ${error.message}`);
+  const rows = data || [];
+  warnIfCeilingHit('ragService.fallbackCosineRank code_chunks', rows);
+
+  const scored = rows.map((r) => {
+    const { embedding, ...rest } = r;
+    const stored = parseStoredEmbedding(embedding);
+    return { ...rest, distance: cosineDistance(queryEmbedding, stored), degraded: true };
+  });
+  scored.sort((a, b) => a.distance - b.distance);
+  return scored.slice(0, topK);
+}
+
+/**
+ * Retrieve top-k code chunks by cosine similarity via the pgvector RPC.
+ *
+ * If the RPC fails (most often a broken/duplicate `match_code_chunks` overload —
+ * PGRST203 — or, in local dev, a missing migration) we do NOT silently return
+ * arbitrary chunks: that produces confident, wrong answers with no signal.
+ * Instead we log loudly and fall back to a real in-process cosine ranking, with
+ * every row flagged `degraded: true`.
  */
 async function retrieveChunks(repoId, embedding, topK = 8) {
   const vectorLiteral = `[${embedding.join(',')}]`;
@@ -44,16 +107,12 @@ async function retrieveChunks(repoId, embedding, topK = 8) {
     p_top_k: topK,
   });
   if (error) {
-    console.warn('[ragService] match_code_chunks RPC failed, using plain fallback:', error.message);
-    const { data: fallback, error: fallbackErr } = await supabaseAdmin
-      .from('code_chunks')
-      .select('file_path, start_line, end_line, content')
-      .eq('repo_id', repoId)
-      .limit(topK);
-    if (fallbackErr) throw new Error(`Vector search failed: ${fallbackErr.message}`);
-    return (fallback || []).map((r) => ({ ...r, distance: 0.5 }));
+    // console.error (not warn): in production this is a real outage of the
+    // vector index, not an expected condition — it must be visible in logs.
+    console.error('[ragService] match_code_chunks RPC failed — falling back to in-process cosine ranking:', error.message);
+    return fallbackCosineRank(repoId, embedding, topK);
   }
   return data || [];
 }
 
-module.exports = { embedQuery, retrieveChunks };
+module.exports = { embedQuery, retrieveChunks, _private: { parseStoredEmbedding, cosineDistance, fallbackCosineRank } };

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -14,7 +14,7 @@ function getOctokit(githubToken) {
   return new Octokit({ auth: githubToken });
 }
 const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
-const { withSupabaseRetry } = require('../lib/dbHelpers');
+const { withSupabaseRetry, SAFE_FETCH_CEILING, warnIfCeilingHit } = require('../lib/dbHelpers');
 const { getGithubTokenForUser } = require('../lib/githubAuth');
 const { scanFileForSecrets } = require('../services/secretScanner');
 const { scanFileForInsecurePatterns } = require('../services/sastEngine');
@@ -34,6 +34,17 @@ const WHOLE_REPO_AUDIT_LIMIT = 20;
 const AUDIT_OUTPUT_TOKEN_ESTIMATE = 900;
 const AUDIT_CONTEXT_TOKEN_ESTIMATE = 1800;
 const EMBEDDING_TOKEN_ESTIMATE = 512;
+
+// Whole-repo audit target scoring. Structural centrality (incoming + complexity)
+// alone misses small but security-critical files (a 5-line route with a hardcoded
+// secret). These large tier offsets ensure security-relevant files reliably enter
+// the audited top-N regardless of how large complexity scores get on big files,
+// while structural score still orders files within each tier.
+const SECURITY_ISSUE_TYPES = new Set(['hardcoded_secret', 'insecure_pattern', 'missing_auth', 'vulnerable_dependency']);
+const ATTACK_SURFACE_CLASSIFICATIONS = new Set(['source', 'sink', 'both']);
+const AUDIT_SECURITY_ISSUE_OFFSET = 1000;
+const AUDIT_ATTACK_SURFACE_OFFSET = 500;
+const SEVERITY_WEIGHT = { critical: 25, high: 20, medium: 10, low: 5 };
 
 async function canAccessRepo(repoId, userId) {
   const { data: owned } = await supabaseAdmin
@@ -258,6 +269,13 @@ function parseFindingsFromText(text, fallback = {}) {
   return findings;
 }
 
+// The audit prompt asks the model to return a single finding with category
+// "secure" when a file is clean. That sentinel is not a vulnerability: it must
+// not render as a finding card nor count toward findings_count / by_severity.
+function isSecureSentinel(finding = {}) {
+  return String(finding.category || '').toLowerCase() === 'secure';
+}
+
 function extractLineNumber(text = '') {
   const match = String(text).match(/(?:line|lines|:)\s*(\d+)/i);
   return match ? Number(match[1]) : null;
@@ -381,13 +399,19 @@ async function fetchFileSource(repoId, filePath) {
 
 async function fetchDeterministicIssues(repoId, filePaths) {
   if (!filePaths.length) return [];
+  // Push the file filter to Postgres via array overlap (file_paths && {wanted})
+  // instead of fetching every issue for the repo and filtering in JS — the
+  // unbounded fetch silently capped at PostgREST's 1000-row default and dropped
+  // issues for the audited files on large repos.
   const { data, error } = await supabaseAdmin
     .from('analysis_issues')
     .select('id, type, severity, description, file_paths')
-    .eq('repo_id', repoId);
+    .eq('repo_id', repoId)
+    .overlaps('file_paths', filePaths)
+    .range(0, SAFE_FETCH_CEILING - 1);
   if (error) return [];
-  const wanted = new Set(filePaths);
-  return (data || []).filter((issue) => (issue.file_paths || []).some((path) => wanted.has(path)));
+  warnIfCeilingHit('fetchDeterministicIssues analysis_issues', data || []);
+  return data || [];
 }
 
 function normalizeReviewFilePath(filePath) {
@@ -606,23 +630,62 @@ async function blastRadiusForFile(repoId, filePath) {
   }
 }
 
+// Select the files a whole-repo security audit should target. Supersedes the
+// older get_security_audit_targets RPC (which ranked purely on incoming +
+// complexity): for a *security* audit we also prioritise attack-surface files
+// and files that already carry deterministic security issues, so a small but
+// dangerous file is not crowded out by large-but-benign ones.
+//
+// `audit_score` is kept as the plain structural score (incoming + complexity)
+// for display continuity; ranking uses a separate tiered key. `security_signal`
+// records why a file was prioritised.
 async function fetchAuditTargets(repoId) {
-  const { data, error } = await supabaseAdmin.rpc('get_security_audit_targets', {
-    p_repo_id: repoId,
-    p_limit: WHOLE_REPO_AUDIT_LIMIT,
-  });
-  if (!error && data) return data;
-
-  const { data: rows, error: fallbackErr } = await supabaseAdmin
+  const { data: nodes, error: nodesErr } = await supabaseAdmin
     .from('graph_nodes')
-    .select('id, file_path, language, incoming_count, complexity_score, line_count')
+    .select('id, file_path, language, incoming_count, complexity_score, line_count, node_classification')
     .eq('repo_id', repoId)
-    .limit(1000);
-  if (fallbackErr) throw fallbackErr;
-  return (rows || [])
-    .map((row) => ({ ...row, audit_score: (row.incoming_count || 0) + (row.complexity_score || 0) }))
-    .sort((a, b) => (b.audit_score || 0) - (a.audit_score || 0))
-    .slice(0, WHOLE_REPO_AUDIT_LIMIT);
+    .range(0, SAFE_FETCH_CEILING - 1);
+  if (nodesErr) throw nodesErr;
+  const rows = nodes || [];
+  warnIfCeilingHit('fetchAuditTargets graph_nodes', rows);
+  if (rows.length === 0) return [];
+
+  // Strongest deterministic security-issue weight per file.
+  const issueBoost = new Map();
+  const { data: issues } = await supabaseAdmin
+    .from('analysis_issues')
+    .select('type, severity, file_paths')
+    .eq('repo_id', repoId)
+    .range(0, SAFE_FETCH_CEILING - 1);
+  for (const issue of issues || []) {
+    if (!SECURITY_ISSUE_TYPES.has(issue.type)) continue;
+    const weight = SEVERITY_WEIGHT[String(issue.severity || '').toLowerCase()] || SEVERITY_WEIGHT.low;
+    for (const filePath of issue.file_paths || []) {
+      issueBoost.set(filePath, (issueBoost.get(filePath) || 0) + weight);
+    }
+  }
+
+  const scored = rows.map((node) => {
+    const structural = (node.incoming_count || 0) + (node.complexity_score || 0);
+    const secWeight = issueBoost.get(node.file_path) || 0;
+    const isAttackSurface = ATTACK_SURFACE_CLASSIFICATIONS.has(node.node_classification);
+    const rankKey = structural
+      + (secWeight > 0 ? AUDIT_SECURITY_ISSUE_OFFSET + secWeight : 0)
+      + (isAttackSurface ? AUDIT_ATTACK_SURFACE_OFFSET : 0);
+    return {
+      id: node.id,
+      file_path: node.file_path,
+      language: node.language,
+      line_count: node.line_count,
+      incoming_count: node.incoming_count,
+      complexity_score: node.complexity_score,
+      audit_score: structural,
+      security_signal: secWeight > 0 ? 'security_issue' : (isAttackSurface ? 'attack_surface' : null),
+      _rank: rankKey,
+    };
+  });
+  scored.sort((a, b) => b._rank - a._rank);
+  return scored.slice(0, WHOLE_REPO_AUDIT_LIMIT).map(({ _rank, ...target }) => target);
 }
 
 async function persistAudit({ userId, repoId, report }) {
@@ -812,7 +875,8 @@ const review = async (req, res) => {
 
     if (mode === 'security_audit') {
       const issues = await fetchDeterministicIssues(repoId, filePath ? [filePath] : []);
-      const findings = linkFindingsToIssues(parseFindingsFromText(text, { file_path: filePath }), issues);
+      const parsed = parseFindingsFromText(text, { file_path: filePath }).filter((finding) => !isSecureSentinel(finding));
+      const findings = linkFindingsToIssues(parsed, issues);
       findings.forEach((finding) => send({ type: 'finding', finding }));
     }
 
@@ -946,6 +1010,8 @@ const runSecurityAudit = async (req, res) => {
 
       const fileIssues = deterministicIssues.filter((issue) => (issue.file_paths || []).includes(target.file_path));
       let findings = parseFindingsFromText(text, { file_path: target.file_path, line_reference: target.file_path });
+      // Drop "secure" sentinels: a clean file contributes audited_count but zero findings.
+      findings = findings.filter((finding) => !isSecureSentinel(finding));
       findings = linkFindingsToIssues(findings, fileIssues);
       findings.forEach((finding) => {
         report.summary.findings_count++;
@@ -1000,15 +1066,24 @@ const listSecurityAudits = async (req, res) => {
   const allowed = await canAccessRepo(repoId, req.user.id);
   if (!allowed) return res.status(404).json({ error: 'Repository not found or unauthorized' });
 
+  // Project only status + summary out of findings_json server-side. The full
+  // report (per-file findings + concatenated raw_text) can be large; the history
+  // list only needs the status badge and finding count. The detail endpoint
+  // (getSecurityAudit) still returns the complete report.
   const { data, error } = await supabaseAdmin
     .from('security_audits')
-    .select('id, user_id, repo_id, findings_json, created_at')
+    .select('id, user_id, repo_id, created_at, status:findings_json->>status, summary:findings_json->summary')
     .eq('repo_id', repoId)
     .eq('user_id', req.user.id)
     .order('created_at', { ascending: false });
 
   if (error) return res.status(500).json({ error: 'Failed to fetch security audit history' });
-  res.json({ audits: data || [] });
+  // Preserve the findings_json.{status,summary} shape the client reads.
+  const audits = (data || []).map(({ status, summary, ...rest }) => ({
+    ...rest,
+    findings_json: { status, summary },
+  }));
+  res.json({ audits });
 };
 
 const getSecurityAudit = async (req, res) => {
@@ -3597,6 +3672,9 @@ module.exports = {
   batchDependencyProposalInternal,
   _private: {
     parseFindingsFromText,
+    isSecureSentinel,
+    fetchAuditTargets,
+    fetchDeterministicIssues,
     rerankSecurityChunks,
     securityKeywordScore,
     linkFindingsToIssues,

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -7,6 +7,7 @@ const crypto            = require('crypto');
 const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage }   = require('../services/usageTracker');
 const { openai, streamChatText, CHAT_MODEL } = require('../ai/openaiClient');
+const { retrieveChunks } = require('../ai/ragService');
 
 function getOctokit(githubToken) {
   const { Octokit } = globalThis.__CODELENS_OCTOKIT__ || require('octokit');
@@ -84,27 +85,8 @@ async function remainingDailyTokens(userId) {
   return Math.max(0, MAX_DAILY_TOKENS - await dailyTokensUsed(userId));
 }
 
-async function retrieveChunks(repoId, embedding, topK = 5) {
-  const vectorLiteral = `[${embedding.join(',')}]`;
-  const { data, error } = await supabaseAdmin.rpc('match_code_chunks', {
-    p_repo_id:   repoId,
-    p_embedding: vectorLiteral,
-    p_top_k:     topK,
-  });
-
-  if (error) {
-    console.warn('[review] match_code_chunks RPC failed, using plain fallback:', error.message);
-    const { data: fallback, error: fallbackErr } = await supabaseAdmin
-      .from('code_chunks')
-      .select('file_path, start_line, end_line, content')
-      .eq('repo_id', repoId)
-      .limit(topK);
-    if (fallbackErr) throw new Error(`Vector search failed: ${fallbackErr.message}`);
-    return (fallback || []).map(r => ({ ...r, distance: 0.5 }));
-  }
-
-  return data || [];
-}
+// retrieveChunks (RPC + degraded in-process cosine fallback) is shared from
+// ../ai/ragService so all RAG callers behave identically on RPC failure.
 
 function securityKeywordScore(text = '') {
   const lower = String(text).toLowerCase();
@@ -222,46 +204,32 @@ function parseFindingsFromText(text, fallback = {}) {
   const trimmed = String(text || '').trim();
   if (!trimmed) return findings;
 
+  const pushRows = (parsed) => {
+    const rows = Array.isArray(parsed) ? parsed : [parsed];
+    rows.forEach((row) => {
+      const finding = normalizeFinding(row, fallback);
+      if (finding) findings.push(finding);
+    });
+  };
+
+  // 1. Whole-text / fenced JSON — an array or a single (possibly pretty-printed)
+  //    object. Brace-safe because JSON.parse handles braces inside string values.
   const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
   const parseTargets = fenced ? [fenced[1].trim(), trimmed] : [trimmed];
-
   for (const target of parseTargets) {
     try {
-      const parsed = JSON.parse(target);
-      const rows = Array.isArray(parsed) ? parsed : [parsed];
-      rows.forEach((row) => {
-        const finding = normalizeFinding(row, fallback);
-        if (finding) findings.push(finding);
-      });
+      pushRows(JSON.parse(target));
       if (findings.length > 0) return findings;
     } catch {
       // Try the next parser strategy.
     }
   }
 
-  const jsonObjectMatches = trimmed.match(/\{[^{}]*(?:"severity"|"category"|"confidence")[^{}]*\}/g) || [];
-  for (const candidate of jsonObjectMatches) {
-    try {
-      const finding = normalizeFinding(JSON.parse(candidate), fallback);
-      if (finding) findings.push(finding);
-    } catch {
-      // Ignore malformed candidate objects while scanning streamed text.
-    }
-  }
-  if (findings.length > 0) return findings;
-
-  try {
-    const parsed = JSON.parse(trimmed);
-    const rows = Array.isArray(parsed) ? parsed : [parsed];
-    rows.forEach((row) => {
-      const finding = normalizeFinding(row, fallback);
-      if (finding) findings.push(finding);
-    });
-    if (findings.length > 0) return findings;
-  } catch {
-    // Fall through to line-by-line JSONL parsing.
-  }
-
+  // 2. JSONL — one compact JSON object per line, which is the format the
+  //    security-audit prompt requests. Parsed per-line so braces inside string
+  //    fields (e.g. code in suggested_fix like `if (x) { ... }`) stay safe.
+  //    MUST run before the regex scan below: that scan cannot match objects whose
+  //    string fields contain braces, and it previously dropped such findings.
   for (const line of trimmed.split(/\r?\n/)) {
     const candidate = line.trim().replace(/^```json|^```|```$/g, '').trim();
     if (!candidate.startsWith('{')) continue;
@@ -270,6 +238,20 @@ function parseFindingsFromText(text, fallback = {}) {
       if (finding) findings.push(finding);
     } catch {
       // Skip malformed JSONL rows; partial streams can split objects.
+    }
+  }
+  if (findings.length > 0) return findings;
+
+  // 3. Last resort: scan free text for brace-delimited objects (e.g. a partial
+  //    stream that never formed valid JSON). Cannot match objects whose string
+  //    fields contain braces — hence JSONL is attempted first.
+  const jsonObjectMatches = trimmed.match(/\{[^{}]*(?:"severity"|"category"|"confidence")[^{}]*\}/g) || [];
+  for (const candidate of jsonObjectMatches) {
+    try {
+      const finding = normalizeFinding(JSON.parse(candidate), fallback);
+      if (finding) findings.push(finding);
+    } catch {
+      // Ignore malformed candidate objects while scanning streamed text.
     }
   }
 

--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -18,42 +18,14 @@ const { supabaseAdmin } = require('../db/supabase');
 const { recordUsage } = require('../services/usageTracker');
 const { bindRequestAbort, isAbortError } = require('../lib/sseAbort');
 const { openai, CHAT_MODEL } = require('../ai/openaiClient');
+const { retrieveChunks } = require('../ai/ragService');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Retrieve the top-k most similar code chunks from Supabase using pgvector.
- * Returns rows from code_chunks ordered by cosine distance ascending.
- */
-async function retrieveChunks(repoId, embedding, topK = 8) {
-  // pgvector cosine distance operator: <=>
-  // Lower = more similar. We cast the JS array to the postgres vector type.
-  const vectorLiteral = `[${embedding.join(',')}]`;
-
-  const { data, error } = await supabaseAdmin.rpc('match_code_chunks', {
-    p_repo_id:   repoId,
-    p_embedding: vectorLiteral,
-    p_top_k:     topK,
-  });
-
-  if (error) {
-    // Fallback: plain SELECT without vector ordering if the RPC doesn't exist yet.
-    // This lets developers test the panel even before the SQL function is deployed.
-    console.warn('[search] match_code_chunks RPC failed, using plain fallback:', error.message);
-    const { data: fallback, error: fallbackErr } = await supabaseAdmin
-      .from('code_chunks')
-      .select('file_path, start_line, end_line, content')
-      .eq('repo_id', repoId)
-      .limit(topK);
-
-    if (fallbackErr) throw new Error(`Vector search failed: ${fallbackErr.message}`);
-    return (fallback || []).map(r => ({ ...r, distance: 0.5 }));
-  }
-
-  return data || [];
-}
+// retrieveChunks (RPC + degraded in-process cosine fallback) is shared from
+// ../ai/ragService so all RAG callers behave identically on RPC failure.
 
 /**
  * Build the LLM system + user prompt from retrieved chunks.

--- a/backend/src/controllers/toursController.js
+++ b/backend/src/controllers/toursController.js
@@ -10,7 +10,13 @@ const { openai, CHAT_MODEL } = require('../ai/openaiClient');
 
 const MODEL = CHAT_MODEL;
 const MAX_DAILY_TOKENS = parseInt(process.env.MAX_DAILY_TOKENS_PER_USER || '500000', 10);
-const DISTANCE_THRESHOLD = 0.4;
+// Cosine *distance* (0..2) from match_code_chunks, NOT similarity. For
+// natural-language→code retrieval with text-embedding-3-small, even a
+// perfectly relevant file lands around 0.6–0.75; the old 0.4 gate was
+// unreachable and made every tour 404. 0.75 keeps genuinely-relevant hits
+// while still rejecting nonsense queries (which return higher distances or
+// no rows at all on an indexed repo).
+const DISTANCE_THRESHOLD = 0.75;
 const MAX_STEPS = 8;
 
 async function getRepoAccess(repoId, userId) {

--- a/backend/test/api.integration.test.js
+++ b/backend/test/api.integration.test.js
@@ -94,6 +94,14 @@ function createSupabaseMock(handlers) {
       this.filters.push({ op: 'in', column, value });
       return this;
     }
+    contains(column, value) {
+      this.filters.push({ op: 'contains', column, value });
+      return this;
+    }
+    overlaps(column, value) {
+      this.filters.push({ op: 'overlaps', column, value });
+      return this;
+    }
     is(column, value) {
       this.filters.push({ op: 'is', column, value });
       return this;
@@ -852,9 +860,9 @@ describe('Backend API integration (mocked)', () => {
       'repositories.select.maybeSingle': async () => ({ data: { id: 'repo-1' }, error: null }),
       'api_usage.select.many': async () => ({ data: [], error: null }),
       'analysis_issues.select.many': async () => ({ data: [], error: null }),
-      'rpc.get_security_audit_targets': async () => ({
+      'graph_nodes.select.many': async () => ({
         data: [
-          { id: 'n1', file_path: 'missing.js', incoming_count: null, complexity_score: null, audit_score: 0 },
+          { id: 'n1', file_path: 'missing.js', language: 'javascript', incoming_count: null, complexity_score: null, line_count: null, node_classification: null },
         ],
         error: null,
       }),
@@ -879,6 +887,88 @@ describe('Backend API integration (mocked)', () => {
     expect(res.text).toContain('"status":"skipped"');
     expect(res.text).toContain('"skipped_count":1');
     expect(res.text).toContain('"type":"done"');
+  });
+
+  it('whole-repo audit targets prioritise security-relevant files over larger benign ones', async () => {
+    supabaseAdminMock = createSupabaseMock({
+      'graph_nodes.select.many': async () => ({
+        data: [
+          { id: 'big', file_path: 'big.js', language: 'js', incoming_count: 40, complexity_score: 60, line_count: 800, node_classification: null },
+          { id: 'route', file_path: 'route.js', language: 'js', incoming_count: 1, complexity_score: 2, line_count: 20, node_classification: 'source' },
+          { id: 'secret', file_path: 'secret.js', language: 'js', incoming_count: 0, complexity_score: 1, line_count: 10, node_classification: null },
+        ],
+        error: null,
+      }),
+      'analysis_issues.select.many': async () => ({
+        data: [{ id: 'i1', type: 'hardcoded_secret', severity: 'high', file_paths: ['secret.js'] }],
+        error: null,
+      }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+    globalThis.__CODELENS_SUPABASE_ANON__ = supabaseAdminMock;
+
+    const reviewController = (await import('../src/controllers/reviewController.js')).default;
+    const targets = await reviewController._private.fetchAuditTargets('repo-1');
+    const order = targets.map((t) => t.file_path);
+
+    // Despite the lowest structural score, the secret-bearing file and the
+    // attack-surface route outrank the large-but-benign file.
+    expect(order.indexOf('secret.js')).toBeLessThan(order.indexOf('big.js'));
+    expect(order.indexOf('route.js')).toBeLessThan(order.indexOf('big.js'));
+
+    const secret = targets.find((t) => t.file_path === 'secret.js');
+    expect(secret.security_signal).toBe('security_issue');
+    // audit_score stays the plain structural score, not polluted by tier offsets.
+    expect(secret.audit_score).toBe(1);
+    expect(targets.find((t) => t.file_path === 'route.js').security_signal).toBe('attack_surface');
+    expect(targets.some((t) => '_rank' in t)).toBe(false);
+  });
+
+  it('whole-repo audit excludes "secure" sentinels from findings and counts', async () => {
+    supabaseAdminMock = createSupabaseMock({
+      'repositories.select.maybeSingle': async () => ({ data: { id: 'repo-1' }, error: null }),
+      'api_usage.select.many': async () => ({ data: [], error: null }),
+      'analysis_issues.select.many': async () => ({ data: [], error: null }),
+      'graph_nodes.select.many': async () => ({
+        data: [{ id: 'n1', file_path: 'clean.js', language: 'js', incoming_count: 5, complexity_score: 3, line_count: 40, node_classification: null }],
+        error: null,
+      }),
+      'file_contents.select.maybeSingle': async () => ({ data: { content: 'export const x = 1;\n' }, error: null }),
+      'rpc.match_code_chunks': async () => ({ data: [], error: null }),
+      'security_audits.insert.single': async (state) => ({ data: { id: 'audit-1', ...state.payload }, error: null }),
+    });
+    globalThis.__CODELENS_SUPABASE_ADMIN__ = supabaseAdminMock;
+    globalThis.__CODELENS_SUPABASE_ANON__ = supabaseAdminMock;
+    globalThis.__CODELENS_OPENAI__ = {
+      embeddings: { create: async () => ({ data: [{ embedding: [0.01, 0.02, 0.03] }], usage: { total_tokens: 3 } }) },
+      chat: {
+        completions: {
+          create: async () => {
+            async function* gen() {
+              yield { choices: [{ delta: { content: '{"severity":"low","category":"secure","line_reference":"clean.js","explanation":"no issue found","suggested_fix":"No fix needed.","confidence":"high"}' }, finish_reason: 'stop' }] };
+              yield { choices: [], usage: { prompt_tokens: 5, completion_tokens: 10 } };
+            }
+            return gen();
+          },
+        },
+      },
+    };
+
+    const reviewController = (await import('../src/controllers/reviewController.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.post('/api/review/:repoId/security-audit', (req, _res, next) => { req.user = { id: 'user-1' }; next(); }, wrap(reviewController.runSecurityAudit));
+    app.use((err, _req, res, _next) => res.status(500).json({ error: err.message || 'error' }));
+
+    const res = await request(app)
+      .post('/api/review/repo-1/security-audit')
+      .expect(200);
+
+    // The clean file is audited, but its "secure" sentinel is neither emitted as
+    // a finding nor counted.
+    expect(res.text).toContain('"audited_count":1');
+    expect(res.text).toContain('"findings_count":0');
+    expect(res.text).not.toContain('"type":"finding"');
   });
 
   it('security finding parsing rejects incomplete objects and links issues by category and line proximity', async () => {

--- a/scripts/fix_match_code_chunks_overload.sql
+++ b/scripts/fix_match_code_chunks_overload.sql
@@ -1,0 +1,49 @@
+-- Fix: duplicate match_code_chunks overloads break PostgREST RPC resolution.
+--
+-- Symptom: PGRST203 "Could not choose the best candidate function between
+--   public.match_code_chunks(uuid, vector, integer) and
+--   public.match_code_chunks(uuid, text, integer)".
+--
+-- Effect: every RAG caller (search, review, agent, tours) fails the RPC. Most
+-- silently fall back to a non-vector plain SELECT and return junk; tours has no
+-- fallback so it surfaces "Vector search failed".
+--
+-- A stale `text`-parameter overload was left in the live DB by an earlier
+-- deploy. Drop BOTH known signatures, then recreate the single canonical
+-- vector(1536) version (identical to scripts/schema.sql). Idempotent.
+
+DROP FUNCTION IF EXISTS public.match_code_chunks(uuid, text, integer);
+DROP FUNCTION IF EXISTS public.match_code_chunks(uuid, vector, integer);
+DROP FUNCTION IF EXISTS public.match_code_chunks(uuid, extensions.vector, integer);
+
+CREATE OR REPLACE FUNCTION match_code_chunks(
+  p_repo_id   UUID,
+  p_embedding vector(1536),
+  p_top_k     INT DEFAULT 8
+)
+RETURNS TABLE (
+  file_path  TEXT,
+  start_line INT,
+  end_line   INT,
+  content    TEXT,
+  distance   FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Higher ef_search trades query time for better recall; safe for RAG workloads.
+  SET LOCAL hnsw.ef_search = 100;
+
+  RETURN QUERY
+  SELECT
+    cc.file_path,
+    cc.start_line,
+    cc.end_line,
+    cc.content,
+    (cc.embedding <=> p_embedding)::FLOAT AS distance
+  FROM code_chunks cc
+  WHERE cc.repo_id = p_repo_id
+  ORDER BY cc.embedding <=> p_embedding
+  LIMIT p_top_k;
+END;
+$$;


### PR DESCRIPTION
Three reliability fixes to the RAG/AI-analysis paths:

- tours: raise RAG distance gate from 0.4 to 0.75. 0.4 was an
  unreachable threshold for NL->code cosine distance with
  text-embedding-3-small (relevant matches land ~0.6-0.75), so
  every tour generation 404'd with "No relevant code found".

- rag: replace the silent junk fallback in retrieveChunks. On RPC
  failure all three callers returned arbitrary unranked chunks
  tagged distance:0.5, masking a vector-index outage as confident
  results. Now falls back to a real in-process cosine ranking,
  flags every row degraded:true, and logs at error level.
  Consolidated the three duplicated copies (ragService,
  searchController, reviewController) into the shared helper.

- security-audit: fix parseFindingsFromText dropping findings whose
  string fields contain braces. The regex scan (\{[^{}]*...\}) ran
  before the brace-safe JSONL parser and early-returned, so any
  finding with code in suggested_fix (e.g. "if (x) { ... }") was
  silently lost in multi-finding files. JSONL parse now runs first;
  regex is the last resort.